### PR TITLE
Moved Contract Call Event Before Contract Update

### DIFF
--- a/backend/Application/Aggregates/Contract/ContractAggregate.cs
+++ b/backend/Application/Aggregates/Contract/ContractAggregate.cs
@@ -278,22 +278,8 @@ internal sealed class ContractAggregate
                     ));
                 break;
             case ContractUpdated contractUpdated:
-                await repository
-                    .AddAsync(new ContractEvent(
-                        blockHeight,
-                        transactionHash,
-                        transactionIndex,
-                        eventIndex,
-                        contractUpdated.ContractAddress,
-                        sender,
-                        contractUpdated,
-                        source,
-                        blockSlotTime
-                        ));
                 if (contractUpdated.Instigator is ContractAddress contractInstigator)
                 {
-                    // Possible a contract has called itself.
-                    eventIndex += 1;
                     await repository
                         .AddAsync(new ContractEvent(
                             blockHeight,
@@ -308,7 +294,21 @@ internal sealed class ContractAggregate
                             source,
                             blockSlotTime
                         ));
+                    // Possible a contract has called itself.
+                    eventIndex += 1;
                 }
+                await repository
+                    .AddAsync(new ContractEvent(
+                        blockHeight,
+                        transactionHash,
+                        transactionIndex,
+                        eventIndex,
+                        contractUpdated.ContractAddress,
+                        sender,
+                        contractUpdated,
+                        source,
+                        blockSlotTime
+                        ));
                 break;
             case ContractUpgraded contractUpgraded:
                 await repository

--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -4,9 +4,8 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <Version>1.7.0</Version>
+        <Version>1.7.1</Version>
     </PropertyGroup>
-
     <ItemGroup>
       <PackageReference Include="ConcordiumNetSdk" Version="4.0.1" />
       <PackageReference Include="Dapper" Version="2.0.123" />

--- a/backend/Tests/Aggregates/Contract/ContractAggregateTests.cs
+++ b/backend/Tests/Aggregates/Contract/ContractAggregateTests.cs
@@ -129,13 +129,12 @@ public sealed class ContractAggregateTests
         
         // Assert
         contractEvents.Count.Should().Be(2);
-        var updateEvent = contractEvents[0];
-        updateEvent.Event.Should().BeOfType<ContractUpdated>();
-        updateEvent.ContractAddressIndex.Should().Be(from);
-        
-        var transferEvent = contractEvents[1];
+        var transferEvent = contractEvents[0];
         transferEvent.Event.Should().BeOfType<ContractCall>();
         transferEvent.ContractAddressIndex.Should().Be(to);
+        var updateEvent = contractEvents[1];
+        updateEvent.Event.Should().BeOfType<ContractUpdated>();
+        updateEvent.ContractAddressIndex.Should().Be(from);
     }
     
     [Fact]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"engine": "16",
 	"type": "module",
 	"private": true,


### PR DESCRIPTION
## Purpose

Moved Contract Call event before a Contract Update event, since in the case where a contract call’s itself it will make most sense to have the Contract Call event shown first.

See example below
<img width="928" alt="Screenshot 2023-09-20 at 13 52 34" src="https://github.com/Concordium/concordium-scan/assets/132270889/3737fc4a-5932-4206-aaec-dcc104b05e30”>

## Changes
- Moved Contract Call and Contract Update event types
- Bump front- and backend versions to prepare for release

Task

https://concordium.atlassian.net/browse/CBW-1250

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.