### PR TITLE
Support Concordium Protocol Version 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,16 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
-    
+
     - name: Restore dependencies
       run: dotnet restore ./backend/CcScan.Backend.sln
-    
+
     - name: Build
       run: dotnet build ./backend/CcScan.Backend.sln -c Release --no-restore
 
     - name: Test
-      run: dotnet test ./backend/CcScan.Backend.sln --filter Category!=IntegrationTests -c Release --no-build --verbosity normal
+      run: |
+        # Tests depend on docker-compose being available due to this issue https://github.com/mariotoffia/FluentDocker/issues/312.
+        # The soft linking should be remove when a fix is released.
+        ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
+        dotnet test ./backend/CcScan.Backend.sln --filter Category!=IntegrationTests -c Release --no-build --verbosity normal

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "backend/concordium-net-sdk"]
+	path = backend/concordium-net-sdk
+	url = ../concordium-net-sdk.git

--- a/backend/Application/Api/GraphQL/Import/AccountWriter.cs
+++ b/backend/Application/Api/GraphQL/Import/AccountWriter.cs
@@ -8,6 +8,7 @@ using Application.Common.Diagnostics;
 using Dapper;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
+using Concordium.Sdk.Types;
 
 namespace Application.Api.GraphQL.Import;
 
@@ -157,20 +158,23 @@ public class AccountWriter
     public async Task UpdateAccount<TSource>(TSource item, Func<TSource, ulong> delegatorIdSelector, Action<TSource, Account> updateAction)
     {
         using var counter = _metrics.MeasureDuration(nameof(AccountWriter), nameof(UpdateAccount));
-        
+
         await using var context = await _dbContextFactory.CreateDbContextAsync();
         var delegatorId = (long)delegatorIdSelector(item);
 
         var account = await context.Accounts.SingleAsync(x => x.Id == delegatorId);
         updateAction(item, account);
-        
+
         await context.SaveChangesAsync();
     }
-    
+
+    /// <summary>
+    /// Update using <paramref name="updateAction"/> on each account with a pending change for delegation that is effective before <paramref name="effectiveTimeEqualOrBefore"/>.
+    /// </summary>
     public async Task UpdateAccountsWithPendingDelegationChange(DateTimeOffset effectiveTimeEqualOrBefore, Action<Account> updateAction)
     {
         using var counter = _metrics.MeasureDuration(nameof(AccountWriter), nameof(UpdateAccountsWithPendingDelegationChange));
-        
+
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
         var sql = $"select * from graphql_accounts where delegation_pending_change->'data'->>'EffectiveTime' <= '{effectiveTimeEqualOrBefore:O}'";
@@ -202,7 +206,31 @@ public class AccountWriter
             await context.SaveChangesAsync();
         }
     }
-    
+
+    /// <summary>
+    /// Remove baker and move its delegators to the passive pool.
+    /// Returns the number of delegators which were moved.
+    /// </summary>
+    public async Task<int> RemoveBaker(BakerId bakerId, DateTimeOffset effectiveTime) {
+        using var counter = _metrics.MeasureDuration(nameof(AccountWriter), nameof(RemoveBaker));
+        await using var context = await _dbContextFactory.CreateDbContextAsync();
+
+        var baker = await context.Bakers.SingleAsync(x => x.BakerId == (long)bakerId.Id.Index);
+        baker.State = new Bakers.RemovedBakerState(effectiveTime);
+
+        var target = new BakerDelegationTarget((long) bakerId.Id.Index);
+        var delegatorAccounts = await context.Accounts
+             .Where(account => account.Delegation != null && account.Delegation.DelegationTarget == target)
+             .ToArrayAsync();
+        foreach (var delegatorAccount in delegatorAccounts) {
+            var delegation = delegatorAccount.Delegation ?? throw new InvalidOperationException("Account delegating to baker target being removed has no delegation attached.");
+            delegation.DelegationTarget = new PassiveDelegationTarget();
+        }
+
+        await context.SaveChangesAsync();
+        return delegatorAccounts.Length;
+    }
+
     public async Task UpdateDelegationStakeIfRestakingEarnings(AccountRewardSummary[] stakeUpdates)
     {
         using var counter = _metrics.MeasureDuration(nameof(AccountWriter), nameof(UpdateDelegationStakeIfRestakingEarnings));

--- a/backend/Application/Api/GraphQL/Import/AccountWriter.cs
+++ b/backend/Application/Api/GraphQL/Import/AccountWriter.cs
@@ -215,7 +215,7 @@ public class AccountWriter
         using var counter = _metrics.MeasureDuration(nameof(AccountWriter), nameof(RemoveBaker));
         await using var context = await _dbContextFactory.CreateDbContextAsync();
 
-        var baker = await context.Bakers.SingleAsync(x => x.BakerId == (long)bakerId.Id.Index);
+        var baker = await context.Bakers.SingleAsync(x => x.Id == (long)bakerId.Id.Index);
         baker.State = new Bakers.RemovedBakerState(effectiveTime);
 
         var target = new BakerDelegationTarget((long) bakerId.Id.Index);

--- a/backend/Application/Api/GraphQL/Import/DelegationImportHandler.cs
+++ b/backend/Application/Api/GraphQL/Import/DelegationImportHandler.cs
@@ -16,45 +16,68 @@ public class DelegationImportHandler
         _logger = Log.ForContext<DelegationImportHandler>();
     }
 
