### PR TITLE
Added cis event reinitialization job

### DIFF
--- a/backend/Application/Aggregates/Contract/EventLogs/EventLogWriter.cs
+++ b/backend/Application/Aggregates/Contract/EventLogs/EventLogWriter.cs
@@ -127,7 +127,7 @@ namespace Application.Aggregates.Contract.EventLogs
                     .GetBaseAddress()
                     .ToString())
                 .Distinct();
-            var accountsMap = this._accountLookup.GetAccountIdsFromBaseAddresses(accountBaseAddresses);
+            var accountsMap = _accountLookup.GetAccountIdsFromBaseAddresses(accountBaseAddresses);
             using var counter = _metrics.MeasureDuration(nameof(EventLogWriter), nameof(ApplyAccountUpdates));
 
             using var context = _dbContextFactory.CreateDbContext();

--- a/backend/Application/Aggregates/Contract/Extensions/ContractExtensions.cs
+++ b/backend/Application/Aggregates/Contract/Extensions/ContractExtensions.cs
@@ -74,5 +74,7 @@ public static class ContractExtensions
         collection.AddTransient<InitialContractEventDeserializationFieldsCatchUpJob>();
         collection.AddTransient<IContractJob, ParallelBatchJob<InitialContractRejectEventDeserializationFieldsCatchUpJob>>();
         collection.AddTransient<InitialContractRejectEventDeserializationFieldsCatchUpJob>();
+        collection.AddTransient<IContractJob, ParallelBatchJob<_10_CisEventReinitialization>>();
+        collection.AddTransient<_10_CisEventReinitialization>();
     }
 }

--- a/backend/Application/Aggregates/Contract/Jobs/IStatelessJob.cs
+++ b/backend/Application/Aggregates/Contract/Jobs/IStatelessJob.cs
@@ -23,6 +23,11 @@ public interface IStatelessJob
     Task<IEnumerable<int>> GetIdentifierSequence(CancellationToken cancellationToken);
 
     /// <summary>
+    /// Actions which should be applied before any call to <see cref="Process"/>.
+    /// </summary>
+    ValueTask Setup(CancellationToken token = default);
+
+    /// <summary>
     /// Process identifier.
     /// </summary>
     ValueTask Process(int identifier, CancellationToken token = default);

--- a/backend/Application/Aggregates/Contract/Jobs/InitialContractEventDeserializationFieldsCatchUpJob.cs
+++ b/backend/Application/Aggregates/Contract/Jobs/InitialContractEventDeserializationFieldsCatchUpJob.cs
@@ -54,7 +54,10 @@ public sealed class InitialContractEventDeserializationFieldsCatchUpJob : IState
         
         return Enumerable.Range(0, batchCount);
     }
-    
+
+    /// <inheritdoc/>
+    public ValueTask Setup(CancellationToken token) => ValueTask.CompletedTask;
+
     /// <summary>
     /// Updates <see cref="Application.Aggregates.Contract.Entities.ContractEvent"/> with hexadecimal fields parsed. 
     /// </summary>

--- a/backend/Application/Aggregates/Contract/Jobs/InitialContractRejectEventDeserializationFieldsCatchUpJob.cs
+++ b/backend/Application/Aggregates/Contract/Jobs/InitialContractRejectEventDeserializationFieldsCatchUpJob.cs
@@ -50,6 +50,9 @@ public sealed class InitialContractRejectEventDeserializationFieldsCatchUpJob : 
     }
 
     /// <inheritdoc/>
+    public ValueTask Setup(CancellationToken token) => ValueTask.CompletedTask;
+
+    /// <inheritdoc/>
     public bool ShouldNodeImportAwait() => false;
     
     /// <summary>

