### PR TITLE
Adding payday commissions

### DIFF
--- a/backend/Application/Api/GraphQL/Bakers/BakerPool.cs
+++ b/backend/Application/Api/GraphQL/Bakers/BakerPool.cs
@@ -1,6 +1,7 @@
 ﻿using Application.Api.GraphQL.Accounts;
 using Application.Api.GraphQL.EfCore;
 using Application.Api.GraphQL.Payday;
+using Concordium.Sdk.Types;
 using HotChocolate;
 using HotChocolate.Data;
 using HotChocolate.Types;
@@ -127,5 +128,26 @@ public class BakerPool
             },
             PaydayStatus = null,
         };
+    }
+    
+    /// <summary>
+    /// Apply payday updates to pool.
+    /// </summary>
+    /// <param name="source">Current payday status fetched from node.</param>
+    /// <param name="rates">Current payday commissions fetched from node.</param>
+    internal void ApplyPaydayStatus(CurrentPaydayBakerPoolStatus? source, Concordium.Sdk.Types.CommissionRates rates)
+    {
+        if (source != null && PaydayStatus != null)
+        {
+            PaydayStatus.Update(source, rates);
+        } 
+        else if (source != null)
+        {
+            PaydayStatus = new CurrentPaydayStatus(source, rates);
+        }
+        else
+        {
+            PaydayStatus = null;
+        }
     }
 }

--- a/backend/Application/Api/GraphQL/Bakers/BakerPool.cs
+++ b/backend/Application/Api/GraphQL/Bakers/BakerPool.cs
@@ -1,5 +1,6 @@
 ﻿using Application.Api.GraphQL.Accounts;
 using Application.Api.GraphQL.EfCore;
+using Application.Api.GraphQL.Payday;
 using HotChocolate;
 using HotChocolate.Data;
 using HotChocolate.Types;
@@ -17,6 +18,12 @@ public class BakerPool
     public ActiveBakerState Owner { get; private set; } = null!;
 
     public BakerPoolOpenStatus OpenStatus { get; set; }
+    /// <summary>
+    /// This holds the latest update to commission rates and are not necessarily those which are used at the
+    /// current payday.
+    /// The commissions rates which are in effect the current payday are at
+    /// <see cref="CurrentPaydayStatus.CommissionRates"/>.
+    /// </summary>
     public CommissionRates CommissionRates { get; init; }
     public string MetadataUrl { get; set; }
 
@@ -39,12 +46,17 @@ public class BakerPool
     {
         return Owner.Owner.Statistics?.PoolTotalStakePercentage;
     }
-
+    
     public decimal? GetLotteryPower()
     {
         return PaydayStatus?.LotteryPower;
     }
-    
+
+    /// <summary>
+    /// Returns the active commissions rate in the current payday.  
+    /// </summary>
+    public CommissionRates? GetPaydayCommissionRates() => PaydayStatus?.CommissionRates;
+
     public PoolApy GetApy(ApyPeriod period)
     {
         return period switch

--- a/backend/Application/Api/GraphQL/Bakers/BakerPool.cs
+++ b/backend/Application/Api/GraphQL/Bakers/BakerPool.cs
@@ -101,6 +101,18 @@ public class BakerPool
             .OrderByDescending(x => x.Index);
     }
     
