### PR TITLE
Export fix

### DIFF
--- a/backend/Application/Api/Rest/EnumerableFileResult.cs
+++ b/backend/Application/Api/Rest/EnumerableFileResult.cs
@@ -1,0 +1,75 @@
+/// https://github.com/philipmat/EnumerableStreamFileResult
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using System.IO;
+
+namespace EnumerableStreamFileResult
+{
+    class EnumerableFileResult<T> : FileResult
+    {
+        private readonly IEnumerable<T> _enumeration;
+        private readonly IStreamWritingAdapter<T> _writer;
+
+        public EnumerableFileResult(IEnumerable<T> enumeration, IStreamWritingAdapter<T> writer)
+            : base(writer.ContentType)
+        {
+            _enumeration = enumeration ?? throw new ArgumentNullException(nameof(enumeration));
+            _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        }
+
+        public override async Task ExecuteResultAsync(ActionContext context)
+        {
+            SetContentType(context);
+            SetContentDispositionHeader(context);
+
+            await WriteContentAsync(context).ConfigureAwait(false);
+        }
+
+        private async Task WriteContentAsync(ActionContext context)
+        {
+            var body = context.HttpContext.Response.Body;
+            await _writer.WriteHeaderAsync(body).ConfigureAwait(false);
+            int recordCount = 0;
+            foreach (var item in _enumeration)
+            {
+                await _writer.WriteAsync(item, body).ConfigureAwait(false);
+                recordCount++;
+            }
+
+            await _writer.WriteFooterAsync(body, recordCount);
+
+            await base.ExecuteResultAsync(context).ConfigureAwait(false);
+        }
+
+        private void SetContentDispositionHeader(ActionContext context)
+        {
+            var headers = context.HttpContext.Response.Headers;
+            var cd = new System.Net.Mime.ContentDisposition
+            {
+                FileName = FileDownloadName,
+                Inline = false, // false = attachement
+            };
+
+            headers.Add(
+                "Content-Disposition",
+                new Microsoft.Extensions.Primitives.StringValues(cd.ToString()));
+        }
+
+        private void SetContentType(ActionContext context)
+        {
+            var response = context.HttpContext.Response;
+            response.ContentType = ContentType;
+        }
+    }
+
+    internal interface IStreamWritingAdapter<T>
+    {
+       string ContentType { get; }
+
+        Task WriteHeaderAsync(Stream stream);
+
+        Task WriteAsync(T item, Stream stream);
+
+        Task WriteFooterAsync(Stream stream, int recordCount); 
+    }
+}

--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -45,7 +45,7 @@ public class ExportController : ControllerBase
 
         var query = dbContext.AccountStatementEntries
             .AsNoTracking()
-            .OrderByDescending(x => x.Index)
+            .OrderByDescending(x => x.Timestamp)
             .Where(x => x.AccountId == account.Id)
             ;
 
@@ -79,10 +79,9 @@ public class ExportController : ControllerBase
          x.EntryType
         )
         );
-        var csv = new StringBuilder("");
-    
+
         return new EnumerableFileResult<string>(result, new StreamWritingAdapter()) {
-            FileDownloadName = "statement-{accountAddress}_{firstTime:yyyyMMddHHmmss}Z-{lastTime:yyyyMMddHHmmss}Z.csv"
+            FileDownloadName = $"statement-{accountAddress}_{from:yyyyMMdd}Z-{to:yyyyMMdd}Z.csv"
         };
     }
     private class StreamWritingAdapter : IStreamWritingAdapter<String>

--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -90,14 +90,14 @@ public class ExportController : ControllerBase
 
         public async Task WriteAsync(string item, Stream stream)
         {
-            byte[] line = Encoding.UTF8.GetBytes(item);
+            byte[] line = Encoding.ASCII.GetBytes(item);
             await stream.WriteAsync(line);
         }
 
         public Task WriteFooterAsync(Stream stream, int recordCount) => Task.CompletedTask;
         public async Task WriteHeaderAsync(Stream stream)
         {
-            byte[] line = Encoding.UTF8.GetBytes("Time,Amount (CCD),Balance (CCD),Label\n");
+            byte[] line = Encoding.ASCII.GetBytes("Time,Amount (CCD),Balance (CCD),Label\n");
             await stream.WriteAsync(line);
         }
     }

