### PR TITLE
Token address searchable - migration

### DIFF
--- a/backend/Application/Aggregates/Contract/Configurations/TokenConfiguration.cs
+++ b/backend/Application/Aggregates/Contract/Configurations/TokenConfiguration.cs
@@ -17,6 +17,7 @@ namespace Application.Aggregates.Contract.Configurations
             builder.Property(t => t.ContractSubIndex).HasColumnName("contract_sub_index");
             builder.Property(t => t.TokenId).HasColumnName("token_id");
             builder.Property(t => t.MetadataUrl).HasColumnName("metadata_url");
+            builder.Property(t => t.TokenAddress).HasColumnName("token_address");
             builder.Property(t => t.TotalSupply).HasColumnName("total_supply");
             
             builder.HasKey(t => new { t.ContractIndex, t.ContractSubIndex, t.TokenId });

--- a/backend/Application/Aggregates/Contract/EventLogs/EventLogWriter.cs
+++ b/backend/Application/Aggregates/Contract/EventLogs/EventLogWriter.cs
@@ -93,14 +93,15 @@ namespace Application.Aggregates.Contract.EventLogs
         private static DbBatchCommand CreateTokenAmountUpdateCmd(DbBatchCommand cmd, CisEventTokenAmountUpdate e)
         {
             cmd.CommandText = @"
-                INSERT INTO graphql_tokens(contract_index, contract_sub_index, token_id, total_supply)
-                VALUES (@ContractIndex, @ContractSubIndex, @TokenId, @AmountDelta)
+                INSERT INTO graphql_tokens(contract_index, contract_sub_index, token_id, token_address, total_supply)
+                VALUES (@ContractIndex, @ContractSubIndex, @TokenId, @TokenAddress, @AmountDelta)
                 ON CONFLICT ON CONSTRAINT graphql_tokens_pkey
                 DO UPDATE SET total_supply = graphql_tokens.total_supply + @AmountDelta";
             
             cmd.Parameters.Add(new NpgsqlParameter<long>("ContractIndex", Convert.ToInt64(e.ContractIndex)));
             cmd.Parameters.Add(new NpgsqlParameter<long>("ContractSubIndex", Convert.ToInt64(e.ContractSubIndex)));
             cmd.Parameters.Add(new NpgsqlParameter<string>("TokenId", e.TokenId));
+            cmd.Parameters.Add(new NpgsqlParameter<string>("TokenAddress", Token.EncodeTokenAddress(e.ContractIndex, e.ContractSubIndex, e.TokenId)));
             cmd.Parameters.Add(new NpgsqlParameter<BigInteger>("AmountDelta", e.AmountDelta));
 
             return cmd;

--- a/backend/Application/Aggregates/Contract/Extensions/ContractExtensions.cs
+++ b/backend/Application/Aggregates/Contract/Extensions/ContractExtensions.cs
@@ -80,5 +80,7 @@ public static class ContractExtensions
         collection.AddTransient<InitialContractRejectEventDeserializationFieldsCatchUpJob>();
         collection.AddTransient<IContractJob, ParallelBatchJob<_05_CisEventReinitialization>>();
         collection.AddTransient<_05_CisEventReinitialization>();
+        collection.AddTransient<IContractJob, ParallelBatchJob<_06_AddTokenAddress>>();
+        collection.AddTransient<_06_AddTokenAddress>();
     }
 }

--- a/backend/Application/Aggregates/Contract/Jobs/_06_AddTokenAddress.cs
+++ b/backend/Application/Aggregates/Contract/Jobs/_06_AddTokenAddress.cs
@@ -37,7 +37,7 @@ public sealed class _06_AddTokenAddress : IStatelessJob
     public async Task<IEnumerable<int>> GetIdentifierSequence(CancellationToken cancellationToken)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-        var max = context.ContractEvents.Max(ce => ce.ContractAddressIndex);
+        var max = context.Contract.Max(ce => ce.ContractAddressIndex);
         return Enumerable.Range(0, (int)max + 1);
     }
 

