### PR TITLE
Frontend: Add account statement export button

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -14,15 +14,15 @@ const VARS: Record<Environment, Config> = {
 		wsUrl: 'wss://mainnet.dev-api.ccdscan.io/graphql',
 	},
 	stagenet: {
-		apiUrl: 'https://api-ccdscan.stagenet.concordium.com/graphql/',
+		apiUrl: 'https://api-ccdscan.stagenet.concordium.com/graphql',
 		wsUrl: 'wss://api-ccdscan.stagenet.concordium.com/graphql',
 	},
 	testnet: {
-		apiUrl: 'https://api-ccdscan.testnet.concordium.com/graphql/',
+		apiUrl: 'https://api-ccdscan.testnet.concordium.com/graphql',
 		wsUrl: 'wss://api-ccdscan.testnet.concordium.com/graphql',
 	},
 	mainnet: {
-		apiUrl: 'https://api-ccdscan.mainnet.concordium.software/graphql/',
+		apiUrl: 'https://api-ccdscan.mainnet.concordium.software/graphql',
 		wsUrl: 'wss://api-ccdscan.mainnet.concordium.software/graphql',
 	},
 }

--- a/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
+++ b/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
@@ -173,5 +173,4 @@ type Props = {
 	exportUrl: string
 }
 defineProps<Props>()
-
 </script>

--- a/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
+++ b/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
@@ -129,13 +129,13 @@
 				/>
 			</div>
 			<div class="col-span-1 flex justify-end">
-				<Button
-					class="mr-4 rounded"
-					:on-click="export_"
+				<a
+					class="bg-theme-button-primary px-8 py-3 hover:bg-theme-button-primary-hover rounded"
+					:href="exportUrl"
 				>
 					<span class="hidden md:inline">Export</span>
 					<DownloadIcon class="h-4 inline align-text-top" />
-				</Button>
+				</a>
 			</div>
 		</div>
 	</div>
@@ -170,10 +170,8 @@ type Props = {
 	accountStatementItems: AccountStatementEntry[]
 	pageInfo: PageInfo
 	goToPage: (page: PageInfo) => (target: PaginationTarget) => void
+	exportUrl: string
 }
 defineProps<Props>()
 
-const export_ = () => {
-	console.log('EXPORT')
-}
 </script>

--- a/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
+++ b/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
@@ -7,7 +7,9 @@
 					<TableTh>Type</TableTh>
 					<TableTh v-if="breakpoint >= Breakpoint.XL">Reference</TableTh>
 					<TableTh align="right">Amount</TableTh>
-					<TableTh v-if="breakpoint >= Breakpoint.XXL" align="right">Balance</TableTh>
+					<TableTh v-if="breakpoint >= Breakpoint.XXL" align="right"
+						>Balance</TableTh
+					>
 				</TableRow>
 			</TableHead>
 			<TableBody>
@@ -142,6 +144,7 @@
 </template>
 
 <script lang="ts" setup>
+import { DownloadIcon } from '@heroicons/vue/solid/index.js'
 import Amount from '~/components/atoms/Amount.vue'
 import Tooltip from '~/components/atoms/Tooltip.vue'
 import RewardIcon from '~/components/icons/RewardIcon.vue'
@@ -150,7 +153,6 @@ import TransferIconIn from '~/components/icons/TransferIconIn.vue'
 import TransferIconOut from '~/components/icons/TransferIconOut.vue'
 import EncryptedIcon from '~/components/icons/EncryptedIcon.vue'
 import DecryptedIcon from '~/components/icons/DecryptedIcon.vue'
-import { DownloadIcon } from '@heroicons/vue/solid/index.js'
 import { translateBakerRewardType } from '~/utils/translateBakerRewardType'
 import { formatTimestamp, convertTimestampToRelative } from '~/utils/format'
 import { translateAccountStatementEntryType } from '~/utils/translateAccountStatementEntry'

--- a/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
+++ b/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
@@ -7,9 +7,7 @@
 					<TableTh>Type</TableTh>
 					<TableTh v-if="breakpoint >= Breakpoint.XL">Reference</TableTh>
 					<TableTh align="right">Amount</TableTh>
-					<TableTh v-if="breakpoint >= Breakpoint.XXL" align="right"
-						>Balance</TableTh
-					>
+					<TableTh v-if="breakpoint >= Breakpoint.XXL" align="right">Balance</TableTh>
 				</TableRow>
 			</TableHead>
 			<TableBody>
@@ -122,11 +120,24 @@
 				</TableRow>
 			</TableBody>
 		</Table>
-		<Pagination
-			v-if="pageInfo && (pageInfo.hasNextPage || pageInfo.hasPreviousPage)"
-			:page-info="pageInfo"
-			:go-to-page="goToPage"
-		/>
+		<div class="grid grid-cols-4 mt-8">
+			<div class="col-span-3">
+				<Pagination
+					v-if="pageInfo && (pageInfo.hasNextPage || pageInfo.hasPreviousPage)"
+					:page-info="pageInfo"
+					:go-to-page="goToPage"
+				/>
+			</div>
+			<div class="col-span-1 flex justify-end">
+				<Button
+					class="mr-4 rounded"
+					:on-click="export_"
+				>
+					<span class="hidden md:inline">Export</span>
+					<DownloadIcon :class="buttonClasses" />
+				</Button>
+			</div>
+		</div>
 	</div>
 </template>
 