+    /// <summary>
+    /// Creates a new default pool.
+    ///
+    /// <see cref="CommissionRates"/> will be overwritten in later events from same transaction. When a validator is
+    /// created multiple events are generated, where <see cref="Concordium.Sdk.Types.BakerAddedEvent"/> is the first.
+    ///
+    /// <see cref="PaydayStatus"/> is set to null since the validator will first be active on the next payday. On payday
+    /// blocks <see cref="PaydayStatus"/> is overwritten with values fetched from the chain.
+    /// <remarks>
+    /// <see href="https://learn.microsoft.com/en-us/dotnet/framework/interop/blittable-and-non-blittable-types">Events when adding a validator.</see>
+    /// </remarks> 
+    /// </summary>
     internal static BakerPool CreateDefaultBakerPool()
     {
         return new BakerPool

--- a/backend/Application/Api/GraphQL/Bakers/BakerPool.cs
+++ b/backend/Application/Api/GraphQL/Bakers/BakerPool.cs
@@ -110,7 +110,7 @@ public class BakerPool
     /// <see cref="PaydayStatus"/> is set to null since the validator will first be active on the next payday. On payday
     /// blocks <see cref="PaydayStatus"/> is overwritten with values fetched from the chain.
     /// <remarks>
-    /// <see href="https://learn.microsoft.com/en-us/dotnet/framework/interop/blittable-and-non-blittable-types">Events when adding a validator.</see>
+    /// <see href="https://testnet.ccdscan.io/staking?dcount=1&amp;dentity=transaction&amp;dhash=c7357fe0d11ec8e6c6a7f410971624845cd19c2034cd4bd44df7cfd759344026">Events when adding a validator.</see>
     /// </remarks> 
     /// </summary>
     internal static BakerPool CreateDefaultBakerPool()

--- a/backend/Application/Api/GraphQL/Bakers/CommissionRates.cs
+++ b/backend/Application/Api/GraphQL/Bakers/CommissionRates.cs
@@ -5,4 +5,12 @@ public class CommissionRates
     public decimal TransactionCommission { get; set; }
     public decimal FinalizationCommission { get; set; }
     public decimal BakingCommission { get; set; }
+
+    internal static CommissionRates From(Concordium.Sdk.Types.CommissionRates rates) =>
+        new()
+        {
+            TransactionCommission = rates.TransactionCommission.AsDecimal(),
+            BakingCommission = rates.BakingCommission.AsDecimal(),
+            FinalizationCommission = rates.FinalizationCommission.AsDecimal()
+        };
 }

--- a/backend/Application/Api/GraphQL/Bakers/CommissionRates.cs
+++ b/backend/Application/Api/GraphQL/Bakers/CommissionRates.cs
@@ -2,9 +2,9 @@
 
 public class CommissionRates
 {
-    public decimal TransactionCommission { get; set; }
-    public decimal FinalizationCommission { get; set; }
-    public decimal BakingCommission { get; set; }
+    public decimal TransactionCommission { get; internal set; }
+    public decimal FinalizationCommission { get; internal set; }
+    public decimal BakingCommission { get; internal set; }
 
     internal static CommissionRates From(Concordium.Sdk.Types.CommissionRates rates) =>
         new()
@@ -13,4 +13,11 @@ public class CommissionRates
             BakingCommission = rates.BakingCommission.AsDecimal(),
             FinalizationCommission = rates.FinalizationCommission.AsDecimal()
         };
+    
+    internal void Update(Concordium.Sdk.Types.CommissionRates rates)
+    {
+        TransactionCommission = rates.TransactionCommission.AsDecimal();
+        BakingCommission = rates.BakingCommission.AsDecimal();
+        FinalizationCommission = rates.FinalizationCommission.AsDecimal();
+    }
 }

--- a/backend/Application/Api/GraphQL/Bakers/CurrentPaydayStatus.cs
+++ b/backend/Application/Api/GraphQL/Bakers/CurrentPaydayStatus.cs
@@ -5,16 +5,16 @@ namespace Application.Api.GraphQL.Bakers;
 /// <summary>
 /// Holds current payday values for a given baker.
 /// </summary>
