### PR TITLE
Bump Debian version in docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bookworm-slim AS base
 WORKDIR /app
 EXPOSE 5000
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim AS publish
 WORKDIR /src
 COPY Application/ Application/
 COPY DatabaseScripts/ DatabaseScripts/


### PR DESCRIPTION
## Purpose

Interop calls to rust binaries has stopped working in the CCD scan after migrating to binaries in the .NET SDK. The issue was only seen when building  and running CCD scan docker image.

The issue is that the binaries in the .NET SDK are build on Ubuntu 22.04
https://github.com/Concordium/concordium-net-sdk/actions/runs/7209178248/job/19639595963

The CCD scan docker images were using mcr.microsoft.com/dotnet/aspnet:6.0 which relies on Debian 11.
https://github.com/dotnet/dotnet-docker/blob/main/README.runtime.md#full-tag-listing

By looking at the shared object dependencies needed for the `librust_bindings.so` build on Ubuntu 22.04 and used in Debian 11 we see that some dependencies are missing
```
./librust_bindings.so: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by ./librust_bindings.so)
./librust_bindings.so: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./librust_bindings.so)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00000040028f2000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000000400290c000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000004002a50000)
	/lib64/ld-linux-x86-64.so.2 (0x0000004000000000)
```

Before the migration to binaries from the .NET SDK, the rust binaries were build within the docker images itself and hence had required dependencies needed. The below is the output of `ldd librust_bindings.so` in CCD scan docker image where the binaries were build within its Debian 11 image
```
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x0000004002b2c000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x0000004002b48000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000004002b6a000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x0000004002cae000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000004002cb4000)
	/lib64/ld-linux-x86-64.so.2 (0x0000004000000000)
```

By changing the image used to `6.0-bookworm-slim` which uses Debian 12 or `6.0-jammy` which uses Ubuntu 22.04 there are no errors when looking at shared object dependencies for `librust_bindings.so`
```
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x0000004002901000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000004002921000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000004002a08000)
	/lib64/ld-linux-x86-64.so.2 (0x0000004000000000)
```

Also interop tests executed inside the docker image runs green in both cases.

## Changes

- Change base image to 6.0-bookworm-slim to bump Debian from 11 to 12 and avoid linking errors for shared object dependencies for `librust_bindings.so`

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.