--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -46,9 +46,7 @@ public class ExportController : ControllerBase
         var query = dbContext.AccountStatementEntries
             .AsNoTracking()
             .OrderByDescending(x => x.Timestamp)
-            .Where(x => x.AccountId == account.Id)
-            ;
-
+            .Where(x => x.AccountId == account.Id);
 
         if (fromTime != null && fromTime.Value.Kind != DateTimeKind.Utc)
         {
@@ -72,15 +70,17 @@ public class ExportController : ControllerBase
         query = query.Where(e => e.Timestamp >= from);
         query = query.Where(e => e.Timestamp <= to);
 
-        var result = query.Select(x => string.Format("{0}, {1}, {2}, {3}\n", 
-        x.Timestamp.ToString("u"), 
-        (x.Amount / (decimal)CcdAmount.MicroCcdPerCcd).ToString(CultureInfo.InvariantCulture),
-        (x.AccountBalance / (decimal)CcdAmount.MicroCcdPerCcd).ToString(CultureInfo.InvariantCulture),
-         x.EntryType
-        )
+        var result = query.Select(x => string.Format(
+            "{0}, {1}, {2}, {3}\n",
+            x.Timestamp.ToString("u"),
+            (x.Amount / (decimal)CcdAmount.MicroCcdPerCcd).ToString(CultureInfo.InvariantCulture),
+            (x.AccountBalance / (decimal)CcdAmount.MicroCcdPerCcd).ToString(CultureInfo.InvariantCulture),
+            x.EntryType
+            )
         );
 
-        return new EnumerableFileResult<string>(result, new StreamWritingAdapter()) {
+        return new EnumerableFileResult<string>(result, new StreamWritingAdapter())
+        {
             FileDownloadName = $"statement-{accountAddress}_{from:yyyyMMdd}Z-{to:yyyyMMdd}Z.csv"
         };
     }

--- a/backend/Application/Api/Rest/ExportController.cs
+++ b/backend/Application/Api/Rest/ExportController.cs
@@ -55,14 +55,14 @@ public class ExportController : ControllerBase
             return BadRequest("Time zone missing on 'fromTime'.");
         }
 
-        DateTimeOffset from = fromTime ?? DateTime.Now.AddDays(-31);
+        DateTimeOffset from = fromTime ?? DateTime.UtcNow.AddDays(-31);
 
         if (toTime != null && toTime.Value.Kind != DateTimeKind.Utc)
         {
             return BadRequest("Time zone missing on 'toTime'.");
         }
 
-        DateTimeOffset to = toTime ?? DateTime.Now;
+        DateTimeOffset to = toTime ?? DateTime.UtcNow;
 
         if ((to - from).TotalDays > MAX_DAYS)
         {
@@ -84,20 +84,20 @@ public class ExportController : ControllerBase
             FileDownloadName = $"statement-{accountAddress}_{from:yyyyMMdd}Z-{to:yyyyMMdd}Z.csv"
         };
     }
-    private class StreamWritingAdapter : IStreamWritingAdapter<String>
+    private class StreamWritingAdapter : IStreamWritingAdapter<string>
     {
         public string ContentType => "text/csv";
 
         public async Task WriteAsync(string item, Stream stream)
         {
-            byte[] line = Encoding.ASCII.GetBytes(item);
+            byte[] line = Encoding.UTF8.GetBytes(item);
             await stream.WriteAsync(line);
         }
 
         public Task WriteFooterAsync(Stream stream, int recordCount) => Task.CompletedTask;
         public async Task WriteHeaderAsync(Stream stream)
         {
-            byte[] line = Encoding.ASCII.GetBytes("Time,Amount (CCD),Balance (CCD),Label\n");
+            byte[] line = Encoding.UTF8.GetBytes("Time,Amount (CCD),Balance (CCD),Label\n");
             await stream.WriteAsync(line);
         }
     }

--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <Version>1.8.18</Version>
+        <Version>1.8.19</Version>
         <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
         <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
         <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 1.8.19
+- Bugfix
+    - Fix performance of account statement export, by adding an index on table `graphql_account_statement_entries`, and streaming the data.
+
 ## 1.8.18
 - Bugfix
     - Fix performance view `graphql_account_rewards` by adding an index on table `graphql_account_statement_entries`.

