### PR TITLE
[CBW-1244] Add two transaction events when account is created

### DIFF
--- a/backend/Application/Api/GraphQL/Transactions/TransactionResultEvent.cs
+++ b/backend/Application/Api/GraphQL/Transactions/TransactionResultEvent.cs
@@ -20,12 +20,8 @@ public abstract record TransactionResultEvent
         switch (blockItemSummaryDetails)
         {
             case AccountCreationDetails accountCreationDetails:
-                yield return accountCreationDetails.CredentialType switch
-                {
-                    CredentialType.Initial => CredentialDeployed.From(accountCreationDetails),
-                    CredentialType.Normal => AccountCreated.From(accountCreationDetails),
-                    _ => throw new ArgumentOutOfRangeException(nameof(accountCreationDetails))
-                };
+                yield return CredentialDeployed.From(accountCreationDetails);
+                yield return AccountCreated.From(accountCreationDetails);
                 break;
             case AccountTransactionDetails accountTransactionDetails:
                 switch (accountTransactionDetails.Effects)

--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <Version>1.6.1</Version>
+        <Version>1.6.2</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.2
+- Bugfix
+    - Added as before protocol update two transaction events, `CredentialDeployed` and `AccountCreated`, when a account is created.
+
 ## 1.6.1
 - Bugfix
     - Bumped NET SDK to 4.0.1 which fixes wrong transaction count mapping.

--- a/backend/Tests/Api/GraphQL/Import/TransactionsWriterTest.cs
+++ b/backend/Tests/Api/GraphQL/Import/TransactionsWriterTest.cs
@@ -216,16 +216,32 @@ public class TransactionsWriterTest
     public async Task TransactionEvents_AccountCreated()
     {
         const string address = "31JA2dWnv6xHrdP73kLKvWqr5RMfqoeuJXG2Mep1iyQV9E5aSd";
+        var bytes = new byte[42];
+
         var accountCreated = new AccountCreationDetailsBuilder(CredentialType.Normal)
             .WithAccountAddress(AccountAddress.From(address))
+            .WithCredentialRegistrationId(new CredentialRegistrationId(bytes))
             .Build();
         var blockItemSummaryAccountCreated = new BlockItemSummaryBuilder(accountCreated)
             .Build();
 
         await WriteData(new List<BlockItemSummary>{blockItemSummaryAccountCreated});
 
-        var result = await ReadSingleTransactionEventType<AccountCreated>();
-        result.AccountAddress.AsString.Should().Be(address);
+        await using var dbContext = _dbContextFactory.CreateDbContext();
+        var transaction = dbContext.Transactions.Single();
+
+        var result = dbContext.TransactionResultEvents.ToArray();
+        result.Length.Should().Be(2);
+        result[0].TransactionId.Should().Be(transaction.Id);
+        result[0].Index.Should().Be(0);
+        result[0].Entity.Should().BeOfType<CredentialDeployed>();
+        var credentialDeployed = result[0].Entity as CredentialDeployed;
+        credentialDeployed!.AccountAddress.AsString.Should().Be(address);
+        credentialDeployed!.RegId.Should().Be(Convert.ToHexString(bytes));
+        result[1].TransactionId.Should().Be(transaction.Id);
+        result[1].Index.Should().Be(1);
+        result[1].Entity.Should().BeOfType<AccountCreated>();
+        (result[1].Entity as AccountCreated)!.AccountAddress.AsString.Should().Be(address);
     }
     
     [Fact]
@@ -243,9 +259,21 @@ public class TransactionsWriterTest
 
         await WriteData(new List<BlockItemSummary>{blockItemSummaryCredentialDeployed});
 
-        var result = await ReadSingleTransactionEventType<CredentialDeployed>();
-        result.RegId.Should().Be(regId);
-        result.AccountAddress.AsString.Should().Be(address);
+        await using var dbContext = _dbContextFactory.CreateDbContext();
+        var transaction = dbContext.Transactions.Single();
+
+        var result = dbContext.TransactionResultEvents.ToArray();
+        result.Length.Should().Be(2);
+        result[0].TransactionId.Should().Be(transaction.Id);
+        result[0].Index.Should().Be(0);
+        result[0].Entity.Should().BeOfType<CredentialDeployed>();
+        var credentialDeployed = result[0].Entity as CredentialDeployed;
+        credentialDeployed!.AccountAddress.AsString.Should().Be(address);
+        credentialDeployed!.RegId.Should().Be(regId);
+        result[1].TransactionId.Should().Be(transaction.Id);
+        result[1].Index.Should().Be(1);
+        result[1].Entity.Should().BeOfType<AccountCreated>();
+        (result[1].Entity as AccountCreated)!.AccountAddress.AsString.Should().Be(address);
     }
 
     [Fact]


### PR DESCRIPTION
## Purpose


* https://concordium.atlassian.net/browse/CBW-1244
   Add two transaction events when account is created to align with how it is before protocol update.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.