### PR TITLE
Compute APY using the expected payday duration instead of last duration

### DIFF
--- a/backend/Application/Api/GraphQL/ChainParameters.cs
+++ b/backend/Application/Api/GraphQL/ChainParameters.cs
@@ -197,6 +197,25 @@ public abstract class ChainParameters
                 throw new ArgumentOutOfRangeException(nameof(chainParameters));
         }
     }
+
+    /// <summary>
+    /// Attempt to extract the RewardPeriodLength from ChainParameters, this will only fail for ChainParameters of blocks prior to P4.
+    /// </summary>
+    internal static bool TryGetRewardPeriodLength(ChainParameters chainParameters, out ulong? rewardPeriodLength) {
+        switch (chainParameters) {
+            case ChainParametersV0:
+                rewardPeriodLength = null;
+                return false;
+            case ChainParametersV1 cpv1:
+                rewardPeriodLength = cpv1.RewardPeriodLength;
+                return true;
+            case ChainParametersV2 cpv2:
+                rewardPeriodLength = cpv2.RewardPeriodLength;
+                return true;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(chainParameters));
+        }
+    }
     
     
 }

--- a/backend/Application/Api/GraphQL/Import/ImportWriteController.cs
+++ b/backend/Application/Api/GraphQL/Import/ImportWriteController.cs
@@ -262,7 +262,7 @@ public class ImportWriteController : BackgroundService
         await _metricsWriter.AddAccountsMetrics(payload.BlockInfo, payload.AccountInfos.CreatedAccounts, importState);
         await _metricsWriter.AddBakerMetrics(payload.BlockInfo.BlockSlotTime, bakerUpdateResults, importState);
         _metricsWriter.AddRewardMetrics(payload.BlockInfo.BlockSlotTime, rewardsSummary);
-        _metricsWriter.AddPaydayPoolRewardMetrics(block, specialEvents, rewardsSummary, paydaySummary, bakerUpdateResults.PaydayPoolStakeSnapshot, passiveDelegationUpdateResults) ;
+        _metricsWriter.AddPaydayPoolRewardMetrics(block, specialEvents, rewardsSummary, paydaySummary, bakerUpdateResults.PaydayPoolStakeSnapshot, passiveDelegationUpdateResults, importState) ;
         
         var finalizationTimeUpdates = await _blockWriter.UpdateFinalizationTimeOnBlocksInFinalizationProof(payload.BlockInfo, importState);
         await _metricsWriter.UpdateFinalizationTimes(finalizationTimeUpdates);

