### PR TITLE
Avoid failing preprocessing due to CIS-0 errors

### DIFF
--- a/backend-rust/src/indexer.rs
+++ b/backend-rust/src/indexer.rs
@@ -2010,9 +2010,8 @@ impl PreparedContractInitialized {
                 event.init_name.as_contract_name(),
                 cis0::StandardIdentifier::CIS2,
             )
-            .await?
-            .response
-            .is_support();
+            .await
+            .is_ok_and(|r| r.response.is_support());
 
             if supports_cis2 {
                 potential_cis2_events
@@ -2214,9 +2213,8 @@ impl PreparedContractUpdate {
                 contract_name,
                 cis0::StandardIdentifier::CIS2,
             )
-            .await?
-            .response
-            .is_support();
+            .await
+            .is_ok_and(|r| r.response.is_support());
 
             if supports_cis2 {
                 potential_cis2_events


### PR DESCRIPTION
## Purpose

Allow preprocessing to proceed when CIS-0 queries fail.

## Changes

Failing the CIS-0 `supports` query will fall back to the assumption of no support.