--- a/backend/Application/Aggregates/Contract/Jobs/_10_CisEventReinitialization.cs
+++ b/backend/Application/Aggregates/Contract/Jobs/_10_CisEventReinitialization.cs
@@ -1,0 +1,144 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using Application.Aggregates.Contract.Dto;
+using Application.Aggregates.Contract.Entities;
+using Application.Aggregates.Contract.EventLogs;
+using Application.Api.GraphQL;
+using Application.Api.GraphQL.EfCore;
+using Application.Api.GraphQL.Transactions;
+using Dapper;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Aggregates.Contract.Jobs;
+
+public sealed class _10_CisEventReinitialization : IStatelessJob
+{
+    private readonly IDbContextFactory<GraphQlDbContext> _contextFactory;
+    private readonly IEventLogHandler _eventLogHandler;
+
+    /// <summary>
+    /// WARNING - Do not change this if job already executed on environment, since it will trigger rerun of job.
+    /// </summary>
+    private const string JobName = "_10_CisEventReinitialization";
+
+    public _10_CisEventReinitialization(
+        IDbContextFactory<GraphQlDbContext> contextFactory,
+        IEventLogHandler eventLogHandler
+        )
+    {
+        _contextFactory = contextFactory;
+        _eventLogHandler = eventLogHandler;
+    }
+
+    /// <inheritdoc/>
+    public string GetUniqueIdentifier() => JobName;
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<int>> GetIdentifierSequence(CancellationToken cancellationToken)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var max = context.ContractEvents.Max(ce => ce.ContractAddressIndex);
+        return Enumerable.Range(0, (int)max + 1);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask Setup(CancellationToken token)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(token);
+        var connection = context.Database.GetDbConnection();
+        await connection.ExecuteAsync("truncate table graphql_account_tokens, graphql_token_events, graphql_tokens;");
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask Process(int identifier, CancellationToken token = default)
+    {
+        TransactionScope? transactionScope = null;
+        try
+        {
+            transactionScope = new TransactionScope(
+                TransactionScopeOption.Required,
+                new TransactionOptions{IsolationLevel = IsolationLevel.ReadCommitted},
+                TransactionScopeAsyncFlowOption.Enabled);
+            
+            var contractEvents = await GetContractEvents(identifier, token);
+            var jobContractRepository = new JobContractRepository(contractEvents);
+            await _eventLogHandler.HandleCisEvent(jobContractRepository);
+            transactionScope.Complete();
+        }
+        finally
+        {
+            transactionScope?.Dispose();
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool ShouldNodeImportAwait() => true;
+
+    private async Task<IList<ContractEvent>> GetContractEvents(int address, CancellationToken token = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(token);
+        var contractEvents = await context.ContractEvents.Where(ce => ce.ContractAddressIndex == (ulong)address)
+            .ToListAsync(cancellationToken: token);
+        return contractEvents;
+    }
+    
+    private sealed class JobContractRepository : IContractRepository
+    {
+        private readonly IEnumerable<ContractEvent> _contractEvents;
+        
+        public JobContractRepository(IEnumerable<ContractEvent> contractEvents)
+        {
+            _contractEvents = contractEvents;
+        }
+    
+        public IEnumerable<ContractEvent> GetContractEventsAddedInTransaction() => _contractEvents;
+    
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    
+        public Task<IList<TransactionRejectEventDto>> FromBlockHeightRangeGetContractRelatedRejections(ulong heightFrom, ulong heightTo)
+        {
+            throw new NotImplementedException();
+        }
+    
+        public Task<IList<TransactionResultEventDto>> FromBlockHeightRangeGetContractRelatedTransactionResultEventRelations(ulong heightFrom, ulong heightTo)
+        {
+            throw new NotImplementedException();
+        }
+    
+        public Task<List<ulong>> FromBlockHeightRangeGetBlockHeightsReadOrdered(ulong heightFrom, ulong heightTo)
+        {
+            throw new NotImplementedException();
+        }
+    
+        public Task<ContractReadHeight?> GetReadonlyLatestContractReadHeight()
+        {
+            throw new NotImplementedException();
+        }
+    
+        public Task<long> GetReadonlyLatestImportState(CancellationToken token = default)
+        {
+            throw new NotImplementedException();
+        }
+    
+        public Task<ContractInitialized> GetReadonlyContractInitializedEventAsync(ContractAddress contractAddress)
+        {
+            throw new NotImplementedException();
+        }
+    
+        public Task AddAsync<T>(params T[] entities) where T : class
+        {
+            throw new NotImplementedException();
+        }
+    
+        public Task AddRangeAsync<T>(IEnumerable<T> heights) where T : class
+        {
+            throw new NotImplementedException();
+        }
+    
+        public Task CommitAsync(CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/backend/Tests/Aggregates/Contract/Jobs/InitialContractEventDeserializationFieldsCatchUpJobTests.cs
+++ b/backend/Tests/Aggregates/Contract/Jobs/InitialContractEventDeserializationFieldsCatchUpJobTests.cs
@@ -65,7 +65,7 @@ public class InitialContractEventDeserializationFieldsCatchUpJobTests
             }
         });
         var job = new InitialContractEventDeserializationFieldsCatchUpJob(dbFactory.Object, options);
-        var parallelBatchJob = new ParallelBatchJob<InitialContractEventDeserializationFieldsCatchUpJob>(job, options, new JobHealthCheck());
+        var parallelBatchJob = new ParallelBatchJob<InitialContractEventDeserializationFieldsCatchUpJob>(job, options);
         
         // Act
         await parallelBatchJob.StartImport(CancellationToken.None);

--- a/backend/Tests/Aggregates/Contract/Jobs/InitialContractRejectEventDeserializationFieldsCatchUpJobTests.cs
+++ b/backend/Tests/Aggregates/Contract/Jobs/InitialContractRejectEventDeserializationFieldsCatchUpJobTests.cs
@@ -56,7 +56,7 @@ public class InitialContractRejectEventDeserializationEventFieldsCatchUpJobTests
             }
         });
         var job = new InitialContractRejectEventDeserializationFieldsCatchUpJob(dbFactory.Object, options);
