### PR TITLE
Remove unused field in the frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/queries/useAccountQuery.ts
+++ b/frontend/src/queries/useAccountQuery.ts
@@ -214,17 +214,6 @@ delegation {
 		}
 	__typename
 	}
-	pendingChange {
-		... on PendingDelegationRemoval {
-			effectiveTime
-			__typename
-		}
-		... on PendingDelegationReduceStake {
-			newStakedAmount
-			effectiveTime
-			__typename
-		}
-	}
 }
 createdAt
 __typename


### PR DESCRIPTION
## Purpose



I can ignore pendingChange as per https://linear.app/concordium/issue/CCD-68/implement-accountdelegation on fungy CCDScan as soon as we stop querying it on the frontend. It does not seem to be used.