### PR TITLE
Change --schema-out <file> argument for ccdscan-api to exit immediately

### DIFF
--- a/backend-rust/src/bin/ccdscan-api.rs
+++ b/backend-rust/src/bin/ccdscan-api.rs
@@ -32,9 +32,9 @@ struct Cli {
     /// Maximum number of connections in the pool.
     #[arg(long, env = "CCDSCAN_API_DATABASE_MAX_CONNECTIONS", default_value_t = 10)]
     max_connections: u32,
-    /// Output the GraphQL Schema for the API and then exits. Output is stored
-    /// as a file at the provided path or to stdout when '-' is provided and
-    /// exit.
+    /// Outputs the GraphQL Schema for the API and then exits. The output is
+    /// stored as a file at the provided path or to stdout when '-' is
+    /// provided.
     #[arg(long)]
     schema_out: Option<PathBuf>,
     /// Address to listen to for API requests.

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -31,8 +31,8 @@ use anyhow::Context as _;
 use async_graphql::{
     http::GraphiQLSource,
     types::{self, connection},
-    ComplexObject, Context, EmptyMutation, Enum, MergedObject, Object, Schema, SimpleObject,
-    Subscription, Union,
+    ComplexObject, Context, EmptyMutation, Enum, MergedObject, Object, SDLExportOptions, Schema,
+    SimpleObject, Subscription, Union,
 };
 use async_graphql_axum::GraphQLSubscription;
 use block::Block;
@@ -171,7 +171,7 @@ pub struct Query(
 );
 
 pub struct Service {
-    pub schema: Schema<Query, EmptyMutation, Subscription>,
+    schema: Schema<Query, EmptyMutation, Subscription>,
 }
 impl Service {
     pub fn new(
@@ -189,6 +189,13 @@ impl Service {
         Self {
             schema,
         }
+    }
+
+    /// Construct the GraphQL Schema Definition Language used by the service.
+    pub fn sdl() -> String {
+        let (subscription, _) = Subscription::new(0);
+        let schema = Schema::build(Query::default(), EmptyMutation, subscription).finish();
+        schema.sdl_with_options(SDLExportOptions::new().prefer_single_line_descriptions())
     }
 
     pub async fn serve(


### PR DESCRIPTION
## Purpose

Change `--schema-out <file>` argument for `ccdscan-api` to exit immediately.

Later we will use this as part of the CI to generate the schema and ensure that we don't introduce changes by accident.