--- a/backend/Application/Aggregates/Contract/Jobs/_06_AddTokenAddress.cs
+++ b/backend/Application/Aggregates/Contract/Jobs/_06_AddTokenAddress.cs
@@ -1,0 +1,67 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Aggregates.Contract.Configurations;
+using Application.Api.GraphQL.EfCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Application.Aggregates.Contract.Entities;
+using Application.Resilience;
+
+namespace Application.Aggregates.Contract.Jobs;
+
+/// <summary>
+/// Adding <see cref="Token.TokenAddress"/> by iterating through all existing tokens.
+/// </summary>
+public sealed class _06_AddTokenAddress : IStatelessJob
+{
+    private readonly IDbContextFactory<GraphQlDbContext> _contextFactory;
+    private readonly ContractAggregateOptions _options;
+    private readonly ILogger _logger;
+    
+    /// <summary>
+    /// WARNING - Do not change this if job already executed on environment, since it will trigger rerun of job.
+    /// </summary>
+    private const string JobName = "_06_AddTokenAddress";
+
+    public _06_AddTokenAddress(
+        IDbContextFactory<GraphQlDbContext> contextFactory,
+        IOptions<ContractAggregateOptions> options)
+    {
+        _contextFactory = contextFactory;
+        _options = options.Value;
+        _logger = Log.ForContext<_06_AddTokenAddress>();
+    }
+
+    public string GetUniqueIdentifier() => JobName;
+
+    public async Task<IEnumerable<int>> GetIdentifierSequence(CancellationToken cancellationToken)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var max = context.ContractEvents.Max(ce => ce.ContractAddressIndex);
+        return Enumerable.Range(0, (int)max + 1);
+    }
+
+    public ValueTask Setup(CancellationToken token = default) => ValueTask.CompletedTask;
+
+    public async ValueTask Process(int identifier, CancellationToken token = default)
+    {
+        _logger.Debug($"Start processing {identifier}");
+        await Policies.GetTransientPolicy(GetUniqueIdentifier(), _logger, _options.RetryCount, _options.RetryDelay)
+            .ExecuteAsync(async () =>
+            {
+                await using var context = await _contextFactory.CreateDbContextAsync(token);
+                var tokens = await context.Tokens
+                    .Where(t => (int)t.ContractIndex == identifier)
+                    .ToListAsync(token);
+                foreach (var cisToken in tokens.Where(cisToken => cisToken.TokenAddress == null))
+                {
+                    cisToken.TokenAddress =
+                        Token.EncodeTokenAddress(cisToken.ContractIndex, cisToken.ContractSubIndex, cisToken.TokenId);
+                }
+                await context.SaveChangesAsync(token);
+            });
+        _logger.Debug($"Completed successfully processing {identifier}");
+    }
+
+    public bool ShouldNodeImportAwait() => true;
+}

--- a/backend/DatabaseScripts/SqlScripts/0050_alter_table_graphql_tokens_add_column_token_address.sql
+++ b/backend/DatabaseScripts/SqlScripts/0050_alter_table_graphql_tokens_add_column_token_address.sql
@@ -1,5 +1,10 @@
 /*
-Add column for token address which consist of contract index, contract subindex and token id. 
+Add column for token address which consist of contract index, contract subindex and token id.
+
+Adds index on the column since it would be needed for searching.
  */
 ALTER TABLE graphql_tokens
 ADD COLUMN token_address text null;
+
+CREATE INDEX graphql_tokens_token_address_index
+    ON graphql_tokens (token_address);

--- a/backend/DatabaseScripts/SqlScripts/0050_alter_table_graphql_tokens_add_column_token_address.sql
+++ b/backend/DatabaseScripts/SqlScripts/0050_alter_table_graphql_tokens_add_column_token_address.sql
@@ -1,0 +1,5 @@
+/*
+Add column for token address which consist of contract index, contract subindex and token id. 
+ */
+ALTER TABLE graphql_tokens
+ADD COLUMN token_address text null;