+    /// <summary>
+    /// Process delegation related information from a block.
+    /// </summary>
     public async Task<DelegationUpdateResults> HandleDelegationUpdates(BlockDataPayload payload,
-        ChainParameters chainParameters, BakerUpdateResults bakerUpdateResults, RewardsSummary rewardsSummary, 
+        ChainParameters chainParameters, BakerUpdateResults bakerUpdateResults, RewardsSummary rewardsSummary,
         BlockImportPaydayStatus importPaydayStatus)
     {
         var resultBuilder = new DelegationUpdateResultsBuilder();
 
-        if (payload.BlockInfo.ProtocolVersion.AsInt() < 4) return resultBuilder.Build();
+        // Delegation was introduced as part of Concordium Protocol Version 4,
+        // meaning we can just return for blocks from a protocol version prior to that.
+        if (payload.BlockInfo.ProtocolVersion < ProtocolVersion.P4) return resultBuilder.Build();
 
-        if (!ChainParameters.TryGetDelegatorCooldown(chainParameters, out var delegatorCooldown))
-        {
-            throw new InvalidOperationException("Delegator cooldown expected for protocol version 4 and above");
+        // Handle effective pending changes for delegators and update the resultBuilder.
+        if (importPaydayStatus is FirstBlockAfterPayday firstBlockAfterPayday) {
+            if (payload.BlockInfo.ProtocolVersion < ProtocolVersion.P7) {
+                // Stake changes only take effect from the first block in each payday.
+                await _writer.UpdateAccountsWithPendingDelegationChange(firstBlockAfterPayday.PaydayTimestamp,
+                    account => ApplyPendingChange(account, resultBuilder));
+            } else if (payload.BlockInfo.ProtocolVersion == ProtocolVersion.P7) {
+                // Starting from Concordium Protocol Version 7 stake changes are immediate,
+                // meaning no delegators are expected to have pending changes from this point.
+                // Only the first reward day in P7 should this do anything, afterwards it is a
+                // no-op, since no accounts with pending changes are expected.
+                await _writer.UpdateAccountsWithPendingDelegationChange(DateTimeOffset.MaxValue,
+                    account => ApplyPendingChange(account, resultBuilder));
+            }
         }
 
-        if (importPaydayStatus is FirstBlockAfterPayday firstBlockAfterPayday)
-            await _writer.UpdateAccountsWithPendingDelegationChange(firstBlockAfterPayday.PaydayTimestamp,
-                account => ApplyPendingChange(account, resultBuilder));
-
+        // Handle delegation state changes due to pools that are either removed or closed for delegation.
         await HandleBakersRemovedOrClosedForAll(bakerUpdateResults, resultBuilder);
 
-        var txEvents = payload.BlockItemSummaries.Where(b => b.IsSuccess())
+        var delegationConfigureEvents = payload.BlockItemSummaries.Where(b => b.IsSuccess())
             .Select(b => b.Details as AccountTransactionDetails)
             .Where(atd => atd is not null)
             .Select(atd => atd!.Effects as DelegationConfigured)
             .Where(d => d is not null)
             .Select(d => d!);
 
-        await UpdateDelegationFromTransactionEvents(txEvents, payload.BlockInfo, delegatorCooldown!.Value, resultBuilder);
+        // Get the current cooldown parameter for delegation.
+        if (!ChainParameters.TryGetDelegatorCooldown(chainParameters, out var delegatorCooldownOut))
+        {
+            throw new InvalidOperationException("Delegator cooldown expected for protocol version 4 and above");
+        }
+        var delegatorCooldown = delegatorCooldownOut!.Value; // Safe since we throw for the failing case above.
+
+        await UpdateDelegationFromTransactionEvents(delegationConfigureEvents, payload.BlockInfo, delegatorCooldown, resultBuilder);
         await _writer.UpdateDelegationStakeIfRestakingEarnings(rewardsSummary.AggregatedAccountRewards);
-            
+
         resultBuilder.SetTotalAmountStaked(await _writer.GetTotalDelegationAmountStaked());
 
         return resultBuilder.Build();
     }
 
+    /// <summary>
+    /// Iterate removed and closed pools, moves the delegators to target the passive pool and updates the account delegation information and updates <paramref name="resultBuilder"/>.
+    /// </summary>
     private async Task HandleBakersRemovedOrClosedForAll(BakerUpdateResults bakerUpdateResults, DelegationUpdateResultsBuilder resultBuilder)
     {
         var bakerIds = bakerUpdateResults.BakerIdsRemoved
             .Concat(bakerUpdateResults.BakerIdsClosedForAll);
-            
+
         foreach (var bakerId in bakerIds)
         {
             var target = new BakerDelegationTarget(bakerId);
@@ -68,6 +91,11 @@ public class DelegationImportHandler
         }
     }
 
+    /// <summary>
+    /// Update/Apply delegation state on the <paramref name="account"/> with the pending change.
+    /// Records the stake change in <paramref name="resultsBuilder"/>.
+    /// Throws if <paramref name="account"/> is not delegating.
+    /// </summary>
     private void ApplyPendingChange(Account account, DelegationUpdateResultsBuilder resultsBuilder)
     {
         var delegation = account.Delegation ?? throw new InvalidOperationException("Apply pending delegation change to an account that has no delegation!");
@@ -108,8 +136,13 @@ public class DelegationImportHandler
                             (_, dst) =>
                             {
                                 if (dst.Delegation == null) throw new InvalidOperationException("Trying to set pending change to remove delegation on an account without a delegation instance!");
-                                var effectiveTime = blockInfo.BlockSlotTime.AddSeconds(delegatorCooldown);
-                                dst.Delegation.PendingChange = new PendingDelegationRemoval(effectiveTime);
+                                if (blockInfo.ProtocolVersion < ProtocolVersion.P7) {
+                                    var effectiveTime = blockInfo.BlockSlotTime.AddSeconds(delegatorCooldown);
+                                    dst.Delegation.PendingChange = new PendingDelegationRemoval(effectiveTime);
+                                } else {
+                                    resultBuilder.DelegationTargetRemoved(dst.Delegation.DelegationTarget);
+                                    dst.Delegation = null;
+                                }
                             });
                         break;
                     case DelegationSetDelegationTarget delegationSetDelegationTarget:
@@ -139,8 +172,12 @@ public class DelegationImportHandler
                             (src, dst) =>
                             {
                                 if (dst.Delegation == null) throw new InvalidOperationException("Trying to set pending change to remove delegation on an account without a delegation instance!");
-                                var effectiveTime = blockInfo.BlockSlotTime.AddSeconds(delegatorCooldown);
-                                dst.Delegation.PendingChange = new PendingDelegationReduceStake(effectiveTime, delegationStakeDecreased.NewStake.Value);
+                                if (blockInfo.ProtocolVersion < ProtocolVersion.P7) {
+                                    var effectiveTime = blockInfo.BlockSlotTime.AddSeconds(delegatorCooldown);
+                                    dst.Delegation.PendingChange = new PendingDelegationReduceStake(effectiveTime, delegationStakeDecreased.NewStake.Value);
+                                } else {
+                                    dst.Delegation.StakedAmount = src.NewStake.Value;
+                                }
                             });
                         break;
                     case DelegationStakeIncreased delegationStakeIncreased:
