### PR TITLE
Blur tables when fetching data

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.5.10",
+	"version": "1.5.11",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/components/Contracts/ContractDetailsContainer.vue
+++ b/frontend/src/components/Contracts/ContractDetailsContainer.vue
@@ -10,6 +10,7 @@
 		:pagination-reject-events="pageOffsetInfoRejectedEvents"
 		:page-dropdown-events="pageDropdownEvents"
 		:page-dropdown-rejected-events="pageDropdownRejectedEvents"
+		:fetching="fetching"
 	/>
 </template>
 
@@ -37,7 +38,7 @@ const props = defineProps<Props>()
 const contractAddressIndex = ref(props.contractAddressIndex)
 const contractAddressSubIndex = ref(props.contractAddressSubIndex)
 
-const { data, error, componentState } = useContractQuery({
+const { data, error, componentState, fetching } = useContractQuery({
 	contractAddressIndex,
 	contractAddressSubIndex,
 	eventsVariables: {

--- a/frontend/src/components/Contracts/ContractDetailsContent.vue
+++ b/frontend/src/components/Contracts/ContractDetailsContent.vue
@@ -50,6 +50,7 @@
 						:total-count="contract.contractEvents.totalCount"
 						:page-offset-info="paginationEvents"
 						:page-dropdown-info="pageDropdownEvents"
+						:fetching="fetching"
 					>
 						<ContractDetailsEvents
 							:contract-events="contract.contractEvents!.items"
@@ -65,6 +66,7 @@
 						:total-count="contract.contractRejectEvents.totalCount"
 						:page-offset-info="paginationRejectEvents"
 						:page-dropdown-info="pageDropdownRejectedEvents"
+						:fetching="fetching"
 					>
 						<ContractDetailsRejectEvents
 							:contract-reject-events="contract.contractRejectEvents!.items"
@@ -104,6 +106,7 @@ type Props = {
 	paginationRejectEvents: PaginationOffsetInfo
 	pageDropdownEvents: PageDropdownInfo
 	pageDropdownRejectedEvents: PageDropdownInfo
+	fetching: boolean
 }
 const props = defineProps<Props>()
 

--- a/frontend/src/components/Details/DetailsTable.vue
+++ b/frontend/src/components/Details/DetailsTable.vue
@@ -3,7 +3,13 @@
 		<PageDropdown 
 			v-if="MIN_PAGE_SIZE < totalCount"
 			:page-dropdown-info="props.pageDropdownInfo"/>
-		<Table :class="['contractDetail', {'no-last': totalCount <= props.pageOffsetInfo.take.value}]">
+		<Table 
+			:class="[
+				'contract-detail',
+				 {
+					'no-last': totalCount <= props.pageOffsetInfo.take.value,
+					'fetching': fetching
+				}]">
 			<slot />
 		</Table>
 		<PaginationOffset 
@@ -23,24 +29,29 @@ type Props = {
 	totalCount: number
 	pageOffsetInfo: PaginationOffsetInfo
 	pageDropdownInfo: PageDropdownInfo
+	fetching: boolean
 }
 
 const props = defineProps<Props>()
 
 </script>
 <style>
-.contractDetail table td {
+.contract-detail table td {
 	padding: 30px 20px 21px;
 	@media screen and (max-width: 640px) {
 		padding: 10px 20px;
 	}
 }
-.contractDetail table tr {
+.contract-detail table tr {
 	border-bottom: 2px solid;
 	border-bottom-color: var(--color-thead-bg);
 }
 
-.contractDetail table thead tr {
+.fetching table tr {
+	opacity: 0.4;
+}
+
+.contract-detail table thead tr {
 	border-bottom: none;
 }
 

--- a/frontend/src/components/Module/ModuleDetailsContainer.vue
+++ b/frontend/src/components/Module/ModuleDetailsContainer.vue
@@ -12,6 +12,7 @@
 		:page-dropdown-events="pageDropdownEvents"
 		:page-dropdown-rejected-events="pageDropdownRejectedEvents"
 		:page-dropdown-linked-contracts="pageDropdownLinkedContracts"
+		:fetching="fetching"
 	/>
 </template>
 
@@ -37,7 +38,7 @@ const pageOffsetInfoLinkedContracts = usePaginationOffset(pageDropdownLinkedCont
 const props = defineProps<Props>()
 const moduleReference = ref(props.moduleReference)
 
-const { data, error, componentState } = useModuleReferenceEventQuery({
+const { data, error, componentState, fetching } = useModuleReferenceEventQuery({
 	moduleReference,
 	eventsVariables: {
 		skip: pageOffsetInfoLinkingEvents.skip,

--- a/frontend/src/components/Module/ModuleDetailsContent.vue
+++ b/frontend/src/components/Module/ModuleDetailsContent.vue
@@ -35,6 +35,7 @@
 						:total-count="moduleReferenceEvent.linkedContracts.totalCount"
 						:page-offset-info="paginationLinkedContracts"
 						:page-dropdown-info="pageDropdownLinkedContracts"
+						:fetching="fetching"
 					>
 						<ModuleDetailsLinkedContracts
 							:linked-contracts="moduleReferenceEvent.linkedContracts!.items"
@@ -49,6 +50,7 @@
 						:total-count="moduleReferenceEvent.moduleReferenceContractLinkEvents.totalCount"
 						:page-offset-info="paginationLinkingEvents"
 						:page-dropdown-info="pageDropdownEvents"
+						:fetching="fetching"
 					>
 						<ModuleDetailsContractLinkEvents
 							:link-events="moduleReferenceEvent.moduleReferenceContractLinkEvents!.items"
@@ -63,6 +65,7 @@
 						:total-count="moduleReferenceEvent.moduleReferenceRejectEvents.totalCount"
 						:page-offset-info="paginationRejectEvents"
 						:page-dropdown-info="pageDropdownRejectedEvents"
+						:fetching="fetching"
 					>
 						<ModuleDetailsRejectEvents
 							:module-reject-events="moduleReferenceEvent.moduleReferenceRejectEvents!.items"
@@ -98,7 +101,8 @@ type Props = {
 	paginationLinkedContracts: PaginationOffsetInfo
 	pageDropdownEvents: PageDropdownInfo
 	pageDropdownRejectedEvents: PageDropdownInfo
-	pageDropdownLinkedContracts: PageDropdownInfo		
+	pageDropdownLinkedContracts: PageDropdownInfo	
+	fetching: boolean	
 }
 const props = defineProps<Props>()
 const tabList = computed(() => {

--- a/frontend/src/queries/useContractQuery.ts
+++ b/frontend/src/queries/useContractQuery.ts
@@ -200,7 +200,8 @@ export const useContractQuery = ({
 }: QueryParams): {
 	data: Ref<ContractQueryResponse | undefined>
 	error: Ref<CombinedError | undefined>
-	componentState: Ref<ComponentState>
+	componentState: Ref<ComponentState>,
+	fetching: Ref<boolean>
 } => {
 	const { data, fetching, error } = useQuery<ContractQueryResponse>({
 		query: ContractQuery,
@@ -221,5 +222,5 @@ export const useContractQuery = ({
 		data,
 	})
 
-	return { data, error, componentState }
+	return { data, error, componentState, fetching }
 }

--- a/frontend/src/queries/useModuleQuery.ts
+++ b/frontend/src/queries/useModuleQuery.ts
@@ -98,7 +98,8 @@ export const useModuleReferenceEventQuery = ({
 }: QueryParams): {
 	data: Ref<ModuleReferenceEventResponse | undefined>
 	error: Ref<CombinedError | undefined>
-	componentState: Ref<ComponentState | undefined>
+	componentState: Ref<ComponentState | undefined>,
+	fetching: Ref<boolean>
 } => {
 	const { data, fetching, error } = useQuery<ModuleReferenceEventResponse>({
 		query: ContractQuery,
@@ -120,5 +121,5 @@ export const useModuleReferenceEventQuery = ({
 		data,
 	})
 
-	return { data, error, componentState }
+	return { data, error, componentState, fetching }
 }


### PR DESCRIPTION
## Purpose

When paginate through pages in tables there are some load time in contracts with a lot of events. Currently it isn’t easy for the user to see a load is happening which is why blur is added.

## Changes

Blur details tails when using pagination and data is loading.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.