### PR TITLE
Remove unused subquery for accounts transaction in accounts page

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fix
+
+- Remove unused sub-query for account transactions in the accounts page.
+
 ## [1.6.0] - 2024-11-05
 
 ### Added

--- a/frontend/src/queries/useAccountListQuery.ts
+++ b/frontend/src/queries/useAccountListQuery.ts
@@ -37,17 +37,6 @@ const AccountsQuery = gql<AccountsListResponse>`
 				}
 				createdAt
 				amount
-				transactions {
-					nodes {
-						transaction {
-							transactionHash
-							block {
-								blockSlotTime
-							}
-							id
-						}
-					}
-				}
 				delegation {
 					stakedAmount
 				}


### PR DESCRIPTION
## Purpose

Improve query performance by removing unused `Account::transactions` sub query.