@@ -152,12 +189,30 @@ public class DelegationImportHandler
                                 dst.Delegation.StakedAmount = src.NewStake.Value;
                             });
                         break;
+                    case DelegationEventBakerRemoved bakerRemoved:
+                        // We can update the database immediately and without tracking a pending change
+                        // because this event was introduced as part of Protocol Version 7, where
+                        // pending changes are also removed.
+                        var delegationsMoveToPassive = await _writer.RemoveBaker(bakerRemoved.BakerId, blockInfo.BlockSlotTime);
+                        // Update the resultsBuilder with the moved delegations.
+                        var bakerTarget = new BakerDelegationTarget((long)bakerRemoved.BakerId.Id.Index);
+                        var passiveTarget = new PassiveDelegationTarget();
+                        for (int i = 0; i < delegationsMoveToPassive; i++)
+                        {
+                            resultBuilder.DelegationTargetRemoved(bakerTarget);
+                            resultBuilder.DelegationTargetAdded(passiveTarget);
+                        }
+                        break;
                 }
-                
+
             }
         }
     }
 
+    /// <summary>
+    /// Tracker of stake changes due to removed or reduced stake by delegators.
+    /// Later this will be used to update the stake of pools.
+    /// </summary>
     public class DelegationUpdateResultsBuilder
     {
         private readonly List<DelegationTarget> _delegationTargetsRemoved = new ();
@@ -183,7 +238,7 @@ public class DelegationImportHandler
                 })
                 .Where(x => x.DelegatorCountDelta != 0)
                 .ToArray();
