### PR TITLE
Token amounts can be more than what decimal fits.

### DIFF
--- a/backend/Application/Aggregates/Contract/Entities/Token.cs
+++ b/backend/Application/Aggregates/Contract/Entities/Token.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System.Numerics;
 using Application.Api.GraphQL;
 using Application.Api.GraphQL.Accounts;
 using Application.Api.GraphQL.EfCore;
@@ -46,7 +47,7 @@ public class Token
     /// <summary>
     /// Total supply of the token
     /// </summary>
-    public decimal TotalSupply { get; set; }
+    public BigInteger TotalSupply { get; set; }
 
     /// <summary>
     /// Get transaction with the initial mint event of the token.

--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <Version>1.8.13</Version>
+        <Version>1.8.14</Version>
         <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
         <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
         <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>

--- a/backend/Tests/Api/GraphQL/__snapshots__/committed-schema.verified.graphql
+++ b/backend/Tests/Api/GraphQL/__snapshots__/committed-schema.verified.graphql
@@ -1907,7 +1907,7 @@ type Token {
   contractSubIndex: UnsignedLong!
   tokenId: String!
   metadataUrl: String
-  totalSupply: Decimal!
+  totalSupply: BigInteger!
   contractAddressFormatted: String!
   tokenAddress: String!
 }

--- a/backend/Tests/Api/Rest/ExportControllerTest.cs
+++ b/backend/Tests/Api/Rest/ExportControllerTest.cs
@@ -66,9 +66,9 @@ public sealed class ExportControllerTest : IAsyncLifetime
     public async void transactionOutsideSpecifiedTimeStampsAreNotReturned()
     {
         // Arrange
-        var date1 = new DateTime(2020, 12, 1, 0,0,0, DateTimeKind.Utc);
-        var date2 = new DateTime(2020, 12, 7, 0,0,0, DateTimeKind.Utc);
-        var date3 = new DateTime(2020, 12, 12, 0,0,0, DateTimeKind.Utc);
+        var date1 = new DateTime(2020, 12, 1, 0, 0, 0, DateTimeKind.Utc);
+        var date2 = new DateTime(2020, 12, 7, 0, 0, 0, DateTimeKind.Utc);
+        var date3 = new DateTime(2020, 12, 12, 0, 0, 0, DateTimeKind.Utc);
         var startDate = DateTime.SpecifyKind(new DateTime(2020, 12, 5), DateTimeKind.Utc);
         var endDate = DateTime.SpecifyKind(new DateTime(2020, 12, 10), DateTimeKind.Utc);
 

--- a/backend/Tests/Api/Rest/ExportControllerTest.cs
+++ b/backend/Tests/Api/Rest/ExportControllerTest.cs
@@ -66,9 +66,9 @@ public sealed class ExportControllerTest : IAsyncLifetime
     public async void transactionOutsideSpecifiedTimeStampsAreNotReturned()
     {
         // Arrange
-        var date1 = new DateTime(2020, 12, 1);
-        var date2 = new DateTime(2020, 12, 7);
-        var date3 = new DateTime(2020, 12, 12);
+        var date1 = new DateTime(2020, 12, 1, 0,0,0, DateTimeKind.Utc);
+        var date2 = new DateTime(2020, 12, 7, 0,0,0, DateTimeKind.Utc);
+        var date3 = new DateTime(2020, 12, 12, 0,0,0, DateTimeKind.Utc);
         var startDate = DateTime.SpecifyKind(new DateTime(2020, 12, 5), DateTimeKind.Utc);
         var endDate = DateTime.SpecifyKind(new DateTime(2020, 12, 10), DateTimeKind.Utc);
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.5.37",
+	"version": "1.5.38",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/components/Contracts/ContractDetailsTokens.vue
+++ b/frontend/src/components/Contracts/ContractDetailsTokens.vue
@@ -23,7 +23,7 @@
 			<TableTd align="right" class="numerical">
 				<TokenAmount
 					:symbol="contractToken.metadata?.symbol"
-					:amount="String(contractToken.totalSupply)"
+					:amount="contractToken.totalSupply"
 					:fraction-digits="Number(contractToken.metadata?.decimals || 0)"
 				/>
 			</TableTd>

--- a/frontend/src/components/Tokens/TokenDetailsContent.vue
+++ b/frontend/src/components/Tokens/TokenDetailsContent.vue
@@ -34,7 +34,7 @@
 				<template #title>Supply {{ token.metadata?.symbol ?? '' }}</template>
 				<template #default>
 					<TokenAmount
-						:amount="String(token.totalSupply)"
+						:amount="token.totalSupply"
 						:symbol="token.metadata?.symbol"
 						:fraction-digits="Number(token.metadata?.decimals || 0)"
 					/>

--- a/frontend/src/pages/tokens/index.vue
+++ b/frontend/src/pages/tokens/index.vue
@@ -36,7 +36,7 @@
 					<TableTd align="right">
 						<TokenAmount
 							:symbol="token.metadata?.symbol"
-							:amount="String(token.totalSupply)"
+							:amount="token.totalSupply"
 							:fraction-digits="Number(token.metadata?.decimals || 0)"
 						/>
 					</TableTd>

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -2875,7 +2875,7 @@ export type Token = {
   tokenAddress: Scalars['String'];
   tokenEvents?: Maybe<TokenEventsCollectionSegment>;
   tokenId: Scalars['String'];
-  totalSupply: Scalars['Decimal'];
+  totalSupply: Scalars['BigInteger'];
 };
 
 


### PR DESCRIPTION
## Purpose

Token amounts are up to 256 bits so they don't fit into a decimal.

I believe this should be sufficient since all the actual updates to the amount are via SQL, and there the value that is added is always a BigInteger. So the value stored in the database is always an integer.

But ideally that would also be changed in the column type from "numeric" to "biginteger'.

The "decimal" makes it so that tokens cannot be read from the database and in particular the data migration job fails sometimes.
```
2024-02-17 19:30:10.575 [EROR] [Application.Jobs.JobsBackgroundService`2[[Application.Aggregates.Contract.Jobs.IContractJob, Application, Version=1.8.13.0, Culture=neutral, PublicKeyToken=null],[Application.Aggregates.Contract.Entities.ContractJob, Application, Version=1.8.13.0, Culture=neutral, PublicKeyToken=null]]] [00-e70217de8bab75aa8e02c36b2eb3746f-3725c7d03603a88f-00] _06_AddTokenAddress didn't succeed successfully due to exception.
System.OverflowException: Numeric value does not fit in a System.Decimal
```

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