--- a/backend/Tests/Aggregates/Contract/Entities/TokenTestWithoutDatabase.cs
+++ b/backend/Tests/Aggregates/Contract/Entities/TokenTestWithoutDatabase.cs
@@ -3,7 +3,7 @@ using FluentAssertions;
 
 namespace Tests.Aggregates.Contract.Entities;
 
-public sealed class TokenExtensionsTest
+public sealed class TokenTestWithoutDatabase
 {
     [Theory]
     [InlineData(0,0,"", "5Pxr5EUtU")]
@@ -11,22 +11,16 @@ public sealed class TokenExtensionsTest
     [InlineData(1,0,"", "5QTdu98KF")]
     [InlineData(1,0,"aa", "LSYqgoQcb6")]
     [InlineData(1,0,"0a", "LSYXivPSWP")]
+    [InlineData(1,0,"01", "LSYWgnCBmz")]
+    [InlineData(2,0,"02", "LUjzdxXnte")]
     public void WhenCreateTokenAddress_ThenCorrectOutput(
         ulong contractIndex,
         ulong contractSubindex,
         string tokenId,
         string expectedTokenAddress)
     {
-        // Arrange
-        var tokenExtensions = new Token.TokenExtensions();
-        var token = new Token{
-            ContractIndex = contractIndex, 
-            ContractSubIndex = contractSubindex,
-            TokenId = tokenId
-        };
-        
         // Act
-        var tokenAddress = tokenExtensions.GetTokenAddress(token);
+        var tokenAddress = Token.EncodeTokenAddress(contractIndex, contractSubindex, tokenId);
         
         // Assert
         tokenAddress.Should().Be(expectedTokenAddress);

--- a/backend/Tests/Aggregates/Contract/EventLog/EventLogWriterTest.cs
+++ b/backend/Tests/Aggregates/Contract/EventLog/EventLogWriterTest.cs
@@ -16,8 +16,8 @@ namespace Tests.Aggregates.Contract.EventLog
     public class EventLogWriterTest
     {
         private const string TOKEN1_METADATA_URL = "http://example.com/token1";
-        private const string TOKEN_1_ID = "token1";
-        private const string TOKEN_2_ID = "token2";
+        private const string TOKEN_1_ID = "01";
+        private const string TOKEN_2_ID = "02";
         private const long ACCOUNT_1_ID = 1;
         private const string ACCOUNT_1_ADDR = "3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P";
 
@@ -110,6 +110,7 @@ namespace Tests.Aggregates.Contract.EventLog
             token1.TotalSupply.Should().Be(1);
             token1.ContractSubIndex.Should().Be(0);
             token1.MetadataUrl.Should().Be(TOKEN1_METADATA_URL);
+            token1.TokenAddress.Should().Be("LSYWgnCBmz");
 
             var token2s = allTokens.Where(t => t.ContractIndex == 2 && t.ContractSubIndex == 0 && t.TokenId == TOKEN_2_ID).ToList();
             token2s.Count.Should().Be(1);
@@ -119,6 +120,7 @@ namespace Tests.Aggregates.Contract.EventLog
             token2.TotalSupply.Should().Be(1);
             token2.ContractSubIndex.Should().Be(0);
             token2.MetadataUrl.Should().BeNull();
+            token2.TokenAddress.Should().Be("LUjzdxXnte");
         }
 
         [Fact]

--- a/backend/Tests/Aggregates/Contract/Jobs/_06_AddTokenAddressTest.cs
+++ b/backend/Tests/Aggregates/Contract/Jobs/_06_AddTokenAddressTest.cs
@@ -2,6 +2,9 @@ using System.Threading;
 using Application.Aggregates.Contract.Configurations;
 using Application.Aggregates.Contract.Entities;
 using Application.Aggregates.Contract.Jobs;
+using Application.Aggregates.Contract.Types;
+using Application.Api.GraphQL;
+using Application.Api.GraphQL.Accounts;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -26,6 +29,26 @@ public sealed class _06_AddTokenAddressTest
         await DatabaseFixture.TruncateTables("graphql_tokens");
         await using (var context = _fixture.CreateGraphQlDbContext())
         {
+            var contractFirst = new Application.Aggregates.Contract.Entities.Contract(
+                0,
+                "",
+                0,
+                0,
+                new ContractAddress(1,0),
+                new AccountAddress(""),
+                ImportSource.NodeImport,
+                DateTimeOffset.UtcNow
+            );
+            var contractSecond = new Application.Aggregates.Contract.Entities.Contract(
+                0,
+                "",
+                0,
+                0,
+                new ContractAddress(2,0),
+                new AccountAddress(""),
+                ImportSource.NodeImport,
+                DateTimeOffset.UtcNow
+            );
             var first = new Token
             {
                 ContractIndex = 1,
@@ -39,6 +62,8 @@ public sealed class _06_AddTokenAddressTest
                 TokenId = "02"
             };
             await context.AddRangeAsync(first, second);
+            await context.AddRangeAsync(contractFirst, contractSecond);
+            await context.SaveChangesAsync();
         }
 
         var options = Options.Create(new ContractAggregateOptions());

--- a/backend/Tests/Aggregates/Contract/Jobs/_06_AddTokenAddressTest.cs
+++ b/backend/Tests/Aggregates/Contract/Jobs/_06_AddTokenAddressTest.cs
@@ -1,0 +1,64 @@
+using System.Threading;
+using Application.Aggregates.Contract.Configurations;
+using Application.Aggregates.Contract.Entities;
+using Application.Aggregates.Contract.Jobs;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Tests.TestUtilities;
+
+namespace Tests.Aggregates.Contract.Jobs;
+
+[Collection(DatabaseCollectionFixture.DatabaseCollection)]
+public sealed class _06_AddTokenAddressTest
+{
+    private readonly DatabaseFixture _fixture;
+    
+    public _06_AddTokenAddressTest(DatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task WhenRunJob_ThenEnrichWithTokenAddress()
+    {
+        // Arrange
+        await DatabaseFixture.TruncateTables("graphql_tokens");
+        await using (var context = _fixture.CreateGraphQlDbContext())
+        {
+            var first = new Token
+            {
+                ContractIndex = 1,
+                ContractSubIndex = 0,
+                TokenId = "01"
+            };
+            var second = new Token
+            {
+                ContractIndex = 2,
+                ContractSubIndex = 0,
+                TokenId = "02"
+            };
+            await context.AddRangeAsync(first, second);
+        }
+
+        var options = Options.Create(new ContractAggregateOptions());
+        var job = new _06_AddTokenAddress(
+            _fixture.CreateDbContractFactoryMock().Object,
+            options
+        );
+        var parallelBatchJob = new ParallelBatchJob<_06_AddTokenAddress>(job, options);
+        
+        // Act
+        await parallelBatchJob.StartImport(CancellationToken.None);
+        
+        // Assert
+        parallelBatchJob.ShouldNodeImportAwait().Should().BeTrue();
+        await using var assetContext = _fixture.CreateGraphQlDbContext();
+        var tokenFirst = await assetContext.Tokens
+            .SingleAsync(t => t.ContractIndex == 1 && t.ContractSubIndex == 0 && t.TokenId == "01");
+        var tokenSecond = await assetContext.Tokens
+            .SingleAsync(t => t.ContractIndex == 2 && t.ContractSubIndex == 0 && t.TokenId == "02");
+        tokenFirst.TokenAddress!.Should().Be("LSYWgnCBmz");
+        tokenSecond.TokenAddress!.Should().Be("LUjzdxXnte");
+    }
+}


### PR DESCRIPTION
## Purpose

This is the first out of two PR’s which enables tokens to be searchable by token address.

This first PR migrates the database to extend token table with column for token address.

Second PR: https://github.com/Concordium/concordium-scan/pull/178
Task: https://concordium.atlassian.net/browse/CBW-1658

## Changes
- Extend `graphql_tokens` with column `token_address`
- Add migration jobs, which iterates through all existing tokens and enrich entities with token adress

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.