-            
+
             return new DelegationUpdateResults(_totalAmountStaked, all);
         }
 

--- a/backend/Application/Api/GraphQL/Import/ImportWriteController.cs
+++ b/backend/Application/Api/GraphQL/Import/ImportWriteController.cs
@@ -125,7 +125,7 @@ public class ImportWriteController : BackgroundService
                         result.Block.BlockHeight,
                         result.Block.BlockSlotTime.ToUniversalTime().ToString());
                 
-                    await _accountBalanceValidator.PerformValidations(result.Block);
+                    await _accountBalanceValidator.PerformValidations(result.Block, envelope.Payload.BlockInfo.ProtocolVersion);
                 
                     if (result.Block.BlockHeight % 5000 == 0)
                         _metricsListener.DumpCapturedMetrics();

--- a/backend/Application/Api/GraphQL/Import/MetricsWriter.cs
+++ b/backend/Application/Api/GraphQL/Import/MetricsWriter.cs
@@ -262,7 +262,9 @@ where metrics_blocks.block_height = sub_query.block_height
             
             var stakeSnapshot = poolReward.Pool switch
             {
-                BakerPoolRewardTarget baker => paydayPoolStakeSnapshot.Items.Single(x => x.BakerId == baker.BakerId),
+                BakerPoolRewardTarget baker =>
+                    // Find the active baker stake, otherwise the baker was removed and empty stake is used.
+                    paydayPoolStakeSnapshot.Items.SingleOrDefault(x => x.BakerId == baker.BakerId, PaydayPoolStakeSnapshotItem.Removed(baker.BakerId)),
                 PassiveDelegationPoolRewardTarget => new PaydayPoolStakeSnapshotItem(-1, 0, paydayPassiveDelegationStakeSnapshot.DelegatedStake),
                 _ => throw new NotImplementedException()
             };

--- a/backend/Application/Api/GraphQL/Import/PaydayPoolStakeSnapshot.cs
+++ b/backend/Application/Api/GraphQL/Import/PaydayPoolStakeSnapshot.cs
@@ -6,4 +6,8 @@ public record PaydayPoolStakeSnapshot(
 public record PaydayPoolStakeSnapshotItem(
     long BakerId,
     long BakerStake,
-    long DelegatedStake);
+    long DelegatedStake) {
+        public static PaydayPoolStakeSnapshotItem Removed(long bakerId) {
+            return new(bakerId, 0, 0);
+        }
+    };