--- a/backend/DatabaseScripts/SqlScripts/0054_create_index_on_graphql_account_statement_for_timestamp.sql
+++ b/backend/DatabaseScripts/SqlScripts/0054_create_index_on_graphql_account_statement_for_timestamp.sql
@@ -1,4 +1,4 @@
 /*
- Creates an index for rewards on graphql_account_statement_entries which is used by view graphql_account_rewards
+ Creates an index on time on graphql_account_statement_entries which is used by account statement export
  */
 create index account_statement_entries_account_id_index_rewards_timestamp on graphql_account_statement_entries (account_id, time);

--- a/backend/DatabaseScripts/SqlScripts/0054_create_index_on_graphql_account_statement_for_timestampsql
+++ b/backend/DatabaseScripts/SqlScripts/0054_create_index_on_graphql_account_statement_for_timestampsql
@@ -1,0 +1,4 @@
+/*
+ Creates an index for rewards on graphql_account_statement_entries which is used by view graphql_account_rewards
+ */
+create index account_statement_entries_account_id_index_rewards_timestamp on graphql_account_statement_entries (account_id, time);

--- a/backend/Tests/Api/Rest/ExportControllerTest.cs
+++ b/backend/Tests/Api/Rest/ExportControllerTest.cs
@@ -72,7 +72,7 @@ public sealed class ExportControllerTest : IAsyncLifetime
         var controller = new ExportController(_testHelper.dbContextFactory);
         var address = "3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P";
 
-        MemoryStream stream = new MemoryStream();
+        MemoryStream stream = new();
         var _headers = new HeaderDictionary();
 
         var httpResponseMock = new Mock<HttpResponse>();
@@ -104,7 +104,6 @@ public sealed class ExportControllerTest : IAsyncLifetime
         var result = Assert.IsType<EnumerableFileResult<string>>(actionResult);
         await result.ExecuteResultAsync(_controllerContext);
         string csv = System.Text.Encoding.ASCII.GetString(stream.ToArray());
-        Console.WriteLine($"csv: {csv}");
 
         // Assert
         Regex.Matches(csv, "\n").Count.Should().Be(2);

--- a/backend/Tests/Api/Rest/ExportControllerTest.cs
+++ b/backend/Tests/Api/Rest/ExportControllerTest.cs
@@ -103,7 +103,7 @@ public sealed class ExportControllerTest : IAsyncLifetime
         var actionResult = await controller.GetStatementExport(address, startDate, endDate);
         var result = Assert.IsType<EnumerableFileResult<string>>(actionResult);
         await result.ExecuteResultAsync(_controllerContext);
-        string csv = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        string csv = System.Text.Encoding.ASCII.GetString(stream.ToArray());
         Console.WriteLine($"csv: {csv}");
 
         // Assert

--- a/backend/Tests/Api/Rest/ExportControllerTest.cs
+++ b/backend/Tests/Api/Rest/ExportControllerTest.cs
@@ -5,6 +5,8 @@ using Application.Database;
 using FluentAssertions;
 using Tests.TestUtilities;
 using Tests.TestUtilities.Builders.GraphQL;
+using Ductus.FluentDocker.Common;
+using System.IO;
 
 namespace Tests.Api.Rest;
 
@@ -80,11 +82,15 @@ public sealed class ExportControllerTest : IAsyncLifetime
 
         // Act
         var actionResult = await controller.GetStatementExport(address, startDate, endDate);
-        var result = Assert.IsType<FileContentResult>(actionResult);
-        string csv = System.Text.Encoding.UTF8.GetString(result.FileContents);
+        var result = Assert.IsType<FileStreamResult>(actionResult);
+        );
+
+        using StreamReader reader = new(result.FileStream, System.Text.Encoding.UTF8);
+        string csv = reader.ReadToEnd();
 
         // Assert
         Regex.Matches(csv, "\n").Count.Should().Be(2);
+
     }
 
 }


### PR DESCRIPTION
## Purpose

Avoid big accounts to timeout (at 30 seconds) when using the export. 

## Changes

- Add index for account statements on account_id and time.
- Change query to stream data, instead of building a big string.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
