### PR TITLE
Use DESC order for contract connection query

### DIFF
--- a/backend-rust/.sqlx/query-3c6ebfdb85f26d0ca0cf19e3e00e9e30b13e547d8c1f075c4dde7136eae72ef3.json
+++ b/backend-rust/.sqlx/query-3c6ebfdb85f26d0ca0cf19e3e00e9e30b13e547d8c1f075c4dde7136eae72ef3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * FROM (\n                SELECT\n                    contracts.index as index,\n                    sub_index,\n                    module_reference,\n                    name as contract_name,\n                    contracts.amount,\n                    blocks.slot_time as block_slot_time,\n                    transactions.block_height,\n                    transactions.hash as transaction_hash,\n                    accounts.address as creator\n                FROM contracts\n                JOIN transactions ON transaction_index = transactions.index\n                JOIN blocks ON transactions.block_height = blocks.height\n                JOIN accounts ON transactions.sender = accounts.index\n                WHERE contracts.index > $1 AND contracts.index < $2\n                ORDER BY\n                    (CASE WHEN $4 THEN contracts.index END) DESC,\n                    (CASE WHEN NOT $4 THEN contracts.index END) ASC\n                LIMIT $3\n            ) AS contract_data\n            ORDER BY contract_data.index ASC",
+  "query": "SELECT * FROM (\n                SELECT\n                    contracts.index as index,\n                    sub_index,\n                    module_reference,\n                    name as contract_name,\n                    contracts.amount,\n                    blocks.slot_time as block_slot_time,\n                    transactions.block_height,\n                    transactions.hash as transaction_hash,\n                    accounts.address as creator\n                FROM contracts\n                JOIN transactions ON transaction_index = transactions.index\n                JOIN blocks ON transactions.block_height = blocks.height\n                JOIN accounts ON transactions.sender = accounts.index\n                WHERE contracts.index > $1 AND contracts.index < $2\n                ORDER BY\n                    (CASE WHEN $4 THEN contracts.index END) ASC,\n                    (CASE WHEN NOT $4 THEN contracts.index END) DESC\n                LIMIT $3\n            ) AS contract_data\n            ORDER BY contract_data.index DESC",
   "describe": {
     "columns": [
       {
@@ -69,5 +69,5 @@
       false
     ]
   },
-  "hash": "374a8c1f6898ce8015d34574d0873cef25e8e514f76132cf499f57938a33fdd0"
+  "hash": "3c6ebfdb85f26d0ca0cf19e3e00e9e30b13e547d8c1f075c4dde7136eae72ef3"
 }

--- a/backend-rust/src/graphql_api/contract.rs
+++ b/backend-rust/src/graphql_api/contract.rs
@@ -90,10 +90,10 @@ impl QueryContract {
             config.contract_connection_limit,
         )?;
 
-        // The CCDScan front-end currently expects an ASC order of the nodes/edges
+        // The CCDScan front-end currently expects an DESC order of the nodes/edges
         // returned (outer `ORDER BY`), while the inner `ORDER BY` is a trick to
-        // get the correct nodes/edges selected based on the `after/before` key
-        // specified.
+        // get the correct nodes/edges selected based on whether the `first` or `last`
+        // query parameter is specified.
         let mut row_stream = sqlx::query!(
             "SELECT * FROM (
                 SELECT
@@ -112,11 +112,11 @@ impl QueryContract {
                 JOIN accounts ON transactions.sender = accounts.index
                 WHERE contracts.index > $1 AND contracts.index < $2
                 ORDER BY
-                    (CASE WHEN $4 THEN contracts.index END) DESC,
-                    (CASE WHEN NOT $4 THEN contracts.index END) ASC
+                    (CASE WHEN $4 THEN contracts.index END) ASC,
+                    (CASE WHEN NOT $4 THEN contracts.index END) DESC
                 LIMIT $3
             ) AS contract_data
-            ORDER BY contract_data.index ASC",
+            ORDER BY contract_data.index DESC",
             query.from,
             query.to,
             query.limit,


### PR DESCRIPTION
## Purpose

The query `Query::contracts` in the new rust backend needs to be descending order like the old backend.