--- a/backend/Application/Api/GraphQL/Import/Validations/AccountValidator.cs
+++ b/backend/Application/Api/GraphQL/Import/Validations/AccountValidator.cs
@@ -195,7 +195,8 @@ public class AccountValidator : IImportValidator
 
     private async Task ValidateBakers(ProtocolVersion protocolVersion, List<AccountBaker> nodeAccountBakers, Block block, GraphQlDbContext dbContext, SingleAccountValidationInfo? singleAccountAddress)
     {
-        _logger.Information($"Validating bakers in ${block.BlockHash}: ${nodeAccountBakers.Select(a=> a.BakerInfo.BakerId).ToString()}");
+       _logger.Information($"Validating bakers in {block.BlockHash}: ${nodeAccountBakers.Select(a=> a.BakerInfo.BakerId).ToString()}");
+
         var blockHeight = (ulong)block.BlockHeight;
         var blockHash = BlockHash.From(block.BlockHash);
         var given = new Given(blockHash);

--- a/backend/Application/Api/GraphQL/Import/Validations/AccountValidator.cs
+++ b/backend/Application/Api/GraphQL/Import/Validations/AccountValidator.cs
@@ -235,8 +235,8 @@ public class AccountValidator : IImportValidator
                             TransactionCommission = x.BakerPoolInfo.CommissionRates.TransactionCommission.AsDecimal(),
                             FinalizationCommission = x.BakerPoolInfo.CommissionRates.FinalizationCommission.AsDecimal(),
                             BakingCommission = x.BakerPoolInfo.CommissionRates.BakingCommission.AsDecimal(),
-                            DelegatedStake = bakerPoolStatus.DelegatedCapital.Value,
-                            DelegatedStakeCap = bakerPoolStatus.DelegatedCapitalCap.Value,
+                            DelegatedStake = bakerPoolStatus!.DelegatedCapital!.Value.Value,
+                            DelegatedStakeCap = bakerPoolStatus.DelegatedCapitalCap!.Value.Value,
                             PaydayStatus = bakerPoolStatus?.CurrentPaydayStatus == null ? null : new
                             {
                                 BakerStake = bakerPoolStatus.CurrentPaydayStatus.BakerEquityCapital.Value,

--- a/backend/Application/Api/GraphQL/Import/Validations/BalanceStatisticsValidator.cs
+++ b/backend/Application/Api/GraphQL/Import/Validations/BalanceStatisticsValidator.cs
@@ -20,7 +20,7 @@ public class BalanceStatisticsValidator : IImportValidator
         _logger = Log.ForContext<BalanceStatisticsValidator>();
     }
 
-    public async Task Validate(Block block)
+    public async Task Validate(Block block, ProtocolVersion _protocolVersion)
     {
         var nodeData = await _grpcNodeClient.GetTokenomicsInfoAsync(new Given(BlockHash.From(block.BlockHash)));
         if (nodeData.Response is RewardOverviewV1 rv1)

--- a/backend/Application/Api/GraphQL/Import/Validations/IImportValidator.cs
+++ b/backend/Application/Api/GraphQL/Import/Validations/IImportValidator.cs
@@ -1,9 +1,10 @@
 ﻿using System.Threading.Tasks;
 using Application.Api.GraphQL.Blocks;
+using Concordium.Sdk.Types;
 
 namespace Application.Api.GraphQL.Import.Validations;
 
 public interface IImportValidator
 {
-    Task Validate(Block block);
+    Task Validate(Block block, ProtocolVersion protocolVersion);
 }

--- a/backend/Application/Api/GraphQL/Import/Validations/ImportValidationController.cs
+++ b/backend/Application/Api/GraphQL/Import/Validations/ImportValidationController.cs
@@ -5,6 +5,7 @@ using Application.Configurations;
 using Concordium.Sdk.Client;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using Concordium.Sdk.Types;
 
 namespace Application.Api.GraphQL.Import.Validations;
 
@@ -27,14 +28,14 @@ public class ImportValidationController
         };
     }
 
-    public async Task PerformValidations(Block block)
+    public async Task PerformValidations(Block block, ProtocolVersion protocolVersion)
     {
         if (!_featureFlags.ConcordiumNodeImportValidationEnabled) return;
 
         if (block.BlockHeight % 10000 == 0)
         {
             foreach (var validator in _validators)
-                await validator.Validate(block);
+            await validator.Validate(block, protocolVersion);
         }
     }
 }

--- a/backend/Application/Api/GraphQL/Import/Validations/PassiveDelegationValidator.cs
+++ b/backend/Application/Api/GraphQL/Import/Validations/PassiveDelegationValidator.cs
@@ -3,6 +3,7 @@ using Application.Api.GraphQL.Blocks;
 using Application.Api.GraphQL.EfCore;
 using Application.Api.GraphQL.PassiveDelegations;
 using Concordium.Sdk.Client;
+using Concordium.Sdk.Types;
 using Dapper;
 using Microsoft.EntityFrameworkCore;
 
@@ -21,10 +22,9 @@ public class PassiveDelegationValidator : IImportValidator
         _logger = Log.ForContext<PassiveDelegationValidator>();
     }
 
