### PR TITLE
Fix date time rendering

### DIFF
--- a/frontend/src/components/Details/DateTimeWithLineBreak.vue
+++ b/frontend/src/components/Details/DateTimeWithLineBreak.vue
@@ -4,7 +4,6 @@
 </template>
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
-import { formatTimestamp } from '../../utils/format'
 type Props = {
 	dateTime: string
 }
@@ -15,8 +14,15 @@ const timePartRef = ref('')
 watch(
 	props,
 	newProps => {
-		const formattedDate = formatTimestamp(newProps.dateTime)
-		const [datePart, timePart] = formattedDate.split(',')
+		const datePart = new Intl.DateTimeFormat('default', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+		}).format(new Date(newProps.dateTime))
+		const timePart = new Intl.DateTimeFormat('default', {
+			hour: 'numeric',
+			minute: 'numeric',
+		}).format(new Date(newProps.dateTime))
 		datePartRef.value = datePart
 		timePartRef.value = timePart
 	},


### PR DESCRIPTION
## Purpose

Correct date and time rendering to display them on multiple lines. The previous implementation did not consider that date and time formats vary with different internationalizations.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.