### PR TITLE
Fix missing P8 Update transaction type

### DIFF
--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-scan"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-scan"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "CCDScan: Indexer and API for the Concordium blockchain"
 authors = ["Concordium <developers@concordium.com>"]

--- a/backend-rust/src/transaction_type.rs
+++ b/backend-rust/src/transaction_type.rs
@@ -133,6 +133,7 @@ pub enum UpdateTransactionType {
     MinBlockTimeUpdate,
     BlockEnergyLimitUpdate,
     FinalizationCommitteeParametersUpdate,
+    ValidatorScoreParametersUpdate,
 }
 
 impl From<concordium_rust_sdk::types::UpdateType> for UpdateTransactionType {
@@ -168,7 +169,9 @@ impl From<concordium_rust_sdk::types::UpdateType> for UpdateTransactionType {
             UpdateType::UpdateFinalizationCommitteeParameters => {
                 UpdateTransactionType::FinalizationCommitteeParametersUpdate
             }
-            UpdateType::UpdateValidatorScoreParameters => todo!(),
+            UpdateType::UpdateValidatorScoreParameters => {
+                UpdateTransactionType::ValidatorScoreParametersUpdate
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose

Indexer is failing due to missing implementation of the P8 update transaction type for the validator score
