### PR TITLE
Refactor rust-bindings to reduce glue code

### DIFF
--- a/backend/rust-bindings/src/lib.rs
+++ b/backend/rust-bindings/src/lib.rs
@@ -25,8 +25,8 @@ impl FFIOption {
     }
 }
 
-fn assign_result<T: ToString>(target: *mut *mut c_char, src: Result<T>) -> bool {
-    match src {
+fn assign_result<F: FnOnce() -> Result<T>, T: ToString>(target: *mut *mut c_char, f: F) -> bool {
+    match f() {
         Ok(output) => {
             unsafe {
                 *target = CString::new(output.to_string()).unwrap().into_raw()
@@ -61,10 +61,10 @@ pub extern "C" fn schema_display(
     schema_version: FFIOption,
     result: *mut *mut c_char) -> bool {
 
-    assign_result(result, (|| {
+    assign_result(result, || {
         let schema_hex = get_str_from_pointer(schema)?;
         schema_display_aux(schema_hex, schema_version.into_option())
-    })())
+    })
 }
 
 #[no_mangle]
@@ -76,14 +76,14 @@ pub extern "C" fn get_receive_contract_parameter(
     value: *const c_char,
     result: *mut *mut c_char) -> bool {
 
-    assign_result(result, (|| {
+    assign_result(result, || {
         let schema_hex = get_str_from_pointer(schema)?;
         let contract_name_str = get_str_from_pointer(contract_name)?;
         let entrypoint_str = get_str_from_pointer(entrypoint)?;
         let value_hex = get_str_from_pointer(value)?;
 
         get_receive_contract_parameter_aux(schema_hex, schema_version.into_option(), &contract_name_str, &entrypoint_str, value_hex)
-    })())
+    })
 }
 
 /// Get contract event in a human interpretable form.
@@ -107,13 +107,13 @@ pub extern "C" fn get_event_contract(
     value: *const c_char,
     result: *mut *mut c_char) -> bool {
 
-    assign_result(result, (|| {
+    assign_result(result, || {
         let schema_hex = get_str_from_pointer(schema)?;
         let contract_name_str = get_str_from_pointer(contract_name)?;
         let value_hex = get_str_from_pointer(value)?;
 
         get_event_contract_aux(schema_hex, schema_version.into_option(), &contract_name_str, value_hex)
-    })())
+    })
 }
 
 /// Get contract receive parameters in a human interpretable form.

--- a/backend/rust-bindings/src/lib.rs
+++ b/backend/rust-bindings/src/lib.rs
@@ -28,16 +28,31 @@ impl FFIOption {
     }
 }
 
-fn assign_result<F: FnOnce() -> Result<T>, T: ToString>(target: *mut *mut c_char, f: F) -> bool {
+/// Compute result using the provided callback f, convert it into a C string and assign it to the provided target.
+///
+/// # Arguments
+///
+/// * 'target' - Pointer to a C String, which will be assigned the result / error message of f.
+/// * 'f' - callback function, which result should be assigned to target.
+///
+/// # Returns
+///
+/// A boolean, that indicates whether the computation was successful or not.
+///
+/// # Safety
+///
+/// This function is marked as unsafe because it deferences a raw pointer.
+unsafe fn assign_result<F: FnOnce() -> Result<T>, T: ToString>(
+    target: *mut *mut c_char,
+    f: F,
+) -> bool {
     match f() {
         Ok(output) => {
-            unsafe { *target = CString::new(output.to_string()).unwrap().into_raw() }
-
+            *target = CString::new(output.to_string()).unwrap().into_raw();
             true
         }
         Err(e) => {
-            unsafe { *target = CString::new(e.to_string()).unwrap().into_raw() }
-
+            *target = CString::new(e.to_string()).unwrap().into_raw();
             false
         }
     }


### PR DESCRIPTION
## Purpose

Refactor of interop glue code. (Easier to show it)

I'm not sure it needs to use a closure, but it was mainly to isolate the handling of the results, and writing the to result variable.