### PR TITLE
Release .NET backend 1.10.0

### DIFF
--- a/.github/workflows/release-net-backend.yaml
+++ b/.github/workflows/release-net-backend.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - ccdscan/*
+      - backend/*
 
 jobs:
   release-ccdscan:

--- a/backend/Application/Application.csproj
+++ b/backend/Application/Application.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
-        <Version>1.9.2</Version>
+        <Version>1.10.0</Version>
     </PropertyGroup>
     
     <ItemGroup>


### PR DESCRIPTION
## Purpose

Release .NET backend 1.10.0

I already update the changelog in my previous PR, but for forgot to update the version in the code.

Also, change the new release pipeline for .NET backend to use the tag previously used by backend.