-public sealed record CurrentPaydayStatus
+public sealed class CurrentPaydayStatus
 {
-    public ulong BakerStake { get; private init; }
-    public ulong DelegatedStake { get; private init; }
-    public ulong EffectiveStake { get; private init; }
-    public decimal LotteryPower { get; private init; }
+    public ulong BakerStake { get; private set; }
+    public ulong DelegatedStake { get; private set; }
+    public ulong EffectiveStake { get; private set; }
+    public decimal LotteryPower { get; private set; }
     /// <summary>
     /// Holds the current payday commission rates.
     /// </summary>
-    public CommissionRates CommissionRates { get; private init; }
+    public CommissionRates CommissionRates { get; }
 
     /// <summary>
     /// Needed for EF
@@ -35,6 +35,8 @@ public sealed record CurrentPaydayStatus
 
     /// <summary>
     /// Creates a <see cref="CurrentPaydayStatus"/> from data fetched by the node.
+    ///
+    /// This will be invoked on the first block of a payday if a validator changes from inactive to active.
     /// </summary>
     internal CurrentPaydayStatus(CurrentPaydayBakerPoolStatus source, Concordium.Sdk.Types.CommissionRates rates)
     {
@@ -43,5 +45,21 @@ public sealed record CurrentPaydayStatus
         EffectiveStake = source.EffectiveStake.Value;
         LotteryPower = source.LotteryPower;
         CommissionRates = CommissionRates.From(rates);
+    }
+    
+    /// <summary>
+    /// Updates the current payday instance with data fetched from node.
+    ///
+    /// This will be updated once each payday on the first block of the payday.
+    /// </summary>
+    /// <param name="source">Current payday status fetched from node.</param>
+    /// <param name="rates">Current payday commissions fetched from node.</param>
+    internal void Update(CurrentPaydayBakerPoolStatus source, Concordium.Sdk.Types.CommissionRates rates)
+    {
+        BakerStake = source.BakerEquityCapital.Value;
+        DelegatedStake = source.DelegatedCapital.Value;
+        EffectiveStake = source.EffectiveStake.Value;
+        LotteryPower = source.LotteryPower;
+        CommissionRates.Update(rates);
     }
 }

--- a/backend/Application/Api/GraphQL/Bakers/CurrentPaydayStatus.cs
+++ b/backend/Application/Api/GraphQL/Bakers/CurrentPaydayStatus.cs
@@ -3,7 +3,7 @@
 namespace Application.Api.GraphQL.Bakers;
 
 /// <summary>
