### PR TITLE
Fix text wraps in tooltips

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.5.7",
+	"version": "1.5.8",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/components/atoms/Tooltip.vue
+++ b/frontend/src/components/atoms/Tooltip.vue
@@ -68,8 +68,8 @@ const handleOnMouseLeave = () => {
 	top: v-bind(tooltipY);
 	left: v-bind(tooltipX);
 	position: v-bind(tooltipPosition);
-	text-wrap: wrap;
 	pointer-events: auto;
+	white-space: normal;
 	text-align: center;
 }
 


### PR DESCRIPTION
## Purpose

Text wrap in was done using `text-wrap` which wasn’t supported in Firefox and Safari browser. This PR changes to use `white-space: normal` which works across browsers.

* ´text-wrap`
https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#browser_compatibility
* `white-space`
https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#browser_compatibility
