### PR TITLE
Make health endpoints check database schema version

### DIFF
--- a/backend-rust/src/bin/ccdscan-api.rs
+++ b/backend-rust/src/bin/ccdscan-api.rs
@@ -6,6 +6,7 @@ use prometheus_client::{
     metrics::{family::Family, gauge::Gauge},
     registry::Registry,
 };
+use serde_json::json;
 use sqlx::postgres::PgPoolOptions;
 use std::{net::SocketAddr, path::PathBuf};
 use tokio::net::TcpListener;
@@ -23,34 +24,35 @@ struct Cli {
     /// Use an environment variable when the connection contains a password, as
     /// command line arguments are visible across OS processes.
     #[arg(long, env = "CCDSCAN_API_DATABASE_URL")]
-    database_url:              String,
+    database_url: String,
     #[arg(long, env = "CCDSCAN_API_DATABASE_RETRY_DELAY_SECS", default_value_t = 5)]
     database_retry_delay_secs: u64,
     /// Minimum number of connections in the pool.
     #[arg(long, env = "CCDSCAN_API_DATABASE_MIN_CONNECTIONS", default_value_t = 5)]
-    min_connections:           u32,
+    min_connections: u32,
     /// Maximum number of connections in the pool.
     #[arg(long, env = "CCDSCAN_API_DATABASE_MAX_CONNECTIONS", default_value_t = 10)]
-    max_connections:           u32,
+    max_connections: u32,
     /// Output the GraphQL Schema for the API to this path.
     #[arg(long)]
-    schema_out:                Option<PathBuf>,
+    schema_out: Option<PathBuf>,
     /// Address to listen to for API requests.
     #[arg(long, env = "CCDSCAN_API_ADDRESS", default_value = "127.0.0.1:8000")]
-    listen:                    SocketAddr,
+    listen: SocketAddr,
     /// Address to listen for monitoring related requests
     #[arg(long, env = "CCDSCAN_API_MONITORING_ADDRESS", default_value = "127.0.0.1:8003")]
-    monitoring_listen:         SocketAddr,
+    monitoring_listen: SocketAddr,
     #[command(flatten, next_help_heading = "Configuration")]
-    api_config:                graphql_api::ApiServiceConfig,
-    #[arg(
-        long = "log-level",
-        default_value = "info",
-        help = "The maximum log level. Possible values are: `trace`, `debug`, `info`, `warn`, and \
-                `error`.",
-        env = "LOG_LEVEL"
-    )]
-    log_level:                 tracing_subscriber::filter::LevelFilter,
+    api_config: graphql_api::ApiServiceConfig,
+    /// The maximum log level. Possible values are: `trace`, `debug`, `info`,
+    /// `warn`, and `error`.
+    #[arg(long, default_value = "info", env = "LOG_LEVEL")]
+    log_level: tracing_subscriber::filter::LevelFilter,
+    /// Check whether the database schema version is compatible with this
+    /// version of the service and then exit the service immediately.
+    /// Non-zero exit code is returned when incompatible.
+    #[arg(long, env = "CCDSCAN_API_CHECK_DATABASE_COMPATIBILITY_ONLY")]
+    check_database_compatibility_only: bool,
 }
 
 #[tokio::main]
@@ -66,6 +68,10 @@ async fn main() -> anyhow::Result<()> {
         .context("Failed constructing database connection pool")?;
     // Ensure the database schema is compatible with supported schema version.
     migrations::ensure_compatible_schema_version(&pool, SUPPORTED_SCHEMA_VERSION).await?;
+    if cli.check_database_compatibility_only {
+        // Exit if we only care about the compatibility.
+        return Ok(());
+    }
 
     let cancel_token = CancellationToken::new();
     let service_info_family = Family::<Vec<(&str, String)>, Gauge>::default();
@@ -112,12 +118,14 @@ async fn main() -> anyhow::Result<()> {
         tokio::spawn(async move { service.serve(tcp_listener, stop_signal).await })
     };
     let mut monitoring_task = {
+        let health_routes =
+            axum::Router::new().route("/", axum::routing::get(health)).with_state(pool);
         let tcp_listener = TcpListener::bind(cli.monitoring_listen)
             .await
             .context("Parsing TCP listener address failed")?;
         let stop_signal = cancel_token.child_token();
         info!("Monitoring server is running at {:?}", cli.monitoring_listen);
-        tokio::spawn(router::serve(registry, tcp_listener, pool, stop_signal))
+        tokio::spawn(router::serve(registry, tcp_listener, stop_signal, health_routes))
     };
 
     // Await for signal to shutdown or any of the tasks to stop.
@@ -152,4 +160,21 @@ async fn main() -> anyhow::Result<()> {
     // Ensure all tasks have stopped
     let _ = tokio::join!(monitoring_task, queries_task, pgnotify_listener);
     Ok(())
+}
+
+/// GET Handler for route `/health`.
+/// Verifying the API service state is as expected.
+async fn health(
+    axum::extract::State(pool): axum::extract::State<sqlx::PgPool>,
+) -> axum::Json<serde_json::Value> {
+    match migrations::ensure_compatible_schema_version(&pool, SUPPORTED_SCHEMA_VERSION).await {
+        Ok(_) => axum::extract::Json(json!({
+            "status": "ok",
+            "database": "connected"
+        })),
+        Err(err) => axum::extract::Json(json!({
+            "status": "error",
+            "database": format!("not connected: {}", err)
+        })),
+    }
 }

--- a/backend-rust/src/router.rs
+++ b/backend-rust/src/router.rs
@@ -1,19 +1,16 @@
-use axum::{extract::State, routing::get, Json, Router};
+use axum::{extract::State, routing::get, Router};
 use prometheus_client::registry::Registry;
-use serde_json::json;
-use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
-/// Run server exposing the Prometheus metrics
+/// Run server exposing the Prometheus metrics and health endpoint.
 pub async fn serve(
     registry: Registry,
     tcp_listener: TcpListener,
-    pool: PgPool,
     stop_signal: CancellationToken,
+    health_routes: Router,
 ) -> anyhow::Result<()> {
-    let health_routes = Router::new().route("/", get(health)).with_state(pool);
     let metric_routes = Router::new().route("/", get(metrics)).with_state(Arc::new(registry));
     let app = Router::new().nest("/metrics", metric_routes).nest("/health", health_routes);
     axum::serve(tcp_listener, app).with_graceful_shutdown(stop_signal.cancelled_owned()).await?;
@@ -27,17 +24,4 @@ async fn metrics(State(registry): State<Arc<Registry>>) -> Result<String, String
     prometheus_client::encoding::text::encode(&mut buffer, &registry)
         .map_err(|err| err.to_string())?;
     Ok(buffer)
-}
-
-async fn health(State(pool): State<PgPool>) -> Json<serde_json::Value> {
-    match sqlx::query("SELECT 1").fetch_one(&pool).await {
-        Ok(_) => Json(json!({
-            "status": "ok",
-            "database": "connected"
-        })),
-        Err(err) => Json(json!({
-            "status": "error",
-            "database": format!("not connected: {}", err)
-        })),
-    }
 }


### PR DESCRIPTION
## Purpose

- Change health checks to validate the database schema version.
- Provide flag for `ccdscan-api` which can be used for validating the database schema before spinning up the service.