-    public async Task Validate(Block block)
+    public async Task Validate(Block block, ProtocolVersion protocolVersion)
     {
-        var nodeInfo = await _nodeClient.GetNodeInfoAsync();
-        if (nodeInfo.Version.Major >= 4)
+        if (protocolVersion >= ProtocolVersion.P4)
         {
             var target = await ReadPassiveDelegation();
 

--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <Version>1.8.19</Version>
+        <Version>1.9.0</Version>
         <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
         <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
         <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>

--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -12,7 +12,6 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="ConcordiumNetSdk" Version="4.3.1" />
       <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="dbup-postgresql" Version="4.5.0" />
       <PackageReference Include="HotChocolate.AspNetCore" Version="13.5.1" />
@@ -36,6 +35,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\DatabaseScripts\DatabaseScripts.csproj" />
+      <ProjectReference Include="..\concordium-net-sdk\src\Concordium.Sdk.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/backend/Application/Import/ImportChannel.cs
+++ b/backend/Application/Import/ImportChannel.cs
@@ -102,6 +102,9 @@ public record GenesisBlockDataPayload : BlockDataPayload
     public IList<IpInfo> GenesisIdentityProviders { get; }
 }
 
+/// <summary>
+/// List of results from GetAccountInfo for accounts that have changed in this block.
+/// </summary>
 public record AccountInfosRetrieved(
     AccountInfo[] CreatedAccounts,
     AccountInfo[] BakersWithNewPendingChanges);

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased changes
 
+- Support Concordium Protocol Version 7.
+  - Transition between Delegation and Validating immediately.
+  - Stake changes are immediate.
+- Fix bug in validation which was branching on the node software version instead of the protocol version.
+
 ## 1.8.19
 - Bugfix
     - Fix performance of account statement export, by adding an index on table `graphql_account_statement_entries`, and streaming the data.

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
 
+## 1.9.0
 - Support Concordium Protocol Version 7.
   - Transition between Delegation and Validating immediately.
   - Stake changes are immediate.

--- a/backend/CcScan.Backend.sln
+++ b/backend/CcScan.Backend.sln
@@ -6,6 +6,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application", "Application\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DatabaseScripts", "DatabaseScripts\DatabaseScripts.csproj", "{F9322D66-8D55-466D-B7DF-04FBF2BD9341}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "concordium-net-sdk", "concordium-net-sdk", "{B970FDDA-8B7C-4DEE-9522-C51EB3D424B4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Concordium.Sdk", "concordium-net-sdk\src\Concordium.Sdk.csproj", "{84A4662D-9D85-482F-84C3-FB37C2894053}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +28,12 @@ Global
 		{F9322D66-8D55-466D-B7DF-04FBF2BD9341}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9322D66-8D55-466D-B7DF-04FBF2BD9341}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9322D66-8D55-466D-B7DF-04FBF2BD9341}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84A4662D-9D85-482F-84C3-FB37C2894053}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84A4662D-9D85-482F-84C3-FB37C2894053}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84A4662D-9D85-482F-84C3-FB37C2894053}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84A4662D-9D85-482F-84C3-FB37C2894053}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{84A4662D-9D85-482F-84C3-FB37C2894053} = {B970FDDA-8B7C-4DEE-9522-C51EB3D424B4}
 	EndGlobalSection
 EndGlobal

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,7 +1,16 @@
-# Introduction 
+# Introduction
 This is the backend of Concordium Scan.
 
 # Getting Started
+
+This project depends on [concordium-net-sdk](https://github.com/Concordium/concordium-net-sdk) as a Git Submodule, which can be installed using:
+
+```
+git submodule update --init --recursive
+```
+
+Check out the readme of this dependency for how to build it.
+
 ## Prerequisites
 The following prerequisites must be met in order to run the test suite and/or run the backend locally:
 

--- a/backend/Tests/Api/GraphQL/Import/AccountImportHandlerTest.cs
+++ b/backend/Tests/Api/GraphQL/Import/AccountImportHandlerTest.cs
@@ -78,7 +78,10 @@ namespace Tests.Api.GraphQL.Import
                         AccountAmount: CcdAmount.FromCcd(1),
                         AccountIndex: receiverAccountId,
                         AccountAddress: receiverAccount,
-                        null
+                        null,
+                        Schedule: ReleaseSchedule.Empty(),
+                        Cooldowns: new List<Concordium.Sdk.Types.Cooldown>(),
+                        AvailableBalance: CcdAmount.FromCcd(1)
                     )
                 },
                 Array.Empty<AccountInfo>());
@@ -143,11 +146,14 @@ namespace Tests.Api.GraphQL.Import
                         AccountAmount: CcdAmount.FromCcd(1),
                         AccountIndex: receiverAccountId,
                         AccountAddress: receiverAccount,
-                        null
+                        null,
+                        Schedule: ReleaseSchedule.Empty(),
+                        Cooldowns: new List<Concordium.Sdk.Types.Cooldown>(),
+                        AvailableBalance: CcdAmount.FromCcd(1)
                     )
                 },
