### PR TITLE
New Payday On Protocol Update

### DIFF
--- a/backend/Application/Api/GraphQL/EfCore/EntityTypeConfigurations/PaydayStatusConfiguration.cs
+++ b/backend/Application/Api/GraphQL/EfCore/EntityTypeConfigurations/PaydayStatusConfiguration.cs
@@ -15,5 +15,6 @@ public class PaydayStatusConfiguration : IEntityTypeConfiguration<PaydayStatus>
         builder.Property(x => x.Id).HasColumnName("id").ValueGeneratedOnAdd();
         builder.Property(x => x.NextPaydayTime).HasColumnName("next_payday_time").HasConversion<DateTimeOffsetToTimestampConverter>();
         builder.Property(x => x.PaydayStartTime).HasColumnName("payday_start_time").HasConversion<DateTimeOffsetToTimestampConverter>();
+        builder.Property(x => x.ProtocolVersion).HasColumnName("protocol_version");
     }
 }

--- a/backend/Application/Api/GraphQL/Import/MetricsWriter.cs
+++ b/backend/Application/Api/GraphQL/Import/MetricsWriter.cs
@@ -190,6 +190,8 @@ public class MetricsWriter
         if (poolRewards.Length == 0) 
             return;
         
+        // Here payday summary cannot be null. 
+        // So pool rewards have length > 0 when there is payday summary
         if (paydaySummary == null) throw new ArgumentNullException(nameof(paydaySummary));
         if (paydayPoolStakeSnapshot == null) throw new ArgumentNullException(nameof(paydayPoolStakeSnapshot));
         if (paydayPassiveDelegationStakeSnapshot == null) throw new ArgumentNullException(nameof(paydayPassiveDelegationStakeSnapshot));
@@ -287,9 +289,11 @@ public class MetricsWriter
 
         if (stakedAmount == 0) return null;
         
-        const double secondsPerYear = 365 * 24 * 60 * 60;
-        var v1 = 1 + rewardAmount / (double)stakedAmount;
-        var v2 = secondsPerYear / paydayDurationSeconds;
-        return Math.Pow(v1, v2) - 1;
+        const double secondsPerYear = 31536000;
+        var rate = rewardAmount / (double)stakedAmount;
+        var compoundingPeriods = secondsPerYear / paydayDurationSeconds;
+        var apy = Math.Pow(1 + rate, compoundingPeriods) - 1;
+
+        return apy;
     }
 }

--- a/backend/Application/Api/GraphQL/Import/PaydayImportHandler.cs
+++ b/backend/Application/Api/GraphQL/Import/PaydayImportHandler.cs
@@ -47,7 +47,7 @@ public class PaydayImportHandler
             {
                 var duration = Convert.ToInt64((status.NextPaydayTime - status.PaydayStartTime).TotalSeconds);
 
-                // Upon update to protocol 5 the time was shifted by ~5 secs on Testnet
+                // Upon update to protocol 5 the time was shifted by ~5 minutes (287 seconds) on Testnet
                 // Duration should be adjusted
                 if(payload.BlockInfo.BlockHash.AsString == "d2d9f88cb953c3314dc1219120d140deaffc44c73ca335f6227b84c09ba7a9d4") {
                     duration = 24 * 60 * 60;

--- a/backend/Application/Api/GraphQL/Import/PaydayImportHandler.cs
+++ b/backend/Application/Api/GraphQL/Import/PaydayImportHandler.cs
@@ -45,8 +45,15 @@ public class PaydayImportHandler
             }
             else if (status.NextPaydayTime != rewardStatus.NextPaydayTime)
             {
-                var duration = status.NextPaydayTime - status.PaydayStartTime;
-                var result = new FirstBlockAfterPayday(status.NextPaydayTime, Convert.ToInt64(duration.TotalSeconds));
+                var duration = Convert.ToInt64((status.NextPaydayTime - status.PaydayStartTime).TotalSeconds);
+
+                // Upon update to protocol 5 the time was shifted by ~5 secs on Testnet
+                // Duration should be adjusted
+                if(payload.BlockInfo.BlockHash.AsString == "d2d9f88cb953c3314dc1219120d140deaffc44c73ca335f6227b84c09ba7a9d4") {
+                    duration = 24 * 60 * 60;
+                }
+
+                var result = new FirstBlockAfterPayday(status.NextPaydayTime, duration);
                 
                 status.PaydayStartTime = status.NextPaydayTime;
                 status.NextPaydayTime = rewardStatus.NextPaydayTime;

--- a/backend/Application/Api/GraphQL/Payday/PaydayStatus.cs
+++ b/backend/Application/Api/GraphQL/Payday/PaydayStatus.cs
@@ -16,7 +16,10 @@ public class PaydayStatus
 
     [GraphQLIgnore]
     public DateTimeOffset PaydayStartTime { get; set; }
-    
+
+    [GraphQLIgnore]
+    public int? ProtocolVersion { get; set; }
+
     [UseDbContext(typeof(GraphQlDbContext))]
     [UsePaging(DefaultPageSize = 10)]
     public IQueryable<PaydaySummary> GetPaydaySummaries([ScopedService] GraphQlDbContext dbContext)

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Handled exceptions when Baker & Account not available in Database while trying to update them.
 - Added support for Contract Upgraded Event (Protocol 5)
 - Reverted catching of all possible Baker Update Exceptions and moved logic to update pool status after a baker has been added.
+- Handling of block `1385825` on testnet. Which changes the NextPaydayTime by just 287 seconds.

--- a/backend/DatabaseScripts/SqlScripts/0037_AlterTable_graphql_payday_status_add_protocol_version.sql
+++ b/backend/DatabaseScripts/SqlScripts/0037_AlterTable_graphql_payday_status_add_protocol_version.sql
@@ -1,0 +1,1 @@
+﻿ALTER TABLE graphql_payday_status ADD COLUMN protocol_version INT NOT NULL DEFAULT 0;

--- a/backend/Tests/Api/GraphQL/EfCore/PaydayStatusConfigurationTest.cs
+++ b/backend/Tests/Api/GraphQL/EfCore/PaydayStatusConfigurationTest.cs
@@ -29,6 +29,7 @@ public class PaydayStatusConfigurationTest : IClassFixture<DatabaseFixture>
         {
             PaydayStartTime = _anyDateTimeOffset,
             NextPaydayTime = _anyDateTimeOffset.AddHours(2),
+            ProtocolVersion = 4
         };
 
         await AddPaydayStatus(input);
@@ -38,6 +39,7 @@ public class PaydayStatusConfigurationTest : IClassFixture<DatabaseFixture>
         result.Should().NotBeNull();
         result!.PaydayStartTime.Should().Be(_anyDateTimeOffset);
         result.NextPaydayTime.Should().Be(_anyDateTimeOffset.AddHours(2));
+        result.ProtocolVersion.Should().Be(4);
     }
 
     private async Task AddPaydayStatus(PaydayStatus input)


### PR DESCRIPTION
## Purpose
Fixes
- https://github.com/Concordium/concordium-scan/issues/35
- https://github.com/Concordium/concordium-scan/issues/36

## Changes

On Testnet the protocol 5 is updated at block `1385825`. The last block as the NextPayDayTime of `22/11/2022 11:00:32`
While Block `1385825` has the payday time of `23/11/2022 11:05:19` causing the duration to be calculated to 287 seconds when it should be ~1day (24 * 60 * 60) seconds. Causing the fixed issues.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance
By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
