### PR TITLE
Rename Query in graphql_api modules due to async_graphql name conflict

### DIFF
--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -120,11 +120,11 @@ pub struct ApiServiceConfig {
 #[derive(MergedObject, Default)]
 pub struct Query(
     BaseQuery,
-    block::Query,
-    transaction::Query,
-    account_metrics::Query,
-    transaction_metrics::Query,
-    block_metrics::Query,
+    block::QueryBlocks,
+    transaction::QueryTransactions,
+    account_metrics::QueryAccountMetrics,
+    transaction_metrics::QueryTransactionMetrics,
+    block_metrics::QueryBlockMetrics,
 );
 
 pub struct Service {

--- a/backend-rust/src/graphql_api/account_metrics.rs
+++ b/backend-rust/src/graphql_api/account_metrics.rs
@@ -37,10 +37,10 @@ struct AccountMetricsBuckets {
 }
 
 #[derive(Default)]
-pub(crate) struct Query;
+pub(crate) struct QueryAccountMetrics;
 
 #[Object]
-impl Query {
+impl QueryAccountMetrics {
     async fn accounts_metrics(
         &self,
         ctx: &Context<'_>,

--- a/backend-rust/src/graphql_api/block.rs
+++ b/backend-rust/src/graphql_api/block.rs
@@ -10,10 +10,10 @@ use async_graphql::{
 use futures::TryStreamExt;
 
 #[derive(Default)]
-pub(crate) struct Query;
+pub(crate) struct QueryBlocks;
 
 #[Object]
-impl Query {
+impl QueryBlocks {
     async fn block<'a>(&self, ctx: &Context<'a>, height_id: types::ID) -> ApiResult<Block> {
         let height: BlockHeight = height_id.try_into().map_err(ApiError::InvalidIdInt)?;
         Block::query_by_height(get_pool(ctx)?, height).await

--- a/backend-rust/src/graphql_api/block_metrics.rs
+++ b/backend-rust/src/graphql_api/block_metrics.rs
@@ -69,10 +69,10 @@ struct BlockMetricsBuckets {
 }
 
 #[derive(Default)]
-pub(crate) struct Query;
+pub(crate) struct QueryBlockMetrics;
 
 #[Object]
-impl Query {
+impl QueryBlockMetrics {
     async fn block_metrics<'a>(
         &self,
         ctx: &Context<'a>,

--- a/backend-rust/src/graphql_api/transaction.rs
+++ b/backend-rust/src/graphql_api/transaction.rs
@@ -16,10 +16,10 @@ use sqlx::PgPool;
 use std::str::FromStr;
 
 #[derive(Default)]
-pub struct Query;
+pub struct QueryTransactions;
 
 #[Object]
-impl Query {
+impl QueryTransactions {
     async fn transaction(&self, ctx: &Context<'_>, id: types::ID) -> ApiResult<Transaction> {
         let index: i64 = id.try_into().map_err(ApiError::InvalidIdInt)?;
         Transaction::query_by_index(get_pool(ctx)?, index).await?.ok_or(ApiError::NotFound)

--- a/backend-rust/src/graphql_api/transaction_metrics.rs
+++ b/backend-rust/src/graphql_api/transaction_metrics.rs
@@ -6,7 +6,7 @@ use sqlx::postgres::types::PgInterval;
 use crate::graphql_api::{get_pool, ApiError, ApiResult, DateTime, MetricsPeriod, TimeSpan};
 
 #[derive(Default)]
-pub(crate) struct Query;
+pub(crate) struct QueryTransactionMetrics;
 
 #[derive(SimpleObject)]
 struct TransactionMetrics {
@@ -38,7 +38,7 @@ struct TransactionMetricsBuckets {
 }
 
 #[Object]
-impl Query {
+impl QueryTransactionMetrics {
     async fn transaction_metrics(
         &self,
         ctx: &Context<'_>,


### PR DESCRIPTION
## Purpose

Rename `Query` in `graphql_api` modules due to `async_graphql` crate produces a runtime error due to name conflict