-/// Holds current payday values for an given baker.
+/// Holds current payday values for a given baker.
 /// </summary>
 public sealed record CurrentPaydayStatus
 {

--- a/backend/Application/Api/GraphQL/Bakers/CurrentPaydayStatus.cs
+++ b/backend/Application/Api/GraphQL/Bakers/CurrentPaydayStatus.cs
@@ -3,7 +3,7 @@
 namespace Application.Api.GraphQL.Bakers;
 
 /// <summary>
-/// Holds current payday active values for an given baker.
+/// Holds current payday values for an given baker.
 /// </summary>
 public sealed record CurrentPaydayStatus
 {
@@ -12,7 +12,7 @@ public sealed record CurrentPaydayStatus
     public ulong EffectiveStake { get; private init; }
     public decimal LotteryPower { get; private init; }
     /// <summary>
-    /// Holds the current payday active commission rates.
+    /// Holds the current payday commission rates.
     /// </summary>
     public CommissionRates CommissionRates { get; private init; }
 
@@ -22,7 +22,7 @@ public sealed record CurrentPaydayStatus
     private CurrentPaydayStatus() {}
     
     /// <summary>
-    /// Create an initial payday status for account bakers given a genesis block.
+    /// Create an initial payday status from a genesis block.
     /// </summary>
     internal CurrentPaydayStatus(CcdAmount stakedAmount, Concordium.Sdk.Types.CommissionRates commissionRates)
     {
@@ -34,7 +34,7 @@ public sealed record CurrentPaydayStatus
     }
 
     /// <summary>
-    /// Creates an <see cref="CurrentPaydayStatus"/> from data fetched by the node.
+    /// Creates a <see cref="CurrentPaydayStatus"/> from data fetched by the node.
     /// </summary>
     internal CurrentPaydayStatus(CurrentPaydayBakerPoolStatus source, Concordium.Sdk.Types.CommissionRates rates)
     {

--- a/backend/Application/Api/GraphQL/Bakers/CurrentPaydayStatus.cs
+++ b/backend/Application/Api/GraphQL/Bakers/CurrentPaydayStatus.cs
@@ -1,9 +1,47 @@
-﻿namespace Application.Api.GraphQL.Bakers;
+﻿using Concordium.Sdk.Types;
 
-public class CurrentPaydayStatus
+namespace Application.Api.GraphQL.Bakers;
+
+/// <summary>
+/// Holds current payday active values for an given baker.
+/// </summary>
+public sealed record CurrentPaydayStatus
 {
-    public ulong BakerStake { get; set; }
-    public ulong DelegatedStake { get; set; }
-    public ulong EffectiveStake { get; set; }
-    public decimal LotteryPower { get; set; }
+    public ulong BakerStake { get; private init; }
+    public ulong DelegatedStake { get; private init; }
+    public ulong EffectiveStake { get; private init; }
+    public decimal LotteryPower { get; private init; }
+    /// <summary>
+    /// Holds the current payday active commission rates.
+    /// </summary>
+    public CommissionRates CommissionRates { get; private init; }
+
+    /// <summary>
+    /// Needed for EF
+    /// </summary>
+    private CurrentPaydayStatus() {}
+    
+    /// <summary>
+    /// Create an initial payday status for account bakers given a genesis block.
+    /// </summary>
+    internal CurrentPaydayStatus(CcdAmount stakedAmount, Concordium.Sdk.Types.CommissionRates commissionRates)
+    {
+        BakerStake = stakedAmount.Value;
+        DelegatedStake = 0;
+        EffectiveStake = 0;
+        LotteryPower = 0;
+        CommissionRates = CommissionRates.From(commissionRates);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="CurrentPaydayStatus"/> from data fetched by the node.
+    /// </summary>
+    internal CurrentPaydayStatus(CurrentPaydayBakerPoolStatus source, Concordium.Sdk.Types.CommissionRates rates)
+    {
+        BakerStake = source.BakerEquityCapital.Value;
+        DelegatedStake = source.DelegatedCapital.Value;
+        EffectiveStake = source.EffectiveStake.Value;
+        LotteryPower = source.LotteryPower;
+        CommissionRates = CommissionRates.From(rates);
+    }
 }

--- a/backend/Application/Api/GraphQL/EfCore/EntityTypeConfigurations/BakerConfiguration.cs
+++ b/backend/Application/Api/GraphQL/EfCore/EntityTypeConfigurations/BakerConfiguration.cs
@@ -44,6 +44,12 @@ public class BakerConfiguration :
                     paydayStatusBuilder.Property(x => x.DelegatedStake).HasColumnName("active_pool_payday_status_delegated_stake");
                     paydayStatusBuilder.Property(x => x.EffectiveStake).HasColumnName("active_pool_payday_status_effective_stake");
                     paydayStatusBuilder.Property(x => x.LotteryPower).HasColumnName("active_pool_payday_status_lottery_power");
+                    paydayStatusBuilder.OwnsOne(x => x.CommissionRates, commissionRatesBuilder =>
+                    {
+                        commissionRatesBuilder.Property(x => x.TransactionCommission).HasColumnName("active_pool_payday_status_transaction_commission");
+                        commissionRatesBuilder.Property(x => x.FinalizationCommission).HasColumnName("active_pool_payday_status_finalization_commission");
+                        commissionRatesBuilder.Property(x => x.BakingCommission).HasColumnName("active_pool_payday_status_baking_commission");
+                    });
                 });
             });
 

--- a/backend/Application/Api/GraphQL/Import/BakerImportHandler.cs
+++ b/backend/Application/Api/GraphQL/Import/BakerImportHandler.cs
@@ -122,12 +122,12 @@ public class BakerImportHandler
     }
 
     /// <summary>
-    /// Map a <see cref="BakerPool"/> given a genesis block.
+    /// Map a <see cref="BakerPool"/> from a genesis block.
     ///
     /// Should only by called if <see cref="accountBaker"/> is an active baker. 
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown if <see cref="AccountBaker.BakerPoolInfo"/> is null since
-    /// the <see cref="accountBaker"/> is expected to be a active baker..</exception>
+    /// the <see cref="accountBaker"/> is expected to be a active baker.</exception>
     private static BakerPool MapBakerPool(AccountBaker accountBaker)
     {
         var poolInfo = accountBaker.BakerPoolInfo;
@@ -177,10 +177,9 @@ public class BakerImportHandler
     }
 
     /// <summary>
-    /// Given <see cref="BakerPoolStatus"/> fetch from the node 
+    /// Updates <see cref="BakerPool.PaydayStatus"/> from <see cref="BakerPoolStatus"/> fetched from the node on all
+    /// validators.
     /// </summary>
