### PR TITLE
Add node query to account cache lookup

### DIFF
--- a/backend/Application/Api/GraphQL/Import/AccountLookup.cs
+++ b/backend/Application/Api/GraphQL/Import/AccountLookup.cs
@@ -1,6 +1,10 @@
-﻿using Application.Common.Diagnostics;
+﻿using System.Threading.Tasks;
+using Application.Common.Diagnostics;
 using Application.Database;
+using Application.Import.ConcordiumNode;
+using Concordium.Sdk.Types;
 using Dapper;
+using Grpc.Core;
 using Microsoft.Extensions.Caching.Memory;
 using Npgsql;
 
@@ -17,16 +21,38 @@ public class AccountLookup : IAccountLookup
     private readonly IMemoryCache _cache;
     private readonly DatabaseSettings _dbSettings;
     private readonly IMetrics _metrics;
+    private readonly IConcordiumNodeClient _client;
     private readonly ILogger _logger;
+    private readonly IBlockHashInput _blockHashInput = new LastFinal();
 
-    public AccountLookup(IMemoryCache cache, DatabaseSettings dbSettings, IMetrics metrics)
+    public AccountLookup(
+        IMemoryCache cache,
+        DatabaseSettings dbSettings,
+        IMetrics metrics,
+        IConcordiumNodeClient client)
     {
         _cache = cache;
         _dbSettings = dbSettings;
         _metrics = metrics;
+        _client = client;
         _logger = Log.ForContext(GetType());
     }
 
+    /// <summary>
+    /// The method first attempts to get account index using base address from cache,
+    ///
+    /// If not present the database i queried and the cache is updated for addresses present in the database.
+    ///
+    /// If the base address isn't present in the database the node is called and the cache is updated for addresses
+    /// found on the node. This should almost always return an account index and only in cases where different nodes
+    /// are queried would there be a small change of not fully synchronization between the nodes.
+    /// Calls to the node are synchronized from async to sync using <see cref="Task.GetAwaiter"/>. 
+    /// </summary>
+    /// <param name="accountBaseAddresses"></param>
+    /// <returns>
+    /// Account ids from base addresses. Null is returned only if not present in cache, database and node.
+    /// </returns>
+    /// <exception cref="RpcException">Rethrow if error from node isn't <see cref="StatusCode.NotFound"/></exception>
     public IDictionary<string, long?> GetAccountIdsFromBaseAddresses(IEnumerable<string> accountBaseAddresses)
     {
         using var counter = _metrics.MeasureDuration(nameof(AccountLookup), nameof(GetAccountIdsFromBaseAddresses));
@@ -52,10 +78,26 @@ public class AccountLookup : IAccountLookup
                 AddToCache(account.Key, account.Result);
                 result.Add(account);
             }
-
-            var nonExistingAccounts = notCached.Except(result.Select(x => x.Key));
-            foreach (var nonExistingAccount in nonExistingAccounts)
+        }
+        
+        var nonExistingAccounts = notCached.Except(result.Select(x => x.Key));
+        
+        foreach (var nonExistingAccount in nonExistingAccounts)
+        {
+            try
             {
+                var response = _client.GetAccountInfoAsync(AccountAddress.From(nonExistingAccount), _blockHashInput).Result;
+                var lookupResult = new LookupResult(nonExistingAccount, (long)response.AccountIndex.Index);
+                AddToCache(lookupResult.Key, lookupResult.Result);
+                result.Add(lookupResult);
+            }
+            catch (RpcException e)
+            {
+                // Only catch errors due to account not found.
+                if (e.StatusCode != StatusCode.NotFound)
+                {
+                    throw;
+                }
                 AddToCache(nonExistingAccount, null);
                 result.Add(new LookupResult(nonExistingAccount, null));
             }

--- a/backend/Application/Import/ConcordiumNode/ConcordiumNodeClient.cs
+++ b/backend/Application/Import/ConcordiumNode/ConcordiumNodeClient.cs
@@ -15,6 +15,11 @@ public interface IConcordiumNodeClient
     
     Task<BakerPoolStatus> GetPoolInfoAsync(BakerId bakerId, IBlockHashInput blockHashInput,
         CancellationToken token = default);
+
+    public Task<AccountInfo> GetAccountInfoAsync(
+        IAccountIdentifier accountIdentifier,
+        IBlockHashInput blockHash,
+        CancellationToken token = default);
 }
 
 internal sealed class ConcordiumNodeClient : IConcordiumNodeClient
