### PR TITLE
Fix bug that blocked exporting account statement for first month in frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.5.40",
+	"version": "1.5.41",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
+++ b/frontend/src/components/Accounts/AccountDetailsAccountStatement.vue
@@ -1,4 +1,4 @@
-﻿<template>
+<template>
 	<div>
 		<Table>
 			<TableHead>
@@ -212,6 +212,8 @@ type Props = {
 const props = defineProps<Props>()
 
 const createdAtMonth = new Date(props.accountCreatedAt)
+// Set createdAtMonth date to first in the month, because otherwise the Month picker will not include that month.
+createdAtMonth.setUTCDate(0)
 const currentMonth = NOW.value
 const chosenMonth = ref(toMonthInput(currentMonth))
 


### PR DESCRIPTION
## Purpose

Allow exporting account statements for the month that an account was created

## Changes

Set createdAtMonth used for month picker to first day in the month (instead of the specific day the account was created)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
