### PR TITLE
Hardcode docker username as the secret

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: concordium
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Purpose

Release fails due to a change in the value `secrets.DOCKER_USERNAME` as the value is now `concordium` (not really a secret) and GitHub therefore prevents it from being used anywhere else in the workflow.
The fix is to avoid using a secret for storing the username, allowing `concordium` to be used elsewhere.
