### PR TITLE
Run P7 delegator migrations at every P7 block instead of only payday

### DIFF
--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <Version>1.9.1</Version>
+        <Version>1.9.2</Version>
     </PropertyGroup>
     
     <ItemGroup>

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased changes
 
+## 1.9.2
+
+- Bugfix
+  - Run P6-P7 migration logic for pending changes of delegators in every P7 blocks instead of only at paydays.
+
 ## 1.9.1
 
 - Bugfix


### PR DESCRIPTION
## Purpose

Fix bug preventing the ingestion from proceeding.
The issue was that delegators with pending changes from P6 were not migrated immediately in P7, as the migration logic was only run at payday.
This PR changes the migration logic to be run at every block ingested in P7.
