### PR TITLE
Sanitize metadata url

### DIFF
--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-scan"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-scan"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 description = "CCDScan: Indexer and API for the Concordium blockchain"
 authors = ["Concordium <developers@concordium.com>"]

--- a/backend-rust/src/indexer.rs
+++ b/backend-rust/src/indexer.rs
@@ -3195,10 +3195,6 @@ async fn process_cis2_token_event(
             )
             .to_string();
 
-            // Since PostgreSQL Text data type does not support NUL we must replace these
-            // before inserting. These are replaced by the a Unicode 'REPLACEMENT CHARACTER'
-            // (U+FFFD).
-            let metadata_url = metadata_url.url().replace('\0', "\u{FFFD}");
             // If the `token_address` does not exist, insert the new token.
             // If the `token_address` exists, update the `metadata_url` value in the
             // database.
@@ -3223,7 +3219,7 @@ async fn process_cis2_token_event(
                 token_address,
                 contract_index,
                 contract_sub_index,
-                metadata_url.as_str(),
+                metadata_url.url(),
                 raw_token_id.to_string(),
                 transaction_index
             )


### PR DESCRIPTION
## Purpose

The database is complaining about unsupported unicode characters again, so I moved the sanitizing code into where we construct the types instead of right before inserting.