### PR TITLE
Have frontend use new backend

### DIFF
--- a/frontend/.env.stagenet
+++ b/frontend/.env.stagenet
@@ -2,6 +2,8 @@
 
 NUXT_PUBLIC_API_URL=https://api-ccdscan.stagenet.concordium.com/graphql
 NUXT_PUBLIC_WS_URL=wss://api-ccdscan.stagenet.concordium.com/graphql
+NUXT_PUBLIC_API_URL_RUST=https://api-ccdscan-fungy.stagenet.concordium.com/api/graphql
+NUXT_PUBLIC_WS_URL_RUST=wss://api-ccdscan-fungy.stagenet.concordium.com/api/graphql
 NUXT_PUBLIC_EXPLORER_NAME=Stagenet
 NUXT_PUBLIC_EXPLORER_EXTERNAL=Mainnet@https://ccdscan.io;Testnet@https://testnet.ccdscan.io
 

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Allowed queries `useBlockListQuery`, `useBlockQuery`, `useChartBlockMetrics`, `useContractQuery`, `useContractsListQuery`, `useTokenQuery`, `useTokenListQuery` and `useModuleQuery` to use a separate API.
+
 ### Fix
 
 - Remove unused fields in query for cis2 token events.

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,17 +1,6 @@
 import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
-	vite: {
-		server: {
-			proxy: {
-				'/api': 'http://127.0.0.1:8000',
-				'/ws': {
-					target: 'ws://127.0.0.1:8000',
-					ws: true,
-				},
-			},
-		},
-	},
 	// Configuration available to the application at runtime, note the `public` object will be
 	// expose directly in the client-side code and therefore should not contain secrets.
 	// Below values are default and can be overwritten by environment variables at runtime.
