### PR TITLE
Remove baker from query

### DIFF
--- a/frontend/src/queries/useAccountQuery.ts
+++ b/frontend/src/queries/useAccountQuery.ts
@@ -150,19 +150,6 @@ address {
 }
 amount
 transactionCount
-baker {
-	bakerId
-	state {
-		...on ActiveBakerState {
-			__typename
-			stakedAmount
-		}
-		...on RemovedBakerState {
-			__typename
-			removedAt
-		}
-	}
-}
 releaseSchedule {
 	totalAmount
 	schedule(


### PR DESCRIPTION
## Purpose

This request should only be used from the account query, and the baker object does not seem to be used from within there 