@@ -139,6 +150,7 @@ import TransferIconIn from '~/components/icons/TransferIconIn.vue'
 import TransferIconOut from '~/components/icons/TransferIconOut.vue'
 import EncryptedIcon from '~/components/icons/EncryptedIcon.vue'
 import DecryptedIcon from '~/components/icons/DecryptedIcon.vue'
+import { DownloadIcon } from '@heroicons/vue/solid/index.js'
 import { translateBakerRewardType } from '~/utils/translateBakerRewardType'
 import { formatTimestamp, convertTimestampToRelative } from '~/utils/format'
 import { translateAccountStatementEntryType } from '~/utils/translateAccountStatementEntry'
@@ -160,4 +172,10 @@ type Props = {
 	goToPage: (page: PageInfo) => (target: PaginationTarget) => void
 }
 defineProps<Props>()
+
+const buttonClasses = 'h-4 inline align-text-top'
+
+const export_ = () => {
+	console.log('EXPORT')
+}
 </script>

--- a/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
+++ b/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
@@ -134,7 +134,7 @@
 					:on-click="export_"
 				>
 					<span class="hidden md:inline">Export</span>
-					<DownloadIcon :class="buttonClasses" />
+					<DownloadIcon class="h-4 inline align-text-top" />
 				</Button>
 			</div>
 		</div>
@@ -172,8 +172,6 @@ type Props = {
 	goToPage: (page: PageInfo) => (target: PaginationTarget) => void
 }
 defineProps<Props>()
-
-const buttonClasses = 'h-4 inline align-text-top'
 
 const export_ = () => {
 	console.log('EXPORT')

--- a/frontend/src/components/Accounts/AccountDetailsContent.vue
+++ b/frontend/src/components/Accounts/AccountDetailsContent.vue
@@ -122,7 +122,7 @@
 						:account-statement-items="account.accountStatement.nodes"
 						:page-info="account.accountStatement.pageInfo"
 						:go-to-page="goToPageAccountStatement"
-						:export-url="exportUrl"
+						:export-url="exportUrl(account.address.asString)"
 					/>
 					<div v-else class="p-4">No entries</div>
 				</template>
@@ -201,8 +201,13 @@ type Props = {
 	goToPageAccountRewards: (page: PageInfo) => (target: PaginationTarget) => void
 }
 
-const props = defineProps<Props>()
+defineProps<Props>()
 
 const { apiUrl } = useRuntimeConfig()
-const exportUrl = `${apiUrl}/../rest/export/statement?accountAddress=${props.account.address.asString}`
+
+function exportUrl(accountAddress) {
+	const url = new URL('../rest/export/statement', apiUrl) // path is relative to '<domain>/graphql'
+	url.searchParams.append('accountAddress', accountAddress)
+	return url.toString()
+}
 </script>

--- a/frontend/src/components/Accounts/AccountDetailsContent.vue
+++ b/frontend/src/components/Accounts/AccountDetailsContent.vue
@@ -206,7 +206,8 @@ defineProps<Props>()
 const { apiUrl } = useRuntimeConfig()
 
 function exportUrl(accountAddress) {
-	const url = new URL('../rest/export/statement', apiUrl) // path is relative to '<domain>/graphql'
+	const url = new URL(apiUrl)
+	url.pathname = 'rest/export/statement' // setting pathname discards any existing path in 'apiUrl'
 	url.searchParams.append('accountAddress', accountAddress)
 	return url.toString()
 }

--- a/frontend/src/components/Accounts/AccountDetailsContent.vue
+++ b/frontend/src/components/Accounts/AccountDetailsContent.vue
@@ -122,7 +122,8 @@
 						:account-statement-items="account.accountStatement.nodes"
 						:page-info="account.accountStatement.pageInfo"
 						:go-to-page="goToPageAccountStatement"
-					></AccountDetailsAccountStatement>
+						:export-url="exportUrl"
+					/>
 					<div v-else class="p-4">No entries</div>
 				</template>
 			</Accordion>
@@ -200,5 +201,8 @@ type Props = {
 	goToPageAccountRewards: (page: PageInfo) => (target: PaginationTarget) => void
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+
+const { apiUrl } = useRuntimeConfig()
+const exportUrl = `${apiUrl}/../rest/export/statement?accountAddress=${props.account.address.asString}`
 </script>

--- a/frontend/src/components/Pagination.vue
+++ b/frontend/src/components/Pagination.vue
@@ -3,7 +3,7 @@
 		class="flex bottom-0 pagination"
 		:class="[
 			position ? position : 'relative',
-			size === 'sm' ? 'justify-end' : 'justify-center mt-8 p-4',
+			'justify-center',
 		]"
 	>
 		<Button


### PR DESCRIPTION
## Purpose

Expose account statement export (#15) as a button in the frontend.

## Changes

Add an "Export" button in the account export widget.

*Before:*

![image](https://user-images.githubusercontent.com/205161/199025390-8d2f07cc-3030-482c-a75f-438d4d2acdb0.png)

*After:*

![image](https://user-images.githubusercontent.com/205161/199025247-b621ccea-4cd9-4561-8f8b-fc3ed4756431.png)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.