### PR TITLE
Order blocks descendingly and compute the next/previous page

### DIFF
--- a/backend-rust/.sqlx/query-3c68bcd07cc8ddee8de17f2996ece8aa625aa70aef64153347f79d84e9dd9a6b.json
+++ b/backend-rust/.sqlx/query-3c68bcd07cc8ddee8de17f2996ece8aa625aa70aef64153347f79d84e9dd9a6b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * FROM (\n                SELECT\n                    hash,\n                    height,\n                    slot_time,\n                    block_time,\n                    finalization_time,\n                    baker_id,\n                    total_amount\n                FROM blocks\n                WHERE height > $1 AND height < $2\n                ORDER BY\n                    (CASE WHEN $4 THEN height END) DESC,\n                    (CASE WHEN NOT $4 THEN height END) ASC\n                LIMIT $3\n            ) ORDER BY height ASC",
+  "query": "SELECT * FROM (\n                SELECT\n                    hash,\n                    height,\n                    slot_time,\n                    block_time,\n                    finalization_time,\n                    baker_id,\n                    total_amount\n                FROM blocks\n                WHERE height > $1 AND height < $2\n                ORDER BY\n                    (CASE WHEN $4 THEN height END) ASC,\n                    (CASE WHEN NOT $4 THEN height END) DESC\n                LIMIT $3\n            ) ORDER BY height DESC",
   "describe": {
     "columns": [
       {
@@ -57,5 +57,5 @@
       false
     ]
   },
-  "hash": "fc2f96416de3d86996d78076ff0a5ab9e9a8bf450265c6ece6e3b57ceb4c0d82"
+  "hash": "3c68bcd07cc8ddee8de17f2996ece8aa625aa70aef64153347f79d84e9dd9a6b"
 }

--- a/backend-rust/.sqlx/query-c5a51f14dfc01a5a58aa0f6b7611953ec6a16b1a4aeef0e4dcd5e4fc24ad2ff1.json
+++ b/backend-rust/.sqlx/query-c5a51f14dfc01a5a58aa0f6b7611953ec6a16b1a4aeef0e4dcd5e4fc24ad2ff1.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT true FROM blocks WHERE height > $1 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "c5a51f14dfc01a5a58aa0f6b7611953ec6a16b1a4aeef0e4dcd5e4fc24ad2ff1"
+}

--- a/backend-rust/src/graphql_api/block.rs
+++ b/backend-rust/src/graphql_api/block.rs
@@ -85,6 +85,7 @@ impl QueryBlocks {
             false
         };
         let has_next_page = if let Some(last) = rows.last() {
+            // Genesis block have height 0, so we check whether the last block is higher.
             last.height > 0
         } else {
             false


### PR DESCRIPTION
## Purpose

Adjust the block list query to use descending order.
Compute the flags for next and previous page as well.
