### PR TITLE
Fix metrics type

### DIFF
--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-scan"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-scan"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "CCDScan: Indexer and API for the Concordium blockchain"
 authors = ["Concordium <developers@concordium.com>"]

--- a/backend-rust/src/bin/ccdscan-api.rs
+++ b/backend-rust/src/bin/ccdscan-api.rs
@@ -2,7 +2,10 @@ use anyhow::Context;
 use async_graphql::SDLExportOptions;
 use clap::Parser;
 use concordium_scan::{graphql_api, router};
-use prometheus_client::registry::Registry;
+use prometheus_client::{
+    metrics::{family::Family, gauge::Gauge},
+    registry::Registry,
+};
 use sqlx::postgres::PgPoolOptions;
 use std::{net::SocketAddr, path::PathBuf};
 use tokio::net::TcpListener;
@@ -58,12 +61,15 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("Failed constructing database connection pool")?;
     let cancel_token = CancellationToken::new();
-
+    let service_info_family = Family::<Vec<(&str, String)>, Gauge>::default();
+    let gauge =
+        service_info_family.get_or_create(&vec![("version", clap::crate_version!().to_string())]);
+    gauge.set(1);
     let mut registry = Registry::with_prefix("api");
     registry.register(
-        "service",
+        "service_info",
         "Information about the software",
-        prometheus_client::metrics::info::Info::new(vec![("version", clap::crate_version!())]),
+        service_info_family.clone(),
     );
     registry.register(
         "service_startup_timestamp_millis",

--- a/backend-rust/src/bin/ccdscan-indexer.rs
+++ b/backend-rust/src/bin/ccdscan-indexer.rs
@@ -5,7 +5,10 @@ use concordium_scan::{
     indexer::{self, IndexerServiceConfig},
     router,
 };
-use prometheus_client::registry::Registry;
+use prometheus_client::{
+    metrics::{family::Family, gauge::Gauge},
+    registry::Registry,
+};
 use sqlx::postgres::PgPoolOptions;
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
@@ -64,11 +67,16 @@ async fn main() -> anyhow::Result<()> {
         .context("Failed constructing database connection pool")?;
     let cancel_token = CancellationToken::new();
 
-    let mut registry = Registry::with_prefix("indexer");
+    let registry = Registry::with_prefix("indexer");
+    let service_info_family = Family::<Vec<(&str, String)>, Gauge>::default();
+    let gauge =
+        service_info_family.get_or_create(&vec![("version", clap::crate_version!().to_string())]);
+    gauge.set(1);
+    let mut registry = Registry::with_prefix("api");
     registry.register(
-        "service",
+        "service_info",
         "Information about the software",
-        prometheus_client::metrics::info::Info::new(vec![("version", clap::crate_version!())]),
+        service_info_family.clone(),
     );
     registry.register(
         "service_startup_timestamp_millis",

--- a/backend-rust/src/bin/ccdscan-indexer.rs
+++ b/backend-rust/src/bin/ccdscan-indexer.rs
@@ -67,12 +67,11 @@ async fn main() -> anyhow::Result<()> {
         .context("Failed constructing database connection pool")?;
     let cancel_token = CancellationToken::new();
 
-    let registry = Registry::with_prefix("indexer");
+    let mut registry = Registry::with_prefix("indexer");
     let service_info_family = Family::<Vec<(&str, String)>, Gauge>::default();
     let gauge =
         service_info_family.get_or_create(&vec![("version", clap::crate_version!().to_string())]);
     gauge.set(1);
-    let mut registry = Registry::with_prefix("api");
     registry.register(
         "service_info",
         "Information about the software",


### PR DESCRIPTION
## Purpose

```
# HELP indexer_service_info Information about the software.
# TYPE indexer_service_info gauge
indexer_service_info{version="0.1.10"} 1
```
Instead of 

```
# HELP indexer_service Information about the software.
# TYPE indexer_service info
indexer_service_info{version="0.1.9"} 1
```

Since info is not a valid metric type causing the collector to fail