### PR TITLE
Sort by contract- index, subindex and token id in Account token view

### DIFF
--- a/backend/Application/Api/GraphQL/Accounts/Account.cs
+++ b/backend/Application/Api/GraphQL/Accounts/Account.cs
@@ -80,8 +80,10 @@ public class Account
     public IQueryable<AccountToken> GetTokens(GraphQlDbContext dbContext)
     {
         return dbContext.AccountTokens
-            .Where(t => t.AccountId == this.Id && t.Balance != 0)
-            .OrderByDescending(t => t.Index)
+            .Where(t => t.AccountId == Id && t.Balance != 0)
+            .OrderByDescending(t => t.ContractIndex)
+            .ThenByDescending(t => t.ContractSubIndex)
+            .ThenByDescending(t => t.TokenId)
             .Include(t=>t.Token)
             .AsNoTracking();
     }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unreleased changes
+- Updated
+    - Token view on account details page now sort tokens by contract- index, subindex and token id.
+
+## 1.8.8
 - Bugfix
     - Fix total token supply
 


### PR DESCRIPTION
## Purpose

Sort tokens by contract- index, subindex and token id.

Issue seen on testnet
https://testnet.ccdscan.io/tokens?dcount=1&dentity=account&daddress=3iCW2ejiWLhB3zNWafhg457X1TqzrkSouosjz8gf4kCifGFZo4

Now sorted as below
<img width="1421" alt="Screenshot 2024-01-29 at 09 21 27" src="https://github.com/Concordium/concordium-scan/assets/132270889/136d12f5-57b2-4fa9-b240-9ba80f4c2e8f">

Issue: https://concordium.atlassian.net/browse/CBW-1660

## Changes
- Change query to sort by contract- index, subindex and token id instead of index indicating when the token was created.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.