-    /// <param name="payload"></param>
-    /// <exception cref="InvalidOperationException"></exception>
     private async Task UpdateCurrentPaydayStatusOnAllBakers(BlockDataPayload payload)
     {
         await _writer.CreateTemporaryBakerPoolPaydayStatuses();

--- a/backend/Application/Api/GraphQL/Import/BakerImportHandler.cs
+++ b/backend/Application/Api/GraphQL/Import/BakerImportHandler.cs
@@ -170,7 +170,7 @@ public class BakerImportHandler
         // This should happen after the bakers from current block has been added to the database
         if (isFirstBlockAfterPayday)
         {
-            await UpdateCurrentPaydayStatusOnAllBakers(payload);
+            await UpdateCurrentPaydayStatusOnAllBakers(payload.ReadAllBakerPoolStatuses);
         }
 
         await _writer.UpdateStakeIfBakerActiveRestakingEarnings(rewardsSummary.AggregatedAccountRewards);
@@ -180,11 +180,11 @@ public class BakerImportHandler
     /// Updates <see cref="BakerPool.PaydayStatus"/> from <see cref="BakerPoolStatus"/> fetched from the node on all
     /// validators.
     /// </summary>
-    private async Task UpdateCurrentPaydayStatusOnAllBakers(BlockDataPayload payload)
+    internal async Task UpdateCurrentPaydayStatusOnAllBakers(Func<Task<BakerPoolStatus[]>> bakerPoolStatuses)
     {
         await _writer.CreateTemporaryBakerPoolPaydayStatuses();
         
-        var poolStatuses = await payload.ReadAllBakerPoolStatuses();
+        var poolStatuses = await bakerPoolStatuses();
         foreach (var poolStatus in poolStatuses)
         {
             await _writer.UpdateBaker(poolStatus, src => src.BakerId.Id.Index, (src, dst) =>

--- a/backend/Application/Api/GraphQL/Import/BakerImportHandler.cs
+++ b/backend/Application/Api/GraphQL/Import/BakerImportHandler.cs
@@ -190,16 +190,12 @@ public class BakerImportHandler
             await _writer.UpdateBaker(poolStatus, src => src.BakerId.Id.Index, (src, dst) =>
             {
                 var pool = dst.ActiveState!.Pool ?? throw new InvalidOperationException("Did not expect this bakers pool property to be null");
-                
-                ApplyPaydayStatus(pool, src.CurrentPaydayStatus, src.PoolInfo.CommissionRates);
+                pool.ApplyPaydayStatus(src.CurrentPaydayStatus, src.PoolInfo.CommissionRates);
             });
         }
     }
 
-    private static void ApplyPaydayStatus(BakerPool pool, CurrentPaydayBakerPoolStatus? source, Concordium.Sdk.Types.CommissionRates rates)
-    {
-        pool.PaydayStatus = source != null ? new CurrentPaydayStatus(source, rates) : null;
-    }
+    
 
     private async Task MaybeMigrateToBakerPools(BlockDataPayload payload, ImportState importState)
     {
@@ -233,7 +229,7 @@ public class BakerImportHandler
                     DelegatedStakeCap = source.DelegatedCapitalCap.Value,
                     TotalStake = source.BakerEquityCapital.Value + source.DelegatedCapital.Value
                 };
-                ApplyPaydayStatus(pool, source.CurrentPaydayStatus, source.PoolInfo.CommissionRates);
+                pool.ApplyPaydayStatus(source.CurrentPaydayStatus, source.PoolInfo.CommissionRates);
                 
                 baker.ActiveState!.Pool = pool;
             },

--- a/backend/Application/Api/GraphQL/Import/MetricsWriter.cs
+++ b/backend/Application/Api/GraphQL/Import/MetricsWriter.cs
@@ -202,6 +202,9 @@ public class MetricsWriter
         conn.Close();
     }
 
+    /// <summary>
+    /// Adds payday events for each bakers, which contains baker- fees, rewards and calculated metrics. 
+    /// </summary>
     public void AddPaydayPoolRewardMetrics(Block block, SpecialEvent[] specialEvents, RewardsSummary rewardsSummary,
         PaydaySummary? paydaySummary, PaydayPoolStakeSnapshot? paydayPoolStakeSnapshot,
         PaydayPassiveDelegationStakeSnapshot? paydayPassiveDelegationStakeSnapshot)