-                Array.Empty<AccountInfo>());            
-            
+                Array.Empty<AccountInfo>());
+
             var blockDataPayload = new BlockDataPayloadBuilder()
                 .WithBlockInfo(blockInfo)
                 .WithBlockItemSummaries(new List<BlockItemSummary>())

--- a/backend/Tests/Api/GraphQL/Import/AccountLookupTest.cs
+++ b/backend/Tests/Api/GraphQL/Import/AccountLookupTest.cs
@@ -115,10 +115,13 @@ public class AccountLookupTest
         var clientMock = new Mock<IConcordiumNodeClient>();
         var accountInfo = new AccountInfo(
             AccountSequenceNumber.From(1UL),
-            CcdAmount.Zero, 
+            CcdAmount.Zero,
             new AccountIndex(accountIndex),
             AccountAddress.From(uniqueAddress),
-            null
+            null,
+            Schedule: ReleaseSchedule.Empty(),
+            Cooldowns: new List<Concordium.Sdk.Types.Cooldown>(),
+            AvailableBalance: CcdAmount.Zero
         );
         clientMock.Setup(m => m.GetAccountInfoAsync(It.IsAny<IAccountIdentifier>(), It.IsAny<IBlockHashInput>(),
                 It.IsAny<CancellationToken>()))

