### PR TITLE
Keep api alive

### DIFF
--- a/backend-rust/src/bin/ccdscan-api.rs
+++ b/backend-rust/src/bin/ccdscan-api.rs
@@ -16,24 +16,26 @@ struct Cli {
     /// Use an environment variable when the connection contains a password, as
     /// command line arguments are visible across OS processes.
     #[arg(long, env = "DATABASE_URL")]
-    database_url:    String,
+    database_url:        String,
+    #[arg(long, env = "DATABASE_RETRY_SECS", default_value_t = 5)]
+    database_retry_secs: String,
     /// Minimum number of connections in the pool.
     #[arg(long, env = "DATABASE_MIN_CONNECTIONS", default_value_t = 5)]
-    min_connections: u32,
+    min_connections:     u32,
     /// Maximum number of connections in the pool.
     #[arg(long, env = "DATABASE_MAX_CONNECTIONS", default_value_t = 10)]
-    max_connections: u32,
+    max_connections:     u32,
     /// Output the GraphQL Schema for the API to this path.
     #[arg(long)]
-    schema_out:      Option<PathBuf>,
+    schema_out:          Option<PathBuf>,
     /// Address to listen to for API requests.
     #[arg(long, env = "CCDSCAN_API_ADDRESS", default_value = "127.0.0.1:8000")]
-    listen:          SocketAddr,
+    listen:              SocketAddr,
     /// Address to listen to for metrics requests.
     #[arg(long, env = "CCDSCAN_API_METRICS_ADDRESS", default_value = "127.0.0.1:8003")]
-    metrics_listen:  SocketAddr,
+    metrics_listen:      SocketAddr,
     #[command(flatten, next_help_heading = "Configuration")]
-    api_config:      graphql_api::ApiServiceConfig,
+    api_config:          graphql_api::ApiServiceConfig,
     #[arg(
         long = "log-level",
         default_value = "info",
@@ -41,7 +43,7 @@ struct Cli {
                 `error`.",
         env = "LOG_LEVEL"
     )]
-    log_level:       tracing_subscriber::filter::LevelFilter,
+    log_level:           tracing_subscriber::filter::LevelFilter,
 }
 
 #[tokio::main]

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -1235,7 +1235,6 @@ impl SubscriptionContext {
 
         Ok(())
     }
-
 }
 
 #[derive(Clone, Debug, SimpleObject)]

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -1094,7 +1094,7 @@ pub struct Subscription {
 }
 
 impl Subscription {
-    pub fn new() -> (Self, SubscriptionContext) {
+    pub fn new(retry_delay_sec: u64) -> (Self, SubscriptionContext) {
         let (block_added_sender, block_added) = broadcast::channel(100);
         let (accounts_updated_sender, accounts_updated) = broadcast::channel(100);
         (
@@ -1105,6 +1105,7 @@ impl Subscription {
             SubscriptionContext {
                 block_added_sender,
                 accounts_updated_sender,
+                retry_delay_sec,
             },
         )
     }

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -1170,7 +1170,6 @@ impl SubscriptionContext {
                     break; // Graceful exit, stop the loop
                 }
                 Err(err) => {
-                    println!("err: {:?}", err);
                     error!("PgListener encountered an error: {}. Retrying...", err);
 
                     // Check if the stop signal has been triggered before retrying
@@ -1204,7 +1203,6 @@ impl SubscriptionContext {
         let exit = stop_signal
             .run_until_cancelled(async move {
                 loop {
-                    println!("Listening for notifications...");
                     let notification = listener.recv().await?;
                     match notification.channel() {
                         Self::BLOCK_ADDED_CHANNEL => {

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -44,7 +44,7 @@ use tokio::{net::TcpListener, sync::broadcast};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{Any, CorsLayer};
-use tracing::error;
+use tracing::{error, info};
 use transaction_metrics::TransactionMetricsQuery;
 
 const VERSION: &str = clap::crate_version!();
@@ -1160,26 +1160,57 @@ pub struct SubscriptionContext {
 impl SubscriptionContext {
     const ACCOUNTS_UPDATED_CHANNEL: &'static str = "account_updated";
     const BLOCK_ADDED_CHANNEL: &'static str = "block_added";
+    const RETRY_DELAY_SEC: u64 = 5;
 
     pub async fn listen(self, pool: PgPool, stop_signal: CancellationToken) -> anyhow::Result<()> {
-        let mut listener = sqlx::postgres::PgListener::connect_with(&pool)
+        loop {
+            match self.run_listener(&pool, &stop_signal).await {
+                Ok(_) => {
+                    info!("PgListener stopped gracefully.");
+                    break; // Graceful exit, stop the loop
+                }
+                Err(err) => {
+                    println!("err: {:?}", err);
+                    error!("PgListener encountered an error: {}. Retrying...", err);
+
+                    // Check if the stop signal has been triggered before retrying
+                    if stop_signal.is_cancelled() {
+                        info!("Stop signal received. Exiting PgListener loop.");
+                        break;
+                    }
+
+                    tokio::time::sleep(std::time::Duration::from_secs(Self::RETRY_DELAY_SEC)).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn run_listener(
+        &self,
+        pool: &PgPool,
+        stop_signal: &CancellationToken,
+    ) -> anyhow::Result<()> {
+        let mut listener = sqlx::postgres::PgListener::connect_with(pool)
             .await
-            .context("Failed to create a postgreSQL listener")?;
+            .context("Failed to create a PostgreSQL listener")?;
 
         listener
             .listen_all([Self::BLOCK_ADDED_CHANNEL, Self::ACCOUNTS_UPDATED_CHANNEL])
             .await
-            .context("Failed to listen to postgreSQL notifications")?;
+            .context("Failed to listen to PostgreSQL notifications")?;
 
         let exit = stop_signal
             .run_until_cancelled(async move {
                 loop {
+                    println!("Listening for notifications...");
                     let notification = listener.recv().await?;
                     match notification.channel() {
                         Self::BLOCK_ADDED_CHANNEL => {
                             let block_height = BlockHeight::from_str(notification.payload())
                                 .context("Failed to parse payload of block added")?;
-                            let block = Block::query_by_height(&pool, block_height).await?;
+                            let block = Block::query_by_height(pool, block_height).await?;
                             self.block_added_sender.send(block)?;
                         }
 
@@ -1197,12 +1228,14 @@ impl SubscriptionContext {
             })
             .await;
 
+        // Handle early exit due to stop signal or errors
         if let Some(result) = exit {
-            result.context("Failed listening")?;
+            result.context("Failed while listening")?;
         }
 
         Ok(())
     }
+
 }
 
 #[derive(Clone, Debug, SimpleObject)]


### PR DESCRIPTION
Predecessor to: https://linear.app/concordium/issue/CCD-114/add-health-check-endpoint

## Purpose

When db shuts down we are shutting down entire api, leaving it to SRE to recover from a bad situation. 

## Changes

Retry on errors.