### PR TITLE
Add a limit on export query

### DIFF
--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -13,6 +13,7 @@ namespace Application.Api.Rest;
 public class ExportController : ControllerBase
 {
     private readonly IDbContextFactory<GraphQlDbContext> _dbContextFactory;
+    private const int queryLimit = 25000;
 
     public ExportController(IDbContextFactory<GraphQlDbContext> dbContextFactory)
     {
@@ -41,7 +42,8 @@ public class ExportController : ControllerBase
 
         var query = dbContext.AccountStatementEntries
             .AsNoTracking()
-            .Where(x => x.AccountId == account.Id);
+            .Where(x => x.AccountId == account.Id)
+            .Take(queryLimit);
         if (fromTime.HasValue)
         {
             if (fromTime.Value.Kind != DateTimeKind.Utc)


### PR DESCRIPTION
## Purpose

https://concordium.slack.com/archives/C02EAPK2CQN/p1707366706075419

We saw memory issues on querying from ccdscan. This export function is a time bomb. In general you never want to have a select from without a high enough limit that it should not be a concern. Maybe it should be higher, I do not know. 

This is untestet and I have to setup local environment in order to test it. 