### PR TITLE
Add workaround to NITRO_PRESET not taking precedence

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -54,7 +54,10 @@ export default defineNuxtConfig({
 			ENVIRONMENT === 'testnet',
 	},
 	nitro: {
-		preset: process.env.NITRO_PRESET || 'firebase', // workaround until whatever depends on Nitro has been upgraded to include  'https://github.com/unjs/nitro/commit/92d711fe936fda0ff877c23d8a0d73ed4ea4adc4'
+		// Workaround: Until whatever depends on Nitro has been upgraded to include 'https://github.com/unjs/nitro/commit/92d711fe936fda0ff877c23d8a0d73ed4ea4adc4', we do it manually.
+		// Workaround on workaround: Have to use empty string instead of "node-server" as otherwise we get error "Cannot resolve preset: node-server"
+		// (see 'https://forum.cleavr.io/t/cannot-resolve-node-server-preset/686').
+		preset: process.env.NITRO_PRESET === 'node-server' ? '' : 'firebase',
 	},
 	css: ['@/assets/css/styles.css'],
 	build: {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -54,7 +54,7 @@ export default defineNuxtConfig({
 			ENVIRONMENT === 'testnet',
 	},
 	nitro: {
-		preset: 'firebase',
+		preset: process.env.NITRO_PRESET || 'firebase', // workaround until whatever depends on Nitro has been upgraded to include  'https://github.com/unjs/nitro/commit/92d711fe936fda0ff877c23d8a0d73ed4ea4adc4'
 	},
 	css: ['@/assets/css/styles.css'],
 	build: {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -54,10 +54,11 @@ export default defineNuxtConfig({
 			ENVIRONMENT === 'testnet',
 	},
 	nitro: {
-		// Workaround: Until whatever depends on Nitro has been upgraded to include 'https://github.com/unjs/nitro/commit/92d711fe936fda0ff877c23d8a0d73ed4ea4adc4', we do it manually.
-		// Workaround on workaround: Have to use empty string instead of "node-server" as otherwise we get error "Cannot resolve preset: node-server"
-		// (see 'https://forum.cleavr.io/t/cannot-resolve-node-server-preset/686').
-		preset: process.env.NITRO_PRESET === 'node-server' ? '' : 'firebase',
+		// Workaround: Until whatever depends on Nitro has been upgraded to include 'https://github.com/unjs/nitro/commit/92d711fe936fda0ff877c23d8a0d73ed4ea4adc4',
+		// we manually let NITRO_PRESET take precedence.
+		// According to the docs ('https://v3.nuxtjs.org/getting-started/deployment/'), the preset for deploying to node.js is "node-server".
+		// But in the version of nuxt/nitro used atm, the correct value to use is "server" (renamed in 'https://github.com/unjs/nitro/commit/4e7ce01481e162cf7e950c27aa5e4b5d1e5bb245').
+		preset: process.env.NITRO_PRESET || 'firebase',
 	},
 	css: ['@/assets/css/styles.css'],
 	build: {


### PR DESCRIPTION
## Purpose

The Nitro preset is defined to `firebase` as that is what we use in production. If you build your own private instance, you probably want to be able to run it in a local node.js instance instead of deploying to Firebase.

The variable `NITRO_PRESET` should override this but didn't until [Nitro v0.5.0](https://github.com/unjs/nitro/releases/tag/v0.5.0) ([commit](https://github.com/unjs/nitro/commit/92d711fe936fda0ff877c23d8a0d73ed4ea4adc4)). It's not easy to figure out which version of Nitro we use in this project, but the variable doesn't work, and judging by timing, it's clearly an earlier version than this.

Currently the workaround used [here](https://github.com/bisgardo/concordium-docker/pull/53/files) is to completely overwrite `nuxt.config.ts` which is not a great solution.

## Changes

Read  `NITRO_PRESET` directly in the config file and let the value take precedence there.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.