### PR TITLE
Backend: Export: Add support for optional time limits

### DIFF
--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -69,10 +69,7 @@ public class ExportController : ControllerBase
         var values = await result.ToListAsync();
         if (values.Count == 0)
         {
-            return new ContentResult
-            {
-                Content = "Nothing to export.\n"
-            };
+            return new NoContentResult();
         }
         
         var csv = new StringBuilder("Time,Amount (CCD),Label\n");

--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -51,7 +51,12 @@ public class ExportController : ControllerBase
         var csv = new StringBuilder("Time,Amount (CCD),Label\n");
         foreach (var v in values)
         {
-            csv.Append($"{v.Timestamp.ToString("u")},{v.Amount / 1e6},{v.EntryType}\n");
+            csv.Append(v.Timestamp.ToString("u"));
+            csv.Append(',');
+            csv.Append(v.Amount / 1e6);
+            csv.Append(',');
+            csv.Append(v.EntryType);
+            csv.Append('\n');
         }
 
         return new FileContentResult(Encoding.ASCII.GetBytes(csv.ToString()), "text/csv")


### PR DESCRIPTION
## Purpose

Make it possible to limit the size of the export.

## Changes

Add optional parameters `fromTime` and `toTime` to let the caller to set time-based limits on what entries to export.

Both parameters expect the time to be provided in ISO 8601 format including time zone (or "Z" for GMT).

The feature is not yet exposed on the frontend as it isn't clear if/how it should be done.

If the statement for an account has no entries, then the string "Nothing to export" is returned instead of a file. If the browser ran into this case, it would change the page to this one. But the frontend already renders "No entries" for accounts with an empty statement, so this case cannot occur.