### PR TITLE
Fix naming from Receive name to Entrypoint

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.5.9",
+	"version": "1.5.10",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/components/Contracts/ContractDetailsRejectEvents.vue
+++ b/frontend/src/components/Contracts/ContractDetailsRejectEvents.vue
@@ -58,11 +58,11 @@
 						</div>
 					</div>
 					<div>
-						<div>Receive name:
+						<div>Entrypoint:
 							<InfoTooltip :text="RECEIVE_NAME"/>
 						</div>
 						<div>
-							{{ contractRejectEvent.rejectedEvent.receiveName }}
+							{{ getEntrypoint(contractRejectEvent.rejectedEvent.receiveName) }}
 						</div>
 					</div>
 					<MessageHEX
@@ -79,6 +79,7 @@ import DateTimeWithLineBreak from '../Details/DateTimeWithLineBreak.vue'
 import MessageHEX from '../Details/MessageHEX.vue'
 import DetailsView from '../Details/DetailsView.vue'
 import InfoTooltip from '../atoms/InfoTooltip.vue'
+import { getEntrypoint } from "./Events/contractEvents";
 import { ContractRejectEvent } from '~~/src/types/generated'
 import TransactionLink from '~~/src/components/molecules/TransactionLink.vue'
 import Tooltip from '~~/src/components/atoms/Tooltip.vue'


### PR DESCRIPTION
## Purpose

Fix missing place where it was receive name instead og entrypoint and contract name was still prefixed.
