### PR TITLE
Use localhost for development

### DIFF
--- a/backend/Application/appsettings.Development.json
+++ b/backend/Application/appsettings.Development.json
@@ -1,11 +1,11 @@
 {
   "PostgresDatabase": {
-    "ConnectionString" : "Host=localhost;Port=5432;Database=ccscan;User ID=postgres;Password=lingo-bingo;Include Error Detail=true;",
-    "ConnectionStringNodeCache" : "Host=localhost;Port=5432;Database=ccscan_node_cache;User ID=postgres;Password=lingo-bingo;Include Error Detail=true;"
+    "ConnectionString" : "Host=localhost;Port=5432;Database=ccscan;User ID=postgres;Password=password;Include Error Detail=true;",
+    "ConnectionStringNodeCache" : "Host=localhost;Port=5432;Database=ccscan_node_cache;User ID=postgres;Password=password;Include Error Detail=true;"
   },
   "ConcordiumNodeGrpc": {
-    "Address": "http://20.123.43.196:10000",
-    "AuthenticationToken": "foo-bar-fighting"
+    "Address": "http://localhost:10000",
+    "AuthenticationToken": "rpcadmin"
   },
   "FeatureFlags": {
     "MigrateDatabasesAtStartup": true,

--- a/backend/README.md
+++ b/backend/README.md
@@ -14,7 +14,7 @@ The following prerequisites must be met in order to run the test suite and/or ru
     * Install with this configuration *(If other configuration values are used, then configuration in code must be changed accordingly)*
         * Port: 5432
         * User: postgres
-        * Password: lingo-bingo
+        * Password: password
 
 * **Concordium Node**
     * During development the Concordium nodes in the development environment (in Azure) were used from local development setup

--- a/backend/Tests/TestUtilities/DatabaseFixture.cs
+++ b/backend/Tests/TestUtilities/DatabaseFixture.cs
@@ -9,8 +9,8 @@ public class DatabaseFixture
     private static readonly object LockObject = new();
     private static bool _databaseAlreadyMigrated;
 
-    public const string ConnectionString = "Host=localhost;Port=5432;Database=ccscan_unittest;User ID=postgres;Password=lingo-bingo;Include Error Detail=true;";
-    public const string ConnectionStringNodeCache = "Host=localhost;Port=5432;Database=ccscan_node_cache_unittest;User ID=postgres;Password=lingo-bingo;Include Error Detail=true;";
+    public const string ConnectionString = "Host=localhost;Port=5432;Database=ccscan_test;User ID=postgres;Password=password;Include Error Detail=true;";
+    public const string ConnectionStringNodeCache = "Host=localhost;Port=5432;Database=ccscan_node_cache_test;User ID=postgres;Password=password;Include Error Detail=true;";
     public DatabaseSettings DatabaseSettings => new()
     {
         ConnectionString = ConnectionString,

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -10,8 +10,8 @@ const ENVIRONMENT = (process.env.ENVIRONMENT as Environment) || 'dev'
 
 const VARS: Record<Environment, Config> = {
 	dev: {
-		apiUrl: 'https://mainnet.dev-api.ccdscan.io/graphql',
-		wsUrl: 'wss://mainnet.dev-api.ccdscan.io/graphql',
+		apiUrl: 'http://localhost:5000/graphql',
+		wsUrl: 'wss://localhost:5000/graphql',
 	},
 	stagenet: {
 		apiUrl: 'https://api-ccdscan.stagenet.concordium.com/graphql/',

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -11,7 +11,7 @@ const ENVIRONMENT = (process.env.ENVIRONMENT as Environment) || 'dev'
 const VARS: Record<Environment, Config> = {
 	dev: {
 		apiUrl: 'http://localhost:5000/graphql',
-		wsUrl: 'wss://localhost:5000/graphql',
+		wsUrl: 'ws://localhost:5000/graphql',
 	},
 	stagenet: {
 		apiUrl: 'https://api-ccdscan.stagenet.concordium.com/graphql/',


### PR DESCRIPTION
## Purpose

By default we should expect development to happen against a local Node and TimescaleDB. At least, the current values don't point at anything that's up anymore.

## Changes

Make default DB connection string and Node gRPC address point to services on localhost.