@@ -30,6 +35,13 @@ internal sealed class ConcordiumNodeClient : IConcordiumNodeClient
     {
         var poolInfoAsync = await _client.GetPoolInfoAsync(bakerId, blockHashInput, token);
         return poolInfoAsync.Response;
+    }
+
+    public async Task<AccountInfo> GetAccountInfoAsync(IAccountIdentifier accountIdentifier, IBlockHashInput blockHash,
+        CancellationToken token = default)
+    {
+        var accountInfo = await _client.GetAccountInfoAsync(accountIdentifier, blockHash, token);
+        return accountInfo.Response;
     }
 
     public async Task<IBlockItemSummaryWrapper> GetBlockItemStatusAsync(TransactionHash transactionHash,

--- a/backend/Tests/Api/GraphQL/Import/AccountLookupTest.cs
+++ b/backend/Tests/Api/GraphQL/Import/AccountLookupTest.cs
@@ -1,9 +1,13 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using Application.Api.GraphQL.Import;
+using Application.Database;
+using Application.Import.ConcordiumNode;
 using Concordium.Sdk.Types;
-using Dapper;
 using FluentAssertions;
+using Grpc.Core;
 using Microsoft.Extensions.Caching.Memory;
+using Moq;
 using Tests.TestUtilities;
 using Tests.TestUtilities.Builders.GraphQL;
 using Tests.TestUtilities.Stubs;
@@ -11,40 +15,30 @@ using Tests.TestUtilities.Stubs;
 namespace Tests.Api.GraphQL.Import;
 
 [Collection(DatabaseCollectionFixture.DatabaseCollection)]
-public class AccountLookupTest : IDisposable
+public class AccountLookupTest
 {
     private readonly GraphQlDbContextFactoryStub _dbContextFactory;
-    private readonly MemoryCache _memoryCache;
-    private readonly AccountLookup _target;
+    private readonly DatabaseSettings _databaseSettings;
 
     public AccountLookupTest(DatabaseFixture dbFixture)
     {
         _dbContextFactory = new GraphQlDbContextFactoryStub(dbFixture. DatabaseSettings);
-
-        var options = new MemoryCacheOptions();
-        _memoryCache = new MemoryCache(options);
-        _target = new AccountLookup(_memoryCache, dbFixture. DatabaseSettings, new NullMetrics());
-
-        using var connection = DatabaseFixture.GetOpenConnection();
-        connection.Execute("TRUNCATE TABLE graphql_accounts");
+        _databaseSettings = dbFixture.DatabaseSettings;
     }
-
-    public void Dispose()
-    {
-        _memoryCache.Dispose();
-    }
-
+    
     [Fact]
-    public void GetAccountIdsFromBaseAddressesAsync_EmptyQuery()
+    public async Task GetAccountIdsFromBaseAddressesAsync_EmptyQuery()
     {
-        var result = _target.GetAccountIdsFromBaseAddresses(Array.Empty<string>());
+        using var testObject = await TestObject.Create(_databaseSettings);
+        var result = testObject.AccountLookup.GetAccountIdsFromBaseAddresses(Array.Empty<string>());
         result.Should().BeEmpty();
     }
 
     [Fact]
-    public void GetAccountIdsFromBaseAddressesAsync_QuerySingle_DoesntExist()
+    public async Task GetAccountIdsFromBaseAddressesAsync_QuerySingle_DoesntExist()
     {
-        var result = _target.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P"});
+        using var testObject = await TestObject.Create(_databaseSettings);
+        var result = testObject.AccountLookup.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P"});
         
         var expected = new Dictionary<string, long?>()
         {
@@ -56,9 +50,10 @@ public class AccountLookupTest : IDisposable
     [Fact]
     public async Task GetAccountIdsFromBaseAddressesAsync_QuerySingle_AccountExists()
     {
+        using var testObject = await TestObject.Create(_databaseSettings);
         await CreateAccount(42, "3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P");
         
-        var result = _target.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P"});
+        var result = testObject.AccountLookup.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P"});
         
         var expected = new Dictionary<string, long?>()
         {
@@ -70,12 +65,13 @@ public class AccountLookupTest : IDisposable
     [Fact]
     public async Task GetAccountIdsFromBaseAddressesAsync_QueryMultiple_AccountsExists_NoneCached()
     {
+        using var testObject = await TestObject.Create(_databaseSettings);
         await CreateAccount(42, "3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P");
         await CreateAccount(47, "44B3fpw5duunyeH5U7uxE3N7mpjiBsk9ZwkDiVF9bLNegcVRoy");
         
-        _target.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P"});
+        testObject.AccountLookup.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P"});
         
-        var result = _target.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P", "44B3fpw5duunyeH5U7uxE3N7mpjiBsk9ZwkDiVF9bLNegcVRoy"});
+        var result = testObject.AccountLookup.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P", "44B3fpw5duunyeH5U7uxE3N7mpjiBsk9ZwkDiVF9bLNegcVRoy"});
         
         var expected = new Dictionary<string, long?>()
         {
@@ -88,14 +84,15 @@ public class AccountLookupTest : IDisposable
     [Fact]
     public async Task GetAccountIdsFromBaseAddressesAsync_QueryMultiple_AccountsExists_PartlyCached()
     {
+        using var testObject = await TestObject.Create(_databaseSettings);
         await CreateAccount(42, "3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P");
         await CreateAccount(47, "44B3fpw5duunyeH5U7uxE3N7mpjiBsk9ZwkDiVF9bLNegcVRoy");
 
         // Put one in cache...
-        _target.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P"});
+        testObject.AccountLookup.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P"});
         
         // .. and now lookup with one in cache and one not in cache
-        var result = _target.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P", "44B3fpw5duunyeH5U7uxE3N7mpjiBsk9ZwkDiVF9bLNegcVRoy"});
+        var result = testObject.AccountLookup.GetAccountIdsFromBaseAddresses(new[]{"3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P", "44B3fpw5duunyeH5U7uxE3N7mpjiBsk9ZwkDiVF9bLNegcVRoy"});
         
         var expected = new Dictionary<string, long?>()
         {
@@ -104,6 +101,81 @@ public class AccountLookupTest : IDisposable
         };
         result.Should().Equal(expected);
     }
+
+    [Fact]
+    public async Task GivenNoAccountInCacheOrDatabase_WhenCallingNodeWhichKnowsAccount_ThenReturnAccount()
+    {
+        // Arrange
+        var uniqueAddress = AccountAddressHelper.GetUniqueAddress();
+        const long accountIndex = 1L;
+        var expected = new Dictionary<string, long?>
+        {
+            { uniqueAddress, accountIndex }
+        };
+        var clientMock = new Mock<IConcordiumNodeClient>();
+        var accountInfo = new AccountInfo(
+            AccountSequenceNumber.From(1UL),
+            CcdAmount.Zero, 
+            new AccountIndex(accountIndex),
+            AccountAddress.From(uniqueAddress),
+            null
+        );
+        clientMock.Setup(m => m.GetAccountInfoAsync(It.IsAny<IAccountIdentifier>(), It.IsAny<IBlockHashInput>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(accountInfo));
+        using var testObject = await TestObject.Create(_databaseSettings, client: clientMock.Object);
+        
+        // Act
+        var result = testObject.AccountLookup.GetAccountIdsFromBaseAddresses(new[] { uniqueAddress });
+        
+        // Assert
+        result.Should().Equal(expected);
+    }
+    
+    private sealed class TestObject : IDisposable
+    {
+        private readonly MemoryCache _cache;
+        internal AccountLookup AccountLookup { get; }
+
+        private TestObject(
+            MemoryCache? memoryCache, 
+            IConcordiumNodeClient client,
+            DatabaseSettings databaseSettings
+        )
+        {
+            _cache = memoryCache ?? new MemoryCache(new MemoryCacheOptions());
+            AccountLookup = new AccountLookup(
+                _cache,
+                databaseSettings,
+                new NullMetrics(),
+                client);
+        }
+
+        internal static async Task<TestObject> Create(
+            DatabaseSettings databaseSettings,
+            MemoryCache? memoryCache = null, 
+            IConcordiumNodeClient? client = null
+        )
+        {
+            await DatabaseFixture.TruncateTables("graphql_accounts");
+            if (client == null)
+            {
+                var mock = new Mock<IConcordiumNodeClient>();
+                mock.Setup(m => m.GetAccountInfoAsync(
+                        It.IsAny<IAccountIdentifier>(),
+                        It.IsAny<IBlockHashInput>(),
+                        It.IsAny<CancellationToken>()))
+                    .Throws(new RpcException(new Status(StatusCode.NotFound, string.Empty)));
+                client = mock.Object;
+            }
+            return new TestObject(memoryCache, client, databaseSettings);
+        }
+
+        public void Dispose()
+        {
+            _cache.Dispose();
+        }
+    }    
 
     private async Task CreateAccount(long accountId, string baseAddress)
     {

--- a/backend/Tests/Api/GraphQL/Import/TransactionsWriterTest.cs
+++ b/backend/Tests/Api/GraphQL/Import/TransactionsWriterTest.cs
@@ -792,9 +792,6 @@ public class TransactionsWriterTest
         const string from = "73ba390d9ce2bb1bf54f124bb00e9dee0d6dc40d6de0f5ba06e1d1f095e4afcc";
         const string to = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         
-        const string firstEvent = "05080000d671a4d501aa3a794db185bb8ac998abe33146301afcb53f78d58266c6417cb9d859c90309c0196da50d25f71a236ec71cedc9ba2d49c8c6fc9fa98df7475d3bfbc7612c32";
-        const string secondEvent = "01080000d671a4d50101aa3a794db185bb8ac998abe33146301afcb53f78d58266c6417cb9d859c9030901c0196da50d25f71a236ec71cedc9ba2d49c8c6fc9fa98df7475d3bfbc7612c32";
-        
         var upgraded = new Upgraded(
             ContractAddress.From(index, subIndex),
             new ModuleReference(from),

--- a/backend/Tests/Api/GraphQL/Network/ClientVersionComparerTest.cs
+++ b/backend/Tests/Api/GraphQL/Network/ClientVersionComparerTest.cs
@@ -18,7 +18,7 @@ public class ClientVersionComparerTest
     [InlineData("3.0.0", "2.0.0", 1)]
     [InlineData("2.0.0", "2.0.0", 0)]
     [InlineData("2.0.0", "10.0.0", -1)]
-    public async Task OrderTest(string? v1, string? v2, int expectedResult)
+    public void OrderTest(string? v1, string? v2, int expectedResult)
     {
         var actualResult = new ClientVersionComparer().Compare(v1, v2);
         expectedResult.Should().Be(actualResult, String.Format("comparing v1:{0} and v2:{1}", v1, v2));


### PR DESCRIPTION
## Purpose

This PR is preparation for step 2, **Migrate all token logic to contract flow, such that token events can be enriched with deserialised messages.**, which will follow PR https://github.com/Concordium/concordium-scan/pull/161.

It enables the account cache to be updated from the node. In theory since account is imported in the main import flow of the CCD scan and contracts in another import flow, it could be the contract flow needs to process information from an account, which hasn’t yet been imported to the database.

By enabling the account cache to lookup the account index on the node and not only the database, we ensure the account cache can be used in other flows than the one which imports account.

## Changes

- Add to account cache look up of account index on the node if it isn’t present in either memory or database

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.