### PR TITLE
Implements `IModuleReadonlyRepository` trait on `IContractRepository`

### DIFF
--- a/backend/Application/Aggregates/Contract/Jobs/_04_InitialContractEventDeserializationFieldsCatchUpJob.cs
+++ b/backend/Application/Aggregates/Contract/Jobs/_04_InitialContractEventDeserializationFieldsCatchUpJob.cs
@@ -334,6 +334,16 @@ WHERE g0.event ->> 'tag' = '16'
         {
             throw new NotImplementedException();
         }
+
+        public Task<ModuleReferenceEvent> GetModuleReferenceEventAsync(string moduleReference)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ModuleReferenceEvent> GetModuleReferenceEventAtAsync(ContractAddress contractAddress, ulong blockHeight, ulong transactionIndex, uint eventIndex)
+        {
+            throw new NotImplementedException();
+        }
     }
     
     /// <summary>

--- a/backend/Application/Aggregates/Contract/Jobs/_05_CisEventReinitialization.cs
+++ b/backend/Application/Aggregates/Contract/Jobs/_05_CisEventReinitialization.cs
@@ -309,5 +309,15 @@ ORDER BY block_height, transaction_index, event_index
         {
             throw new NotImplementedException();
         }
+
+        public Task<ModuleReferenceEvent> GetModuleReferenceEventAsync(string moduleReference)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ModuleReferenceEvent> GetModuleReferenceEventAtAsync(ContractAddress contractAddress, ulong blockHeight, ulong transactionIndex, uint eventIndex)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
## Purpose
Fixes the reported error
```
2024-06-06 07:17:05.588 [DBUG] [Application.Aggregates.Contract.ContractAggregate] [00-21a79dd04dd68545abe08571361feafe-b5438bc22109a2d6-00] Reading block a38f0e17c1aa481248d555bbf9a57f5487425782b580731beba12da336c2bd50, at height 2566608
2024-06-06 07:17:05.597 [EROR] [Application.Aggregates.Contract.ContractAggregate] [00-21a79dd04dd68545abe08571361feafe-5d8d4989a06a906f-00] Got exception running NodeImportJob will try again with 21552
System.InvalidOperationException: Sequence contains no elements.
   at Microsoft.EntityFrameworkCore.Query.ShapedQueryCompilingExpressionVisitor.SingleAsync[TSource](IAsyncEnumerable`1 asyncEnumerable, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.ShapedQueryCompilingExpressionVisitor.SingleAsync[TSource](IAsyncEnumerable`1 asyncEnumerable, CancellationToken cancellationToken)
   at Application.Api.GraphQL.Transactions.ContractInitialized.ParseEvents(IModuleReadonlyRepository moduleReadonlyRepository) in /src/Application/Api/GraphQL/Transactions/TransactionResultEvent.cs:line 579
   at Application.Api.GraphQL.Transactions.ContractInitialized.TryUpdateWithParsedEvents(IModuleReadonlyRepository moduleReadonlyRepository) in /src/Application/Api/GraphQL/Transactions/TransactionResultEvent.cs:line 561
   at Application.Aggregates.Contract.ContractAggregate.StoreEvent(ImportSource source, IContractRepository contractRepository, IModuleReadonlyRepository moduleReadonlyRepository, IContractNodeClient client, TransactionResultEvent transactionResultEvent, AccountAddress sender, UInt64 blockHeight, DateTimeOffset blockSlotTime, String transactionHash, UInt64 transactionIndex, UInt32 eventIndex) in /src/Application/Aggregates/Contract/ContractAggregate.cs:line 416
   at Application.Aggregates.Contract.ContractAggregate.StoreEvents(IContractRepository contractRepository, IModuleReadonlyRepository moduleReadonlyRepository, IContractNodeClient client, BlockInfo blockInfo, AccountTransactionDetails details, BlockItemSummary blockItemSummary) in /src/Application/Aggregates/Contract/ContractAggregate.cs:line 494
   at Application.Aggregates.Contract.ContractAggregate.NodeImport(IContractRepository repository, IContractNodeClient client, UInt64 height, CancellationToken token) in /src/Application/Aggregates/Contract/ContractAggregate.cs:line 109
   at Application.Aggregates.Contract.ContractAggregate.NodeImport(IContractRepository repository, IContractNodeClient client, UInt64 height, CancellationToken token) in /src/Application/Aggregates/Contract/ContractAggregate.cs:line 101
   at Application.Aggregates.Contract.ContractAggregate.NodeImport(IContractRepository repository, IContractNodeClient client, UInt64 height, CancellationToken token) in /src/Application/Aggregates/Contract/ContractAggregate.cs:line 113
   at Application.Aggregates.Contract.ContractAggregate.NodeImportRange(IContractNodeClient client, UInt64 fromBlockHeight, UInt64 toBlockHeight, CancellationToken token) in /src/Application/Aggregates/Contract/ContractAggregate.cs:line 529
   at Application.Aggregates.Contract.ContractAggregate.NodeImportRange(IContractNodeClient client, UInt64 fromBlockHeight, UInt64 toBlockHeight, CancellationToken token) in /src/Application/Aggregates/Contract/ContractAggregate.cs:line 540
   at Application.Aggregates.Contract.ContractAggregate.NodeImportJob(IContractNodeClient client, CancellationToken token) in /src/Application/Aggregates/Contract/ContractAggregate.cs:line 63
```

## Changes

Implements `IModuleReadonlyRepository` for `IContractRepository`. 
This is needed because in the `ContractAggregate` class `contractRepository` is being used to add a `ModuleReferenceEvent` while `IModuleReadonlyRepository` was being used to read them. Saving the txn only after the complete block has been saved. 

Therefore causing exception on trying to find the module when the contract is initialized and module is deployed in the same block

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
