### PR TITLE
Disallow unused variables in graphql_api.rs

### DIFF
--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -1,8 +1,6 @@
 //! TODO
 //! - Enable GraphiQL through flag instead of always.
 
-#![allow(unused_variables)]
-
 mod account;
 mod account_metrics;
 mod baker;
@@ -562,10 +560,7 @@ impl BaseQuery {
             )
             .fetch_one(pool)
             .await?;
-
-            if let Some(edge) = connection.edges.last() {
-                connection.has_next_page = max_index.map_or(false, |db_max| db_max > page_max_index)
-            }
+            connection.has_next_page = max_index.map_or(false, |db_max| db_max > page_max_index)
         }
 
         if let Some(edge) = connection.edges.first() {
@@ -784,12 +779,12 @@ impl PaydayStatus {
     // `payday_summaries` list.
     async fn payday_summaries(
         &self,
-        #[graphql(desc = "Returns the first _n_ elements from the list.")] first: Option<u64>,
+        #[graphql(desc = "Returns the first _n_ elements from the list.")] _first: Option<u64>,
         #[graphql(desc = "Returns the elements in the list that come after the specified cursor.")]
-        after: Option<String>,
-        #[graphql(desc = "Returns the last _n_ elements from the list.")] last: Option<u64>,
+        _after: Option<String>,
+        #[graphql(desc = "Returns the last _n_ elements from the list.")] _last: Option<u64>,
         #[graphql(desc = "Returns the elements in the list that come before the specified cursor.")]
-        before: Option<String>,
+        _before: Option<String>,
     ) -> ApiResult<connection::Connection<String, PaydaySummary>> {
         let mut connection = connection::Connection::new(false, false);
 

--- a/backend-rust/src/graphql_api/account.rs
+++ b/backend-rust/src/graphql_api/account.rs
@@ -180,7 +180,7 @@ impl AccountReward {
 
     async fn amount(&self) -> ApiResult<Amount> { Ok(self.amount.try_into()?) }
 
-    async fn reward_type(&self, ctx: &Context<'_>) -> ApiResult<RewardType> {
+    async fn reward_type(&self) -> ApiResult<RewardType> {
         let transaction: RewardType = self.entry_type.try_into().map_err(|_| {
             ApiError::InternalError(format!(
                 "AccountStatementEntryType: Not a valid reward type: {}",

--- a/backend-rust/src/graphql_api/block.rs
+++ b/backend-rust/src/graphql_api/block.rs
@@ -284,7 +284,7 @@ impl Block {
             .fetch_one(pool)
             .await?
             .unwrap_or(0);
-            connection.has_previous_page = page_min_index.map_or(false, |i| i > 0);
+            connection.has_previous_page = page_min_id > 0;
             connection.has_next_page = page_max_id < max_index;
         }
         Ok(connection)

--- a/backend-rust/src/graphql_api/token.rs
+++ b/backend-rust/src/graphql_api/token.rs
@@ -84,9 +84,7 @@ impl Token {
         )
     }
 
-    async fn total_supply(&self, ctx: &Context<'_>) -> ApiResult<BigInteger> {
-        Ok(BigInteger::from(self.raw_total_supply.clone()))
-    }
+    async fn total_supply(&self) -> BigInteger { BigInteger::from(self.raw_total_supply.clone()) }
 
     async fn token_address(&self) -> &String { &self.token_address }
 
@@ -98,8 +96,8 @@ impl Token {
 
     async fn contract_sub_index(&self) -> i64 { self.contract_sub_index }
 
-    async fn contract_address_formatted(&self, ctx: &Context<'_>) -> ApiResult<String> {
-        Ok(format!("<{},{}>", self.contract_index, self.contract_sub_index))
+    async fn contract_address_formatted(&self) -> String {
+        format!("<{},{}>", self.contract_index, self.contract_sub_index)
     }
 
     async fn accounts(
@@ -371,9 +369,7 @@ impl AccountToken {
         Account::query_by_index(get_pool(ctx)?, self.account_id).await?.ok_or(ApiError::NotFound)
     }
 
-    async fn balance(&self, ctx: &Context<'_>) -> ApiResult<BigInteger> {
-        Ok(BigInteger::from(self.raw_balance.clone()))
-    }
+    async fn balance(&self) -> BigInteger { BigInteger::from(self.raw_balance.clone()) }
 }
 
 // Interim struct used to fetch AccountToken data from the database.


### PR DESCRIPTION
## Purpose

Remove `#![allow(unused_variables)]` from `graphql_api.rs` and address the warnings