### PR TITLE
Database Timeouts & Indexes to `graphql_account_statement_entries` Table

### DIFF
--- a/backend/Application/Database/DatabaseMigrator.cs
+++ b/backend/Application/Database/DatabaseMigrator.cs
@@ -97,7 +97,9 @@ namespace Application.Database
                 .WithScriptsEmbeddedInAssembly(_sqlScriptsAssembly, scriptPath => scriptPath.EndsWith(".sql") && scriptPath.Contains($".{sqlScriptsFolder}."))
                 .LogTo(_dbUpLogWrapper)
                 .WithTransaction()
+                .WithExecutionTimeout(_settings.MigrationTimeout)
                 .Build();
+                
             return upgrader;
         }
 

--- a/backend/Application/Database/DatabaseSettings.cs
+++ b/backend/Application/Database/DatabaseSettings.cs
@@ -4,4 +4,15 @@ public class DatabaseSettings
 {
     public string ConnectionString { get; init; }
     public string ConnectionStringNodeCache { get; init; }
+
+    /// <summary>
+    /// Timeout for each query.
+    /// </summary>
+    /// <value></value>
+    public TimeSpan QueryTimeout { get; init; }
+    
+    /// <summary>
+    /// Timeout for each executed query during Migration.
+    /// </summary>
+    public TimeSpan MigrationTimeout { get; init; }
 }

--- a/backend/Application/Program.cs
+++ b/backend/Application/Program.cs
@@ -70,7 +70,10 @@ builder.Services.AddSingleton<ImportValidationController>();
 builder.Services.AddControllers();
 builder.Services.AddPooledDbContextFactory<GraphQlDbContext>(options =>
 {
-    options.UseNpgsql(databaseSettings.ConnectionString);
+    options.UseNpgsql(
+        databaseSettings.ConnectionString,
+        configBuilder => configBuilder.CommandTimeout((int?)databaseSettings.QueryTimeout.TotalSeconds)
+    );
 });
 builder.Services.AddSingleton<NodeCache>();
 builder.Services.AddSingleton<IGrpcNodeCache>(x => x.GetRequiredService<NodeCache>());

--- a/backend/Application/appsettings.Development.json
+++ b/backend/Application/appsettings.Development.json
@@ -1,7 +1,9 @@
 {
   "PostgresDatabase": {
     "ConnectionString" : "Host=localhost;Port=5432;Database=ccscan;User ID=postgres;Password=password;Include Error Detail=true;",
-    "ConnectionStringNodeCache" : "Host=localhost;Port=5432;Database=ccscan_node_cache;User ID=postgres;Password=password;Include Error Detail=true;"
+    "ConnectionStringNodeCache" : "Host=localhost;Port=5432;Database=ccscan_node_cache;User ID=postgres;Password=password;Include Error Detail=true;",
+    "QueryTimeout": "00:00:30",
+    "MigrationTimeout": "00:02:00"
   },
   "ConcordiumNodeGrpc": {
     "Address": "http://localhost:10000",

--- a/backend/Application/appsettings.json
+++ b/backend/Application/appsettings.json
@@ -1,7 +1,9 @@
 {
   "PostgresDatabase": {
     "ConnectionString" : "Host=postgres;Port=5432;Database=ConcordiumScan;User ID=postgres;Password=passwordFTB2021",
-    "ConnectionStringNodeCache" : "Host=postgres;Port=5432;Database=ConcordiumScan_node_cache;User ID=postgres;Password=passwordFTB2021"
+    "ConnectionStringNodeCache" : "Host=postgres;Port=5432;Database=ConcordiumScan_node_cache;User ID=postgres;Password=passwordFTB2021",
+    "QueryTimeout": "00:00:30",
+    "MigrationTimeout": "00:02:00"
   },
   "ConcordiumNodeGrpc": {
     "Address": "http://ccnode:10000",

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Changed the header from "Total circulating supply of CCD" to "Total unlocked CCD"
 - Added New API endpoint to get "unlocked CCD"
 - Fixed Issue 55 by setting account balance to actual queried balance in case of genesis block.
+- Added database timeout settings & Added indexes to graphql_account_statement_entries

--- a/backend/DatabaseScripts/SqlScripts/0040_AlterTable_graphql_account_statement_entries_add_indexes.sql
+++ b/backend/DatabaseScripts/SqlScripts/0040_AlterTable_graphql_account_statement_entries_add_indexes.sql
@@ -1,0 +1,6 @@
+﻿create index account_statement_entries_account_id_index
+    on graphql_account_statement_entries (account_id);
+create index account_statement_entries_entry_type_index
+    on graphql_account_statement_entries (entry_type);
+create index account_statement_entries_timestamp_index
+    on graphql_account_statement_entries (time);


### PR DESCRIPTION
## Purpose
Added database timeout settings & Added indexes to graphql_account_statement_entries

## Changes
Added database timeout settings & Added indexes to graphql_account_statement_entries

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance
By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