--- a/backend/Application/Api/GraphQL/Import/MetricsWriter.cs
+++ b/backend/Application/Api/GraphQL/Import/MetricsWriter.cs
@@ -218,7 +218,7 @@ where metrics_blocks.block_height = sub_query.block_height
     /// </summary>
     public void AddPaydayPoolRewardMetrics(Block block, SpecialEvent[] specialEvents, RewardsSummary rewardsSummary,
         PaydaySummary? paydaySummary, PaydayPoolStakeSnapshot? paydayPoolStakeSnapshot,
-        PaydayPassiveDelegationStakeSnapshot? paydayPassiveDelegationStakeSnapshot)
+        PaydayPassiveDelegationStakeSnapshot? paydayPassiveDelegationStakeSnapshot, ImportState importState)
     {
         var poolRewards = specialEvents
             .OfType<PaydayPoolRewardSpecialEvent>()
@@ -288,9 +288,13 @@ where metrics_blocks.block_height = sub_query.block_height
             var sumBaker = transactionFeesBaker + bakerRewardBaker + finalizationRewardBaker;
             var sumDelegators = transactionFeesDelegators + bakerRewardDelegators + finalizationRewardDelegators;
 
-            var totalApy = CalculateApy(sumTotal, stakeSnapshot.BakerStake + stakeSnapshot.DelegatedStake, paydaySummary.PaydayDurationSeconds);
-            var bakerApy = CalculateApy(sumBaker, stakeSnapshot.BakerStake, paydaySummary.PaydayDurationSeconds);
-            var delegatorsApy = CalculateApy(sumDelegators, stakeSnapshot.DelegatedStake, paydaySummary.PaydayDurationSeconds);
+            if (importState.LatestWrittenChainParameters == null || !ChainParameters.TryGetRewardPeriodLength(importState.LatestWrittenChainParameters, out var rewardPeriodLength)) {
+                throw new NotImplementedException("The reward period length is expected to be available here");
+            }
+            var expectedPaydayDurationSeconds = ((long) importState.EpochDuration) * (long) rewardPeriodLength!.Value / 1000L;
+            var totalApy = CalculateApy(sumTotal, stakeSnapshot.BakerStake + stakeSnapshot.DelegatedStake, expectedPaydayDurationSeconds);
+            var bakerApy = CalculateApy(sumBaker, stakeSnapshot.BakerStake, expectedPaydayDurationSeconds);
+            var delegatorsApy = CalculateApy(sumDelegators, stakeSnapshot.DelegatedStake, expectedPaydayDurationSeconds);
             
             cmd.Parameters.Add(new NpgsqlParameter<DateTime>("Time", block.BlockSlotTime.UtcDateTime));
             cmd.Parameters.Add(new NpgsqlParameter<long>("PoolId", poolId));

--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <Version>1.9.0</Version>
+        <Version>1.9.1</Version>
     </PropertyGroup>
     
     <ItemGroup>

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased changes
 
+## 1.9.1
+
 - Bugfix
     - Change APY computation to be based on the expected payday length instead of the last measure payday length. ([#217](https://github.com/Concordium/concordium-scan/pull/217))
+    - Fix crashing issue for when a block contains transactions for both deploying a smart contract module and initializing a smart contract from this module. ([#213](https://github.com/Concordium/concordium-scan/pull/213))
 
 ## 1.9.0
 - Support Concordium Protocol Version 7.

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased changes
 
+- Bugfix
+    - Change APY computation to be based on the expected payday length instead of the last measure payday length. ([#217](https://github.com/Concordium/concordium-scan/pull/217))
+
 ## 1.9.0
 - Support Concordium Protocol Version 7.
   - Transition between Delegation and Validating immediately.

--- a/backend/Tests/Api/GraphQL/Import/MetricsWriterTest.cs
+++ b/backend/Tests/Api/GraphQL/Import/MetricsWriterTest.cs
@@ -237,8 +237,17 @@ public class MetricsWriterTest
             new []{ new PaydayPoolStakeSnapshotItem(42, 9000000, 1000000)});
 
         var paydayPassiveDelegationStakeSnapshot = new PaydayPassiveDelegationStakeSnapshot(200000);
-        
-        _target.AddPaydayPoolRewardMetrics(block, specialEvents, rewardsSummary, paydaySummary, paydayPoolStakeSnapshot, paydayPassiveDelegationStakeSnapshot);
+
+        var importState = new ImportState()
+        {
+            GenesisBlockHash = "12ba993f256c03e805e34d1bbe4f12c255ec1cfc507feedd245543ba5df297e9",
+            LatestWrittenChainParameters = new ChainParametersV2(){
+                RewardPeriodLength = 2
+            },
+            EpochDuration = 1000 * 60 * 60 // milliseconds
+        };
+
+        _target.AddPaydayPoolRewardMetrics(block, specialEvents, rewardsSummary, paydaySummary, paydayPoolStakeSnapshot, paydayPassiveDelegationStakeSnapshot, importState);
 
         await using var dbContext = _dbContextFactory.CreateDbContext();
         var result = await dbContext.PaydayPoolRewards.SingleOrDefaultAsync();
@@ -290,7 +299,15 @@ public class MetricsWriterTest
 
         var paydayPassiveDelegationStakeSnapshot = new PaydayPassiveDelegationStakeSnapshot(20000000);
 
-        _target.AddPaydayPoolRewardMetrics(block, specialEvents, rewardsSummary, paydaySummary, paydayPoolStakeSnapshot, paydayPassiveDelegationStakeSnapshot);
+        var importState = new ImportState()
+        {
+            GenesisBlockHash = "12ba993f256c03e805e34d1bbe4f12c255ec1cfc507feedd245543ba5df297e9",
+            LatestWrittenChainParameters = new ChainParametersV2(){
+                RewardPeriodLength = 2
+            },
+            EpochDuration = 1000 * 60 * 60 // milliseconds
+        };
+        _target.AddPaydayPoolRewardMetrics(block, specialEvents, rewardsSummary, paydaySummary, paydayPoolStakeSnapshot, paydayPassiveDelegationStakeSnapshot, importState);
 
         await using var dbContext = _dbContextFactory.CreateDbContext();
         var result = await dbContext.PaydayPoolRewards.SingleOrDefaultAsync();


### PR DESCRIPTION
## Purpose

Fix issue where backend is crashing when protocol update is effective within the same second as the next payday.
This results in a payday duration rounded to `0` seconds, which is an issue for the current computation of APY.

This PR changes the APY computation to be based on the expected payday length instead of the last measured payday length.

Also updated the changelog and prepared for release 1.9.1