### PR TITLE
gRPC: Use secure credentials for HTTPS address

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ The project ships a Docker Compose spec for deploying a CCDScan Backend with a T
 
 *Example*
 
-Run backend from public image `concordium/ccdscan:1.3.0-0` against a local mainnet node on port 5001:
+Run backend on port 5001 from public image `concordium/ccdscan:<tag>` against a local mainnet node:
 
 ```shell
-export CCDSCAN_BACKEND_IMAGE=concordium/ccdscan:1.3.0-0
+export CCDSCAN_BACKEND_IMAGE=concordium/ccdscan:<tag>
 export CCDSCAN_BACKEND_PORT=5001
 export CCDSCAN_DOMAIN=mainnet.concordium.software
 docker-compose pull

--- a/backend/ConcordiumSdk/NodeApi/GrpcNodeClient.cs
+++ b/backend/ConcordiumSdk/NodeApi/GrpcNodeClient.cs
@@ -33,14 +33,15 @@ public class GrpcNodeClient : INodeClient, IDisposable
             { "authentication", settings.AuthenticationToken }
         };
 
+        var address = settings.Address;
         var options = new GrpcChannelOptions
         {
-            Credentials = ChannelCredentials.Insecure,
+            Credentials = address.StartsWith("https:") ? ChannelCredentials.SecureSsl : ChannelCredentials.Insecure,
             HttpClient = httpClient,
             DisposeHttpClient = false,
             MaxReceiveMessageSize = 64 * 1024 * 1024, // 64 MB
         };
-        _grpcChannel = GrpcChannel.ForAddress(settings.Address, options);
+        _grpcChannel = GrpcChannel.ForAddress(address, options);
         _client = new P2P.P2PClient(_grpcChannel);
 
         _jsonSerializerOptions = GrpcNodeJsonSerializerOptionsFactory.Create();

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,6 +14,8 @@ FROM build AS publish
 RUN dotnet publish "Application.csproj" -c Release -o /app/publish
 
 FROM base AS final
+# Install 'ca-certificates' for supporting HTTPS.
+RUN apt-get update && apt-get install ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS=http://+:5000


### PR DESCRIPTION
## Purpose

Support Node communication via HTTPS.

## Changes

Use `ChannelCredentials.SecureSsl` if Node address starts with `https:`.

The solution has been verified to work against `https://reporters.internal.testnet.concordium.com:10000`.