### PR TITLE
Removing Finalization Time Chart

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/pages/blocks/index.vue
+++ b/frontend/src/pages/blocks/index.vue
@@ -7,7 +7,7 @@
 			>
 				<MetricsPeriodDropdown v-model="selectedMetricsPeriod" />
 			</div>
-			<FtbCarousel non-carousel-classes="grid-cols-3">
+			<FtbCarousel non-carousel-classes="grid-cols-2">
 				<CarouselSlide class="w-full">
 					<BlocksAddedChart
 						:block-metrics-data="metricsData"
@@ -16,12 +16,6 @@
 				</CarouselSlide>
 				<CarouselSlide class="w-full">
 					<BlockTimeChart
-						:block-metrics-data="metricsData"
-						:is-loading="metricsFetching"
-					/>
-				</CarouselSlide>
-				<CarouselSlide class="w-full">
-					<FinalizationTimeChart
 						:block-metrics-data="metricsData"
 						:is-loading="metricsFetching"
 					/>


### PR DESCRIPTION
## Purpose

Remove Finalization Time Chart until endpoint BlockInfo on nodes has updated, which block last finalized points to.

When fixed, another PR already exist which fixes calculations of finalization times
https://github.com/Concordium/concordium-scan/pull/91

## Changes

Remove Finalization Time Chart from Block page.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.