--- a/backend/Tests/Api/GraphQL/__snapshots__/committed-schema.verified.graphql
+++ b/backend/Tests/Api/GraphQL/__snapshots__/committed-schema.verified.graphql
@@ -2127,7 +2127,7 @@ enum AccountTransactionType {
   SIMPLE_TRANSFER
   "Transfer encrypted amount."
   ENCRYPTED_TRANSFER
-  "Same as transfer but with a memo field."
+  "Same as transfer, but with a memo field."
   SIMPLE_TRANSFER_WITH_MEMO
   "Same as encrypted transfer, but with a memo."
   ENCRYPTED_TRANSFER_WITH_MEMO
@@ -2196,9 +2196,9 @@ enum ContractVersion {
 
 "Enumeration of the types of credentials."
 enum CredentialDeploymentTransactionType {
-  "Initial credential is a credential that is submitted by the identity\nprovider on behalf of the user. There is only one initial credential\nper identity."
+  "Initial credential is a credential that is submitted by the identity\nprovider on behalf of the user. There is at most one initial credential\nper identity."
   INITIAL
-  "A normal credential is one where the identity behind it is only known to\nthe owner of the account, unless the anonymity revocation process was\nfollowed."
+  "A normal credential is one where the identity behind it is only known to\nthe owner of the account, unless the identity disclosure process was\nhas been initiated."
   NORMAL
 }
 

--- a/backend/Tests/Api/GraphQL/__snapshots__/committed-schema.verified.graphql
+++ b/backend/Tests/Api/GraphQL/__snapshots__/committed-schema.verified.graphql
@@ -2117,27 +2117,49 @@ enum AccountStatementEntryType {
   TRANSACTION_FEE_REWARD
 }
 
+"Types of account transactions."
 enum AccountTransactionType {
+  "Initialize a smart contract instance."
   INITIALIZE_SMART_CONTRACT_INSTANCE
+  "Update a smart contract instance."
   UPDATE_SMART_CONTRACT_INSTANCE
+  "Transfer CCD from an account to another."
   SIMPLE_TRANSFER
+  "Transfer encrypted amount."
   ENCRYPTED_TRANSFER
+  "Same as transfer but with a memo field."
   SIMPLE_TRANSFER_WITH_MEMO
+  "Same as encrypted transfer, but with a memo."
   ENCRYPTED_TRANSFER_WITH_MEMO
+  "Same as transfer with schedule, but with an added memo."
   TRANSFER_WITH_SCHEDULE_WITH_MEMO
+  "Deploy a Wasm module."
   DEPLOY_MODULE
+  "Register an account as a baker."
   ADD_BAKER
+  "Remove an account as a baker."
   REMOVE_BAKER
+  "Update the staked amount."
   UPDATE_BAKER_STAKE
+  "Update whether the baker automatically restakes earnings."
   UPDATE_BAKER_RESTAKE_EARNINGS
+  "Update baker keys"
   UPDATE_BAKER_KEYS
+  "Update given credential keys"
   UPDATE_CREDENTIAL_KEYS
+  "Transfer from public to encrypted balance of the same account."
   TRANSFER_TO_ENCRYPTED
+  "Transfer from encrypted to public balance of the same account."
   TRANSFER_TO_PUBLIC
+  "Transfer a CCD with a release schedule."
   TRANSFER_WITH_SCHEDULE
+  "Update the account's credentials."
   UPDATE_CREDENTIALS
+  "Register some data on the chain."
   REGISTER_DATA
+  "Configure an account's baker."
   CONFIGURE_BAKER
+  "Configure an account's stake delegation."
   CONFIGURE_DELEGATION
 }
 
@@ -2172,8 +2194,11 @@ enum ContractVersion {
   V1
 }
 
+"Enumeration of the types of credentials."
 enum CredentialDeploymentTransactionType {
+  "Initial credential is a credential that is submitted by the identity\nprovider on behalf of the user. There is only one initial credential\nper identity."
   INITIAL
+  "A normal credential is one where the identity behind it is only known to\nthe owner of the account, unless the anonymity revocation process was\nfollowed."
   NORMAL
 }
 
@@ -2234,29 +2259,53 @@ enum TextDecodeType {
   HEX
 }
 
+"The type of an update."
 enum UpdateTransactionType {
+  "Update of protocol version."
   UPDATE_PROTOCOL
+  "Update of the election difficulty."
   UPDATE_ELECTION_DIFFICULTY
+  "Update of conversion rate of Euro per energy."
   UPDATE_EURO_PER_ENERGY
+  "Update of conversion rate of CCD per Euro."
   UPDATE_MICRO_GTU_PER_EURO
+  "Update of account marked as foundation account."
   UPDATE_FOUNDATION_ACCOUNT
+  "Update of distribution of minted CCD."
   UPDATE_MINT_DISTRIBUTION
+  "Update of distribution of transaction fee."
   UPDATE_TRANSACTION_FEE_DISTRIBUTION
+  "Update of distribution of GAS rewards."
   UPDATE_GAS_REWARDS
+  "Update of minimum threshold for becoming a validator."
   UPDATE_BAKER_STAKE_THRESHOLD
+  "Introduce new Identity Disclosure Authority."
   UPDATE_ADD_ANONYMITY_REVOKER
+  "Introduce new Identity Provider."
   UPDATE_ADD_IDENTITY_PROVIDER
+  "Update of root keys."
   UPDATE_ROOT_KEYS
+  "Update of level1 keys."
   UPDATE_LEVEL1_KEYS
+  "Update of level2 keys."
   UPDATE_LEVEL2_KEYS
+  "Update of pool parameters."
   UPDATE_POOL_PARAMETERS
+  "Update of cooldown parameters."
   UPDATE_COOLDOWN_PARAMETERS
+  "Update of time parameters."
   UPDATE_TIME_PARAMETERS
+  "Update of distribution of minted CCD."
   MINT_DISTRIBUTION_CPV1_UPDATE
+  "Update of distribution of GAS rewards."
   GAS_REWARDS_CPV2_UPDATE
+  "Update of timeout parameters."
   TIMEOUT_PARAMETERS_UPDATE
+  "Update of min-block-time parameters."
   MIN_BLOCK_TIME_UPDATE
+  "Update of block energy limit parameters."
   BLOCK_ENERGY_LIMIT_UPDATE
+  "Update of finalization committee parameters."
   FINALIZATION_COMMITTEE_PARAMETERS_UPDATE
 }
 

--- a/backend/Tests/TestUtilities/DatabaseFixture.cs
+++ b/backend/Tests/TestUtilities/DatabaseFixture.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using Application.Api.GraphQL.EfCore;
 using Application.Database;
 using Dapper;
+using Ductus.FluentDocker.Model.Compose;
 using Ductus.FluentDocker.Builders;
 using Ductus.FluentDocker.Services;
 using Microsoft.EntityFrameworkCore;
@@ -32,6 +33,7 @@ public sealed class DatabaseFixture : IDisposable
         _service = new Builder()
             .UseContainer()
             .UseCompose()
+            .AssumeComposeVersion(ComposeVersion.V2)
             .FromFile(file)
             .RemoveOrphans()
             .WaitForPort("timescaledb-test", "5432/tcp", 30_000)


### PR DESCRIPTION
## Purpose

Prepare CCDScan for Concordium Protocol Version 7.

## Changes

- Fix CI due to `docker-compose` not being available in the ubuntu image anymore (see https://github.com/mariotoffia/FluentDocker/issues/312)
- Added concordium-net-sdk as submodule.
- Introduced some doc comments while learning the codebase.
- Fix bug in validation code, which branched on the node version instead of the protocol version of the block.
- Handle new events for configuring delegation and validators.
- Make stake changes immediate for protocol version 7 blocks and onwards, ignoring pending changes from this point on.