### PR TITLE
Backend: Add endpoint for exporting account statement as CSV file

### DIFF
--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -48,7 +48,7 @@ public class ExportController : ControllerBase
             x.Amount,
         });
         var values = await scalarQuery.ToListAsync();
-        // Should use something like 'CsvHelper' (see 'https://joshclose.github.io/CsvHelper/examples/writing/write-anonymous-type-objects/')?
+        // TODO Should use something like 'CsvHelper' (see 'https://joshclose.github.io/CsvHelper/examples/writing/write-anonymous-type-objects/')?
         var csv = new StringBuilder("Time,Amount (CCD),Label\n");
         foreach (var v in values)
         {

--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -24,14 +24,14 @@ public class ExportController : ControllerBase
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
 
         if (!ConcordiumSdk.Types.AccountAddress.TryParse(accountAddress, out var parsed))
-            throw new InvalidOperationException("Account does not exist!");
+            return NotFound("Account does not exist!");
 
         var baseAddress = new AccountAddress(parsed!.GetBaseAddress().AsString);
         var account = dbContext.Accounts
             .AsNoTracking()
             .SingleOrDefault(account => account.BaseAddress == baseAddress);
         if (account == null)
-            throw new InvalidOperationException("Account does not exist!");
+            return NotFound("Account does not exist!");
 
         var query = dbContext.AccountStatementEntries
             .AsNoTracking()

--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using System.Text;
+using Application.Api.GraphQL.Accounts;
 using Application.Api.GraphQL.EfCore;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -7,26 +8,37 @@ using Microsoft.EntityFrameworkCore;
 namespace Application.Api.Rest;
 
 [ApiController]
-public class CsvExportController : ControllerBase
+public class ExportController : ControllerBase
 {
     private readonly IDbContextFactory<GraphQlDbContext> _dbContextFactory;
 
-    public CsvExportController(IDbContextFactory<GraphQlDbContext> dbContextFactory)
+    public ExportController(IDbContextFactory<GraphQlDbContext> dbContextFactory)
     {
         _dbContextFactory = dbContextFactory;
     }
 
     [HttpGet]
     [Route("rest/export/statement")]
-    public async Task<ActionResult> GetStatementExport(long accountId)
+    public async Task<ActionResult> GetStatementExport(string accountAddress)
     {
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
 
+        if (!ConcordiumSdk.Types.AccountAddress.TryParse(accountAddress, out var parsed))
+            throw new InvalidOperationException("Account does not exist!");
+
+        var baseAddress = new AccountAddress(parsed!.GetBaseAddress().AsString);
+        var account = dbContext.Accounts
+            .AsNoTracking()
+            .SingleOrDefault(account => account.BaseAddress == baseAddress);
+        if (account == null)
+            throw new InvalidOperationException("Account does not exist!");
+
         var query = dbContext.AccountStatementEntries
             .AsNoTracking()
-            .Where(x => x.AccountId == accountId);
+            .Where(x => x.AccountId == account.Id);
 
-        var scalarQuery = query.Select(x => new {
+        var scalarQuery = query.Select(x => new
+        {
             x.Timestamp,
             x.EntryType,
             x.Amount,
@@ -34,10 +46,10 @@ public class CsvExportController : ControllerBase
         var values = await scalarQuery.ToListAsync();
         // TODO Use something like 'CsvHelper' (see 'https://joshclose.github.io/CsvHelper/examples/writing/write-anonymous-type-objects/')?
         var sb = new StringBuilder("Time,Amount (CCD),Label\n");
-        var csv = values.Aggregate(sb, (acc, v) => acc.Append($"{v.Timestamp.ToString("u")},{v.Amount/1e6},{v.EntryType}\n"));
+        var csv = values.Aggregate(sb, (acc, v) => acc.Append($"{v.Timestamp.ToString("u")},{v.Amount / 1e6},{v.EntryType}\n"));
         var result = new FileContentResult(Encoding.ASCII.GetBytes(csv.ToString()), "text/csv")
         {
-            FileDownloadName = $"statement-{accountId}.csv",
+            FileDownloadName = $"statement-{accountAddress}.csv",
         };
         return result;
     }

--- a/backend/Application/Api/Rest/RewardsCsvController.cs
+++ b/backend/Application/Api/Rest/RewardsCsvController.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using System.Text;
 using Application.Api.GraphQL.EfCore;
 using Microsoft.AspNetCore.Mvc;
@@ -28,9 +27,9 @@ public class CsvExportController : ControllerBase
             .Where(x => x.AccountId == accountId);
 
         var scalarQuery = query.Select(x => new {
-            Timestamp = x.Timestamp,
-            EntryType = x.EntryType,
-            Amount = x.Amount,
+            x.Timestamp,
+            x.EntryType,
+            x.Amount,
         });
         var values = await scalarQuery.ToListAsync();
         // TODO Use something like 'CsvHelper' (see 'https://joshclose.github.io/CsvHelper/examples/writing/write-anonymous-type-objects/')?

--- a/backend/Application/Api/Rest/RewardsCsvController.cs
+++ b/backend/Application/Api/Rest/RewardsCsvController.cs
@@ -34,8 +34,8 @@ public class CsvExportController : ControllerBase
         });
         var values = await scalarQuery.ToListAsync();
         // TODO Use something like 'CsvHelper' (see 'https://joshclose.github.io/CsvHelper/examples/writing/write-anonymous-type-objects/')?
-        var sb = new StringBuilder("timestamp,type,amount_uccd\n");
-        var csv = values.Aggregate(sb, (acc, v) => acc.Append($"{v.Timestamp.ToString("u")},{v.EntryType},{v.Amount}\n"));
+        var sb = new StringBuilder("Time,Amount (CCD),Label\n");
+        var csv = values.Aggregate(sb, (acc, v) => acc.Append($"{v.Timestamp.ToString("u")},{v.Amount/1e6},{v.EntryType}\n"));
         var result = new FileContentResult(Encoding.ASCII.GetBytes(csv.ToString()), "text/csv")
         {
             FileDownloadName = $"statement-{accountId}.csv",

--- a/backend/Application/Api/Rest/RewardsCsvController.cs
+++ b/backend/Application/Api/Rest/RewardsCsvController.cs
@@ -1,0 +1,43 @@
+﻿using System.Globalization;
+using System.Threading.Tasks;
+using System.Text;
+using Application.Api.GraphQL.EfCore;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Api.Rest;
+
+[ApiController]
+public class RewardsCsvController : ControllerBase
+{
+    private readonly IDbContextFactory<GraphQlDbContext> _dbContextFactory;
+
+    public RewardsCsvController(IDbContextFactory<GraphQlDbContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory;
+    }
+
+    [HttpGet]
+    [Route("rest/rewards")]
+    public async Task<ActionResult> GetRewards(long accountId)
+    {
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
+
+        var query = dbContext.AccountRewards
+            .AsNoTracking()
+            .Where(x => x.AccountId == accountId);
+
+        var scalarQuery = query.Select(x => new {
+            Timestamp = x.Timestamp,
+            RewardType = x.RewardType,
+            Amount = x.Amount,
+        });
+        var values = await scalarQuery.ToListAsync();
+        var csv = string.Join("", values.ConvertAll(v => $"\"{v.Timestamp}\",\"{v.RewardType}\",\"{v.Amount}\"\n"));
+        var result = new FileContentResult(Encoding.ASCII.GetBytes(csv), "text/csv")
+        {
+            FileDownloadName = $"rewards-{accountId}.csv",
+        };
+        return result;
+    }
+}

--- a/backend/Application/Api/Rest/RewardsCsvController.cs
+++ b/backend/Application/Api/Rest/RewardsCsvController.cs
@@ -8,37 +8,37 @@ using Microsoft.EntityFrameworkCore;
 namespace Application.Api.Rest;
 
 [ApiController]
-public class RewardsCsvController : ControllerBase
+public class CsvExportController : ControllerBase
 {
     private readonly IDbContextFactory<GraphQlDbContext> _dbContextFactory;
 
-    public RewardsCsvController(IDbContextFactory<GraphQlDbContext> dbContextFactory)
+    public CsvExportController(IDbContextFactory<GraphQlDbContext> dbContextFactory)
     {
         _dbContextFactory = dbContextFactory;
     }
 
     [HttpGet]
-    [Route("rest/rewards")]
-    public async Task<ActionResult> GetRewards(long accountId)
+    [Route("rest/export/statement")]
+    public async Task<ActionResult> GetStatementExport(long accountId)
     {
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
 
-        var query = dbContext.AccountRewards
+        var query = dbContext.AccountStatementEntries
             .AsNoTracking()
             .Where(x => x.AccountId == accountId);
 
         var scalarQuery = query.Select(x => new {
             Timestamp = x.Timestamp,
-            RewardType = x.RewardType,
+            EntryType = x.EntryType,
             Amount = x.Amount,
         });
         var values = await scalarQuery.ToListAsync();
-        // TODO Better to use something like 'CsvHelper' (see 'https://joshclose.github.io/CsvHelper/examples/writing/write-anonymous-type-objects/')?
+        // TODO Use something like 'CsvHelper' (see 'https://joshclose.github.io/CsvHelper/examples/writing/write-anonymous-type-objects/')?
         var sb = new StringBuilder("timestamp,type,amount_uccd\n");
-        var csv = values.Aggregate(sb, (acc, v) => acc.Append($"{v.Timestamp},{v.RewardType},{v.Amount}\n"));
+        var csv = values.Aggregate(sb, (acc, v) => acc.Append($"{v.Timestamp.ToString("u")},{v.EntryType},{v.Amount}\n"));
         var result = new FileContentResult(Encoding.ASCII.GetBytes(csv.ToString()), "text/csv")
         {
-            FileDownloadName = $"rewards-{accountId}.csv",
+            FileDownloadName = $"statement-{accountId}.csv",
         };
         return result;
     }

--- a/backend/Application/Api/Rest/RewardsCsvController.cs
+++ b/backend/Application/Api/Rest/RewardsCsvController.cs
@@ -33,8 +33,10 @@ public class RewardsCsvController : ControllerBase
             Amount = x.Amount,
         });
         var values = await scalarQuery.ToListAsync();
-        var csv = string.Join("", values.ConvertAll(v => $"\"{v.Timestamp}\",\"{v.RewardType}\",\"{v.Amount}\"\n"));
-        var result = new FileContentResult(Encoding.ASCII.GetBytes(csv), "text/csv")
+        // TODO Better to use something like 'CsvHelper' (see 'https://joshclose.github.io/CsvHelper/examples/writing/write-anonymous-type-objects/')?
+        var sb = new StringBuilder("timestamp,type,amount_uccd\n");
+        var csv = values.Aggregate(sb, (acc, v) => acc.Append($"{v.Timestamp},{v.RewardType},{v.Amount}\n"));
+        var result = new FileContentResult(Encoding.ASCII.GetBytes(csv.ToString()), "text/csv")
         {
             FileDownloadName = $"rewards-{accountId}.csv",
         };


### PR DESCRIPTION
## Purpose

Provide a solution for users wanting to export a full account statement. No support for filtering is implemented. It could make sense to add optional time bounds.

Part of epic "Export transactions from CCDScan".

Most accounts will process in less than 1s. Account `35CJPZohio6Ztii2zy1AYzJKvuxbGG44wrBn7hLHiYLoF2nxnh` which as of this writing has 4339327 statement entries takes 5-6 secs locally and results in a 200MB download (and has too many entries for spreadsheets to open it). This could be used maliciously, so adding some form of rate limiting may be desirable.

## Changes

Add endpoint `/rest/export/statement?accountAddress=<account-address>` to the backend that responds with a CSV file `statement-<account-address>.csv` containing all records formatted like:

```csv
Time,Amount (CCD),Label
2022-10-07 08:00:19Z,15526.040342,FinalizationReward
2022-10-08 08:00:01Z,38.824926,TransactionFeeReward
2022-10-08 08:00:01Z,256225.95173,BakerReward
2022-10-08 08:00:01Z,15523.962755,FinalizationReward
...
```

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.