--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <Version>1.7.9</Version>
+        <Version>1.8.0</Version>
         <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
         <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
         <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased changes
 
+## 1.8.0
+- Added current payday commissions for validators such that pending commission changes can be identified.
+
 ## 1.7.9
 - Added functionality to sort validators based on their block commissions.
 

--- a/backend/DatabaseScripts/SqlScripts/0047_alter_table_graphql_bakers_add_payday_commissions.sql
+++ b/backend/DatabaseScripts/SqlScripts/0047_alter_table_graphql_bakers_add_payday_commissions.sql
@@ -1,10 +1,19 @@
+/*
+Add columns for current payday commissions.
+
+Values are initialized to those of the latest change to commissions received. They may not be correct since changes
+on the payday of the migration will be wrongly used.
+
+The values will be reset on the next payday block, hence the values will only be wrong until the next payday block
+is received.
+*/
 ALTER TABLE graphql_bakers
 ADD COLUMN active_pool_payday_status_transaction_commission     numeric null,
 ADD COLUMN active_pool_payday_status_finalization_commission    numeric null,
 ADD COLUMN active_pool_payday_status_baking_commission          numeric null;
-    
+
 UPDATE graphql_bakers
 SET 
-    active_pool_payday_status_transaction_commission = (SELECT active_pool_transaction_commission from graphql_bakers),
-    active_pool_payday_status_finalization_commission = (SELECT active_pool_finalization_commission from graphql_bakers),
-    active_pool_payday_status_baking_commission = (SELECT active_pool_baking_commission from graphql_bakers);
+    active_pool_payday_status_transaction_commission = active_pool_transaction_commission,
+    active_pool_payday_status_finalization_commission = active_pool_finalization_commission,
+    active_pool_payday_status_baking_commission = active_pool_baking_commission;

--- a/backend/DatabaseScripts/SqlScripts/0047_alter_table_graphql_bakers_add_payday_commissions.sql
+++ b/backend/DatabaseScripts/SqlScripts/0047_alter_table_graphql_bakers_add_payday_commissions.sql
@@ -1,0 +1,10 @@
+ALTER TABLE graphql_bakers
+ADD COLUMN active_pool_payday_status_transaction_commission     numeric null,
+ADD COLUMN active_pool_payday_status_finalization_commission    numeric null,
+ADD COLUMN active_pool_payday_status_baking_commission          numeric null;
+    
+UPDATE graphql_bakers
+SET 
+    active_pool_payday_status_transaction_commission = (SELECT active_pool_transaction_commission from graphql_bakers),
+    active_pool_payday_status_finalization_commission = (SELECT active_pool_finalization_commission from graphql_bakers),
+    active_pool_payday_status_baking_commission = (SELECT active_pool_baking_commission from graphql_bakers);

--- a/backend/Tests/Api/GraphQL/__snapshots__/committed-schema.verified.graphql
+++ b/backend/Tests/Api/GraphQL/__snapshots__/committed-schema.verified.graphql
@@ -358,6 +358,7 @@ type BakerPool {
   "Total stake of the baker pool as a percentage of all CCDs in existence. Value may be null for brand new bakers where statistics have not been calculated yet. This should be rare and only a temporary condition."
   totalStakePercentage: Decimal
   lotteryPower: Decimal
+  paydayCommissionRates: CommissionRates
   apy(period: ApyPeriod!): PoolApy!
   "Ranking of the baker pool by total staked amount. Value may be null for brand new bakers where statistics have not been calculated yet. This should be rare and only a temporary condition."
   rankingByTotalStake: Ranking


### PR DESCRIPTION
## Purpose

Add columns for payday commissions on baker. These are only populated from payday blocks and are constant throughout the payday.

The current commissions value on the baker changes instantly on all baker commission configuration and possible chain parameters. Hence these doesn’t give the actual current payday commission but instead show the most recent commission change.

By adding columns for payday commissions one can always see if there are pending changes to commissions, by comparing the current payday commissions and the those from their latest change.

https://concordium.atlassian.net/browse/CBW-1484
https://concordium.atlassian.net/browse/CBW-1485

## Changes
* Add columns to table `graphql_baker` with current payday commissions
* Populated current payday commissions on payday blocks

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.