-        var parallelBatchJob = new ParallelBatchJob<InitialContractRejectEventDeserializationFieldsCatchUpJob>(job, options, new JobHealthCheck());
+        var parallelBatchJob = new ParallelBatchJob<InitialContractRejectEventDeserializationFieldsCatchUpJob>(job, options);
         
         // Act
         await parallelBatchJob.StartImport(CancellationToken.None);

--- a/backend/Tests/Aggregates/Contract/Jobs/ParallelBatchJobTests.cs
+++ b/backend/Tests/Aggregates/Contract/Jobs/ParallelBatchJobTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Threading;
 using Application.Aggregates.Contract.Configurations;
 using Application.Aggregates.Contract.Jobs;
-using Application.Observability;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
 
@@ -21,8 +20,7 @@ public sealed class ParallelBatchJobTests
         var statelessMockJob = new StatelessMockJob();
         var parallelBatchJob = new ParallelBatchJob<StatelessMockJob>(
             statelessMockJob,
-            Options.Create(new ContractAggregateOptions()),
-            new JobHealthCheck()
+            Options.Create(new ContractAggregateOptions())
             );
         
         // Act
@@ -45,6 +43,11 @@ public sealed class ParallelBatchJobTests
         public Task<IEnumerable<int>> GetIdentifierSequence(CancellationToken cancellationToken)
         {
             return Task.FromResult(Enumerable.Range(0, 42));
+        }
+
+        public ValueTask Setup(CancellationToken token = default)
+        {
+            throw new NotImplementedException();
         }
 
         public ValueTask Process(int identifier, CancellationToken token = default)


### PR DESCRIPTION
## Purpose

This is the third PR out of four which adds CIS2 token events to the CCD scan.

~~1. Add to existing flow new token events~~ https://github.com/Concordium/concordium-scan/pull/161
~~2. Migrate all token logic to contract flow, such that token events can be enriched with deserialised messages.~~ https://github.com/Concordium/concordium-scan/pull/166
3. Create a catch-up job which enrich storage with events and fix data corruption on total token supply
4. Add frontend which visualise tokens

Feature continues work on PR https://github.com/Concordium/concordium-scan/pull/73

## Changes

- Add a job which start by truncate tables graphql_account_tokens, graphql_token_events and graphql_tokens. Reinitialization is needed both because 
    - Mint events wasn’t correctly updating account token balances. This was fixed in PR https://github.com/Concordium/concordium-scan/pull/160
    - Adding all Cis events to table `graphql_token_events`

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.