### PR TITLE
Accounts updated subscription

### DIFF
--- a/backend-rust/migrations/0001_initialize.up.sql
+++ b/backend-rust/migrations/0001_initialize.up.sql
@@ -376,7 +376,6 @@ CREATE INDEX contract_events_idx ON contract_events (contract_index, contract_su
 CREATE OR REPLACE FUNCTION account_updated_notify_trigger_function() RETURNS trigger AS $trigger$
 DECLARE
   rec affected_accounts;
-  payload TEXT;
   lookup_result TEXT;
 BEGIN
   CASE TG_OP

--- a/backend-rust/migrations/0001_initialize.up.sql
+++ b/backend-rust/migrations/0001_initialize.up.sql
@@ -373,6 +373,32 @@ CREATE INDEX event_index_per_contract_idx ON contract_events (event_index_per_co
 -- Important for quickly filtering contract events by a specific contract.
 CREATE INDEX contract_events_idx ON contract_events (contract_index, contract_sub_index);
 
+CREATE OR REPLACE FUNCTION account_updated_notify_trigger_function() RETURNS trigger AS $trigger$
+DECLARE
+  rec affected_accounts;
+  payload TEXT;
+  lookup_result TEXT;
+BEGIN
+  CASE TG_OP
+       WHEN 'INSERT' THEN
+            -- Lookup the account address associated with the account index.
+            SELECT address
+            INTO lookup_result
+            FROM accounts
+            WHERE index = NEW.account_index;
+
+            -- Include the lookup result in the payload
+            PERFORM pg_notify('account_updated', lookup_result);
+       ELSE NULL;
+  END CASE;
+  RETURN NEW;
+END;
+$trigger$ LANGUAGE plpgsql;
+
+CREATE TRIGGER account_updated_notify_trigger AFTER INSERT
+ON affected_accounts
+FOR EACH ROW EXECUTE PROCEDURE account_updated_notify_trigger_function();
+
 CREATE OR REPLACE FUNCTION block_added_notify_trigger_function() RETURNS trigger AS $trigger$
 DECLARE
   rec blocks;

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -1120,14 +1120,6 @@ impl SubscriptionContext {
                         }
 
                         Self::ACCOUNTS_UPDATED_CHANNEL => {
-                            // let address = notification.payload().to_string();
-
-                            // if let Some(ref filter) = account_address {
-                            //     if &address != filter {
-                            //         continue; // Skip if the address doesn't match the filter
-                            //     }
-                            // }
-
                             self.accounts_updated_sender.send(AccountsUpdatedSubscriptionItem {
                                 address: notification.payload().to_string(),
                             })?;

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -1055,6 +1055,8 @@ impl Subscription {
 
     async fn accounts_updated(
         &self,
+        // TODO: What to do with this?
+        account_address: String,
     ) -> impl Stream<Item = Result<AccountsUpdatedSubscriptionItem, BroadcastStreamRecvError>> {
         tokio_stream::wrappers::BroadcastStream::new(self.accounts_updated.resubscribe())
     }

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -1068,7 +1068,7 @@ pub struct SubscriptionContext {
 }
 
 impl SubscriptionContext {
-    const ACCOUNTS_UPDATED_CHANNEL: &'static str = "accounts_updated";
+    const ACCOUNTS_UPDATED_CHANNEL: &'static str = "account_updated";
     const BLOCK_ADDED_CHANNEL: &'static str = "block_added";
 
     pub async fn listen(self, pool: PgPool, stop_signal: CancellationToken) -> anyhow::Result<()> {

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -1071,7 +1071,7 @@ impl Subscription {
                                     // Pass on notification.
                                     Some(Ok(notification))
                                 } else {
-                                    // Skip if filter does non match.
+                                    // Skip if filter does not match.
                                     None
                                 }
                             } else {


### PR DESCRIPTION
## Purpose

I'm honestly not sure where this is used in the frontend.

## Changes

Added the `AccountsUpdatedSubscriptionItem` and the appropriate methods to `Subscription`, which are largely inspired by the already-existing `block_added` subscription.

What's missing is actually sending the notifications when the appropriate event happens - this is left for future work.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.