### PR TITLE
Fix overlapping Search Results

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.5.4",
+	"version": "1.5.5",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/components/Navigation/DesktopNavigation.vue
+++ b/frontend/src/components/Navigation/DesktopNavigation.vue
@@ -1,5 +1,5 @@
 <template>
-	<nav class="hidden lg:flex -mr-4 lol flex-grow flex-shrink-0">
+	<nav class="hidden xl:flex -mr-4 lol flex-grow flex-shrink-0">
 		<NuxtLink
 			v-for="route in navRoutes"
 			:key="route.path"

--- a/frontend/src/components/Navigation/MobileNavigation.vue
+++ b/frontend/src/components/Navigation/MobileNavigation.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="lg:hidden">
+	<div class="xl:hidden">
 		<button
 			type="button"
 			aria-label="Open navigation"

--- a/frontend/src/components/Search/Search.vue
+++ b/frontend/src/components/Search/Search.vue
@@ -371,7 +371,7 @@ const getTooltipPosition = (index: number) => {
 /**
  * Class used for search results.
  *
- * When the windows is less then `Breakpoint.LG` the search results has full page width.
+ * When the screen size is less then `Breakpoint.LG` the search results has full page width.
  */
 const getSearchClass = computed(() => {
 	if (breakpoint.value >= Breakpoint.XXL) {

--- a/frontend/src/components/Search/Search.vue
+++ b/frontend/src/components/Search/Search.vue
@@ -45,7 +45,7 @@
 						<div
 							v-for="(block, index) in data.search.blocks.nodes"
 							:key="block.blockHash"
-							class="grid grid-cols-1 sm:grid-cols-3 xl:grid-cols-2 2xl:grid-cols-3 gap-8"
+							:class="$style.searchColumns"
 						>
 							<div>
 								<BlockLink
@@ -119,7 +119,7 @@
 						<div
 							v-for="(account, index) in data.search.accounts.nodes"
 							:key="account.address.asString"
-							:class="getSearchClass"
+							:class="$style.searchColumns"
 						>
 							<AccountLink
 								:address="account.address.asString"
@@ -147,7 +147,7 @@
 						<div
 							v-for="(contract, index) in data.search.contracts.nodes"
 							:key="contract.contractAddress"
-							:class="getSearchClass"
+							:class="$style.searchColumns"
 						>
 							<ContractLink
 								:address="contract.contractAddress"
@@ -179,7 +179,7 @@
 						<div
 							v-for="(module, index) in data.search.modules.nodes"
 							:key="module.moduleReference"
-							:class="getSearchClass"
+							:class="$style.searchColumns"
 						>
 							<ModuleLink
 								:module-reference="module.moduleReference"
@@ -207,7 +207,7 @@
 						<div
 							v-for="baker in data.search.bakers.nodes"
 							:key="baker.bakerId"
-							:class="getSearchClass"
+							:class="$style.searchColumns"
 						>
 							<BakerLink :id="baker.bakerId" @blur="lostFocusOnSearch" />
 							<div v-if="shouldShowColumn(3)"></div>
@@ -229,7 +229,7 @@
 						<div
 							v-for="node in data.search.nodeStatuses.nodes"
 							:key="node.id"
-							:class="getSearchClass"
+							:class="$style.searchColumns"
 						>
 							<NodeLink :node="node" @blur="lostFocusOnSearch" />
 							<div v-if="shouldShowColumn(3)"></div>
@@ -367,24 +367,6 @@ const lostFocusOnSearch = (x: FocusEvent) => {
 const getTooltipPosition = (index: number) => {
 	return index === 0 ? tooltipPositionBottom : tooltipPositionTop
 }
-
-/**
- * Class used for search results.
- *
- * When the screen size is less then `Breakpoint.LG` the search results has full page width.
- */
-const getSearchClass = computed(() => {
-	if (breakpoint.value >= Breakpoint.XXL) {
-		return 'grid grid-cols-3 gap-8'
-	}
-	if (breakpoint.value >= Breakpoint.XL) {
-		return 'grid grid-cols-2 gap-8'
-	}
-	if (breakpoint.value >= Breakpoint.SM) {
-		return 'grid grid-cols-3 gap-8'
-	}
-	return 'grid grid-cols-1 gap-8'
-})
 
 /**
  * Calculated if a columns should be shown conditional on the `columnCount`

--- a/frontend/src/components/Search/Search.vue
+++ b/frontend/src/components/Search/Search.vue
@@ -45,7 +45,7 @@
 						<div
 							v-for="(block, index) in data.search.blocks.nodes"
 							:key="block.blockHash"
-							:class="getSearchClass"
+							class="grid grid-cols-1 sm:grid-cols-3 xl:grid-cols-2 2xl:grid-cols-3 gap-8"
 						>
 							<div>
 								<BlockLink
@@ -78,7 +78,7 @@
 						<div
 							v-for="(transaction, index) in data.search.transactions.nodes"
 							:key="transaction.transactionHash"
-							:class="getSearchClass"
+							:class="$style.searchColumns"
 						>
 							<TransactionLink
 								:id="transaction.id"
@@ -430,6 +430,20 @@ const resultCount = computed(() => ({
 </script>
 
 <style module>
+.searchColumns {
+	display: grid;
+	grid-template-columns: repeat(1, minmax(0, 1fr));
+	@media (min-width: 640px) {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+	@media (min-width: 1280px) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+	@media (min-width: 1536px) {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}
+
 .input {
 	background: var(--color-input-bg);
 	-webkit-appearance: none;

--- a/frontend/src/components/Search/Search.vue
+++ b/frontend/src/components/Search/Search.vue
@@ -55,8 +55,8 @@
 									@blur="lostFocusOnSearch"
 								/>
 							</div>
-							<div v-if="shouldShowColumn(3)">@ {{ block.blockHeight }}</div>
-							<div v-if="shouldShowColumn(2)">
+							<div :class="$style.threeColumns">@ {{ block.blockHeight }}</div>
+							<div :class="$style.twoColumns">
 								Age
 								<Tooltip
 									:text="formatTimestamp(block.blockSlotTime)"
@@ -86,7 +86,7 @@
 								:hide-tooltip="true"
 								@blur="lostFocusOnSearch"
 							/>
-							<div v-if="shouldShowColumn(3)">
+							<div :class="$style.threeColumns">
 								<BlockLink
 									:id="transaction.block.id"
 									:hash="transaction.block.blockHash"
@@ -94,7 +94,7 @@
 									@blur="lostFocusOnSearch"
 								/>
 							</div>
-							<div v-if="shouldShowColumn(2)">
+							<div :class="$style.twoColumns">
 								Age
 								<Tooltip
 									:text="formatTimestamp(transaction.block.blockSlotTime)"
@@ -126,8 +126,8 @@
 								:hide-tooltip="true"
 								@blur="lostFocusOnSearch"
 							/>
-							<div v-if="shouldShowColumn(3)"></div>
-							<div v-if="shouldShowColumn(2)">
+							<div :class="$style.threeColumns"></div>
+							<div :class="$style.twoColumns">
 								Age
 								<Tooltip
 									:text="formatTimestamp(account.createdAt)"
@@ -157,10 +157,10 @@
 								@blur="lostFocusOnSearch"
 							/>
 							<AccountLink
-								v-if="shouldShowColumn(3)"
+								:class="$style.threeColumns"
 								:address="contract.creator.asString"
 							/>
-							<div v-if="shouldShowColumn(2)">
+							<div :class="$style.twoColumns">
 								Age
 								<Tooltip
 									:text="formatTimestamp(contract.blockSlotTime)"
@@ -186,8 +186,8 @@
 								:hide-tooltip="true"
 								@blur="lostFocusOnSearch"
 							/>
-							<div v-if="shouldShowColumn(3)"></div>
-							<div v-if="shouldShowColumn(2)">
+							<div :class="$style.threeColumns"></div>
+							<div :class="$style.twoColumns">
 								Age
 								<Tooltip
 									:text="formatTimestamp(module.blockSlotTime)"
@@ -210,8 +210,8 @@
 							:class="$style.searchColumns"
 						>
 							<BakerLink :id="baker.bakerId" @blur="lostFocusOnSearch" />
-							<div v-if="shouldShowColumn(3)"></div>
-							<div v-if="shouldShowColumn(2)">
+							<div :class="$style.threeColumns"></div>
+							<div :class="$style.twoColumns">
 								<AccountLink
 									:address="baker.account.address.asString"
 									:hide-tooltip="true"
@@ -232,8 +232,8 @@
 							:class="$style.searchColumns"
 						>
 							<NodeLink :node="node" @blur="lostFocusOnSearch" />
-							<div v-if="shouldShowColumn(3)"></div>
-							<div v-if="shouldShowColumn(2)">
+							<div :class="$style.threeColumns"></div>
+							<div :class="$style.twoColumns">
 								<BakerLink
 									v-if="Number.isInteger(node.consensusBakerId)"
 									:id="node.consensusBakerId"
@@ -368,30 +368,6 @@ const getTooltipPosition = (index: number) => {
 	return index === 0 ? tooltipPositionBottom : tooltipPositionTop
 }
 
-/**
- * Calculated if a columns should be shown conditional on the `columnCount`
- * parameter.
- * @param {number} `columnCount` - Column count of property.
- */
-function shouldShowColumn(columnCount: number) {
-	if (columnCount === 3) {
-		if (breakpoint.value >= Breakpoint.XXL) {
-			return true
-		}
-		if (breakpoint.value < Breakpoint.XL && breakpoint.value >= Breakpoint.SM) {
-			return true
-		}
-		return false
-	}
-	if (columnCount === 2) {
-		if (breakpoint.value >= Breakpoint.SM) {
-			return true
-		}
-		return false
-	}
-	return true
-}
-
 const resultCount = computed(() => ({
 	modules: data.value?.search.modules.nodes.length,
 	contracts: data.value?.search.contracts.nodes.length,
@@ -412,6 +388,20 @@ const resultCount = computed(() => ({
 </script>
 
 <style module>
+.twoColumns {
+	@media (max-width: 640px) {
+		display: none;
+	}
+}
+.threeColumns {
+	@media only screen and (min-width: 1280px) and (max-width: 1535px) {
+		display: none;
+	}
+	@media (max-width: 639px) {
+		display: none;
+	}
+}
+
 .searchColumns {
 	display: grid;
 	grid-template-columns: repeat(1, minmax(0, 1fr));

--- a/frontend/src/components/Search/Search.vue
+++ b/frontend/src/components/Search/Search.vue
@@ -264,11 +264,9 @@ import ContractLink from '~/components/molecules/ContractLink.vue'
 import { useDateNow } from '~/composables/useDateNow'
 import type { Position } from '~/composables/useTooltip'
 import NodeLink from '~/components/molecules/NodeLink.vue'
-import { Breakpoint } from '~~/src/composables/useBreakpoint'
 
 const { NOW } = useDateNow()
 const drawer = useDrawer()
-const { breakpoint } = useBreakpoint()
 
 const tooltipPositionBottom = 'bottom' as Position
 const tooltipPositionTop = 'top' as Position


### PR DESCRIPTION
## Purpose

Due to introduction of new tab ‘Contract’ the search result columns was overlapping. This PR fixes this.
Bug
- https://concordium.atlassian.net/browse/CBW-1364

## Changes

- Change Search Result View from going to full screen at screen size LG (1024) instead of XL (1280).
- Change navigation tabs from going to burger style at screen size less than XL (1280) instead of first at LG (1024)

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.