@@ -24,6 +13,12 @@ export default defineNuxtConfig({
 			// URL to use when using websockets in GraphQL CCDscan API.
 			// (env NUXT_PUBLIC_WS_URL)
 			wsUrl: 'ws://localhost:5090/graphql',
+			// URL to use when sending GraphQL queries to the CCDscan API.
+			// (env NUXT_PUBLIC_API_URL_RUST)
+			apiUrlRust: 'http://localhost:8000/api/graphql',
+			// URL to use when using websockets in GraphQL CCDscan API.
+			// (env NUXT_PUBLIC_WS_URL_RUST)
+			wsUrlRust: 'ws://localhost:8000/api/graphql',
 			// Settings for how to display the explorer.
 			explorer: {
 				// The name to display for the explorer.
@@ -47,8 +42,6 @@ export default defineNuxtConfig({
 		},
 	},
 	// Directory for finding the source files.
-
-
 
 	srcDir: 'src/',
 	// Directories to search for components.

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,6 +1,17 @@
 import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
+	vite: {
+		server: {
+			proxy: {
+				'/api': 'http://127.0.0.1:8000',
+				'/ws': {
+					target: 'ws://127.0.0.1:8000',
+					ws: true,
+				},
+			},
+		},
+	},
 	// Configuration available to the application at runtime, note the `public` object will be
 	// expose directly in the client-side code and therefore should not contain secrets.
 	// Below values are default and can be overwritten by environment variables at runtime.
@@ -36,6 +47,9 @@ export default defineNuxtConfig({
 		},
 	},
 	// Directory for finding the source files.
+
+
+
 	srcDir: 'src/',
 	// Directories to search for components.
 	components: [

--- a/frontend/src/queries/useBlockListQuery.ts
+++ b/frontend/src/queries/useBlockListQuery.ts
@@ -33,6 +33,7 @@ const BlocksQuery = gql<BlockListResponse>`
 
 export const useBlockListQuery = (variables: Partial<QueryVariables>) => {
 	const { data, executeQuery } = useQuery({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: BlocksQuery,
 		requestPolicy: 'cache-and-network',
 		variables,

--- a/frontend/src/queries/useBlockQuery.ts
+++ b/frontend/src/queries/useBlockQuery.ts
@@ -115,6 +115,7 @@ export const useBlockQuery = ({ id, hash, eventsVariables }: QueryParams) => {
 	const { data, fetching, error } = useQuery<
 		BlockResponse | BlockByBlockHashResponse | undefined
 	>({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query,
 		requestPolicy: 'cache-first',
 		variables: {

--- a/frontend/src/queries/useChartBlockMetrics.ts
+++ b/frontend/src/queries/useChartBlockMetrics.ts
@@ -21,13 +21,8 @@ const BlockMetricsQuery = gql<BlockMetricsQueryResponse>`
 				bucketWidth
 				x_Time
 				y_BlocksAdded
-				y_BlockTimeMin
 				y_BlockTimeAvg
-				y_BlockTimeMax
-				y_LastTotalMicroCcd
 				y_FinalizationTimeAvg
-				y_MinTotalMicroCcdStaked
-				y_MaxTotalMicroCcdStaked
 				y_LastTotalMicroCcdStaked
 			}
 		}
@@ -36,6 +31,7 @@ const BlockMetricsQuery = gql<BlockMetricsQueryResponse>`
 
 export const useBlockMetricsQuery = (period: Ref<MetricsPeriod>) => {
 	const { data, executeQuery, fetching } = useQuery({
+		context: { url: '/api/graphql' },
 		query: BlockMetricsQuery,
 		requestPolicy: 'cache-and-network',
 		variables: { period },

--- a/frontend/src/queries/useChartBlockMetrics.ts
+++ b/frontend/src/queries/useChartBlockMetrics.ts
@@ -31,7 +31,7 @@ const BlockMetricsQuery = gql<BlockMetricsQueryResponse>`
 
 export const useBlockMetricsQuery = (period: Ref<MetricsPeriod>) => {
 	const { data, executeQuery, fetching } = useQuery({
-		context: { url: '/api/graphql' },
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: BlockMetricsQuery,
 		requestPolicy: 'cache-and-network',
 		variables: { period },

--- a/frontend/src/queries/useContractQuery.ts
+++ b/frontend/src/queries/useContractQuery.ts
@@ -241,6 +241,7 @@ export const useContractQuery = ({
 	fetching: Ref<boolean>
 } => {
 	const { data, fetching, error } = useQuery<ContractQueryResponse>({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: ContractQuery,
 		requestPolicy: 'cache-first',
 		variables: {

--- a/frontend/src/queries/useContractsListQuery.ts
+++ b/frontend/src/queries/useContractsListQuery.ts
@@ -46,6 +46,7 @@ export const useContractsListQuery = (
 	variables: Variables
 ): { data: Ref<ContractListResponse | undefined> } => {
 	const { data } = useQuery({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: Query,
 		requestPolicy: 'cache-and-network',
 		variables,

--- a/frontend/src/queries/useModuleQuery.ts
+++ b/frontend/src/queries/useModuleQuery.ts
@@ -97,6 +97,7 @@ export const useModuleReferenceEventQuery = ({
 	fetching: Ref<boolean>
 } => {
 	const { data, fetching, error } = useQuery<ModuleReferenceEventResponse>({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: ContractQuery,
 		requestPolicy: 'cache-first',
 		variables: {

--- a/frontend/src/queries/useTokenQuery.ts
+++ b/frontend/src/queries/useTokenQuery.ts
@@ -132,7 +132,7 @@ query (
       block {
         blockSlotTime
       }
-    }    
+    }
     accounts(skip: $skipAccount, take: $takeAccount) {
       items {
         accountId
@@ -140,7 +140,7 @@ query (
           address {
             asString
           }
-        }        
+        }
         balance
         contractIndex
         contractSubIndex
@@ -169,6 +169,7 @@ export const useTokenQuery = ({
 	fetching: Ref<boolean>
 } => {
 	const { data, fetching, error } = useQuery<TokenQueryResponse>({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: TokenQuery,
 		requestPolicy: 'cache-first',
 		variables: {

--- a/frontend/src/queries/useTokensListQuery.ts
+++ b/frontend/src/queries/useTokensListQuery.ts
@@ -38,6 +38,7 @@ export const useTokensListQuery = (
 	variables: ListVariables
 ): { data: Ref<ListResponse | undefined> } => {
 	const { data } = useQuery<ListResponse, ListVariables>({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: TokensQuery,
 		requestPolicy: 'cache-and-network',
 		variables,


### PR DESCRIPTION
## Purpose

Set up the frontend to use the new backend for block page, contract page and token page.

## Changes

Affected queries:

- `useBlockListQuery`
- `useBlockQuery`
- `useChartBlockMetrics`
- `useContractQuery`
- `useContractsListQuery`
- `useModuleQuery`
- `useTokenQuery`
- `useTokenListQuery`
