### PR TITLE
Fix "unsupported Unicode escape sequence" in DataRegistered event

### DIFF
--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -3661,7 +3661,9 @@ impl DecodedText {
     fn from_bytes(bytes: &[u8]) -> Self {
         if let Ok(text) = ciborium::from_reader::<String, _>(bytes) {
             Self {
-                text,
+                text: match text.as_str() {
+                    "\0" => String::from("none"),
+                    _ => text,
                 decode_type: TextDecodeType::Cbor,
             }
         } else {


### PR DESCRIPTION


## Purpose

When the indexer run to the 2875786 block, it got error "Failed saving block: error returned from database: unsupported Unicode escape sequence". The event has decoded text String("\0") mean null, which does not support by Postgresql. The solution is return a string "none" if the decoded value is null
## Changes

in struct DecodedText, edit method from_bytes from:
` Self {
                text: match text.as_str() {
                    "\0" => String::from("none"),
                    _ => text,
                },
                decode_type: TextDecodeType::Cbor,
            }`

to 
` Self {
                text: match text.as_str() {
                    "\0" => String::from("none"),
                    _ => text,
                },
                decode_type: TextDecodeType::Cbor,
            }`
