### PR TITLE
Align parameter for Query::block to match .NET backend

### DIFF
--- a/backend-rust/src/graphql_api/block.rs
+++ b/backend-rust/src/graphql_api/block.rs
@@ -14,8 +14,8 @@ pub(crate) struct QueryBlocks;
 
 #[Object]
 impl QueryBlocks {
-    async fn block<'a>(&self, ctx: &Context<'a>, height_id: types::ID) -> ApiResult<Block> {
-        let height: BlockHeight = height_id.try_into().map_err(ApiError::InvalidIdInt)?;
+    async fn block<'a>(&self, ctx: &Context<'a>, id: types::ID) -> ApiResult<Block> {
+        let height: BlockHeight = id.try_into().map_err(ApiError::InvalidIdInt)?;
         Block::query_by_height(get_pool(ctx)?, height).await
     }
 


### PR DESCRIPTION
## Purpose

Fix inconsistency.
The graphql API of the .NET backend expects the argument to be named differently.
