### PR TITLE
Fix token tooltip

### DIFF
--- a/frontend/src/components/molecules/TokenId.vue
+++ b/frontend/src/components/molecules/TokenId.vue
@@ -1,6 +1,11 @@
 <template>
 	<div class="inline-block">
-		<Tooltip :text="tokenIdLowerCase">
+		<Tooltip
+			:text="tokenIdLowerCase"
+			x="50%"
+			y="0%"
+			tooltip-position="absolute"
+		>
 			<div class="token-id truncate">
 				{{ tokenIdLowerCase }}
 			</div>

--- a/frontend/src/components/molecules/TokenLink.vue
+++ b/frontend/src/components/molecules/TokenLink.vue
@@ -2,7 +2,13 @@
 	<div class="inline-block whitespace-nowrap">
 		<TokenIcon class="h-5 inline align-text-top" />
 		<LinkButton class="numerical px-2" @blur="emitBlur" @click="handleOnClick">
-			<Tooltip :text="props.tokenAddress" text-class="text-theme-body">
+			<Tooltip
+				:text="props.tokenAddress"
+				text-class="text-theme-body"
+				x="50%"
+				y="0%"
+				tooltip-position="absolute"
+			>
 				<div class="token-address truncate">
 					{{ props.tokenAddress }}
 				</div>


### PR DESCRIPTION
## Purpose

Tooltips on token- address and id was pointing to the beginning of the `div` element instead of being positioned at the center.

Issue can be seen on testnet.

## Changes
- Change tooltips for token- address and id to be positioned using position absolute

https://github.com/Concordium/concordium-scan/assets/132270889/46585c70-7264-49c8-9a9d-18fb86f875eb

