### PR TITLE
Fix issues with insecure default password

### DIFF
--- a/backend-rust/.env.template
+++ b/backend-rust/.env.template
@@ -1,0 +1,2 @@
+PGPASSWORD=$DB_PASSWORD
+DATABASE_URL=postgres://postgres:$DB_PASSWORD@localhost/ccd-scan

--- a/backend-rust/Dockerfile
+++ b/backend-rust/Dockerfile
@@ -1,0 +1,30 @@
+ARG build_image=rust:1.76-bookworm
+ARG base_image=debian:bookworm-slim
+FROM ${build_image} AS build
+
+WORKDIR /usr/app/concordium-scan
+
+COPY ./Cargo.toml ./Cargo.lock ./
+COPY ./src ./src
+RUN cargo install sqlx-cli --no-default-features --features "postgres"
+RUN cargo build --release --locked
+
+
+FROM ${base_image}
+
+WORKDIR /usr/app
+
+RUN apt-get update && \
+    apt-get install -y gnupg wget lsb-release && \
+    sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/postgres.list' && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get -y install \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY notification-server/resources /usr/app/resources
+COPY --from=build /usr/app/notification-server/target/release/notification-api /usr/app/notification-server/target/release/notification-service /usr/bin/
+COPY --from=build $HOME/.cargo/bin/sqlx-cli /usr/local/bin/sqlx-cli
+
+RUN chmod +x /usr/bin/notification-api /usr/bin/notification-service

--- a/backend-rust/Makefile
+++ b/backend-rust/Makefile
@@ -1,0 +1,36 @@
+.DEFAULT_GOAL := all
+
+all: docker-up wait-for-db create-tables
+
+setup: setup-db
+
+setup-db:
+	@echo "Setting default password"
+	@DB_PASSWORD=$$(openssl rand -base64 12) && \
+	export DB_PASSWORD=$$DB_PASSWORD && \
+	cat .env.template | envsubst > .env
+
+docker-up:
+	@echo "Starting Docker containers..."
+	docker compose up -d db
+
+# Target to wait for the PostgreSQL database to be ready.
+wait-for-db:
+	@echo "Waiting for the database to be ready..."
+	@max_attempts=10; \
+	current_attempt=1; \
+	until docker compose exec -T db pg_isready -U postgres; do \
+		sleep 5; \
+		current_attempt=$$((current_attempt+1)); \
+		if [ $$current_attempt -gt $$max_attempts ]; then \
+			echo "Database did not become ready in time."; \
+			exit 1; \
+		fi; \
+		echo "Retrying ($$current_attempt/$$max_attempts)..."; \
+	done
+
+create-tables:
+	@echo "Creating tables from SQL files..."
+	cargo sqlx prepare
+
+.PHONY: setup setup-db all docker-up wait-for-db create-tables

--- a/backend-rust/docker-compose.yml
+++ b/backend-rust/docker-compose.yml
@@ -1,12 +1,13 @@
 version: '3.9'
 services:
+
   db:
-    image: "postgres:16"
+    image: postgres:16
+    restart: always
     ports:
-      - 5432:5432
+      - "5432:5432"
     volumes:
       - ./data:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: example
+      POSTGRES_PASSWORD: ${PGPASSWORD}
       POSTGRES_DB: ccd-scan


### PR DESCRIPTION
## Purpose

We cannot have a default password defined in the source code for a postgresdb. Anyone can connect to it and obtain a bash on the container with write access to the host machine including access to the other containers running on the host machine.

```
❯ psql -U postgres --password --host=localhost --dbname=ccd-scan
Password:
psql (14.15 (Homebrew), server 16.6 (Debian 16.6-1.pgdg120+1))
WARNING: psql major version 14, server major version 16.
         Some psql features might not work.
Type "help" for help.

ccd-scan=# \! bash
bash-5.2$ whoami
lassemolleralm
bash-5.2$ ls -a
```