### PR TITLE
Provide option to point to different .env file

### DIFF
--- a/backend-rust/.env.mainnet
+++ b/backend-rust/.env.mainnet
@@ -1,0 +1,12 @@
+# gRPC interface of the node.
+CCDSCAN_INDEXER_GRPC_ENDPOINTS=https://grpc.mainnet.concordium.software
+# CCDSCAN_INDEXER_GRPC_ENDPOINTS=http://localhost:20000
+
+# Database connection used by the ccdscan-indexer.
+CCDSCAN_INDEXER_DATABASE_URL=postgres://postgres:secret@localhost/ccdscan_mainnet
+
+# Database connection used by the ccdscan-api.
+CCDSCAN_API_DATABASE_URL=${CCDSCAN_INDEXER_DATABASE_URL}
+
+# Run database migrations at startup.
+CCDSCAN_INDEXER_MIGRATE=true

--- a/backend-rust/.env.mainnet
+++ b/backend-rust/.env.mainnet
@@ -1,5 +1,5 @@
 # gRPC interface of the node.
-CCDSCAN_INDEXER_GRPC_ENDPOINTS=https://grpc.mainnet.concordium.software
+CCDSCAN_INDEXER_GRPC_ENDPOINTS=https://grpc.mainnet.concordium.software:20000
 # CCDSCAN_INDEXER_GRPC_ENDPOINTS=http://localhost:20000
 
 # Database connection used by the ccdscan-indexer.

--- a/backend-rust/.env.stagenet
+++ b/backend-rust/.env.stagenet
@@ -1,0 +1,12 @@
+# gRPC interface of the node.
+CCDSCAN_INDEXER_GRPC_ENDPOINTS=https://grpc.stagenet.concordium.com
+# CCDSCAN_INDEXER_GRPC_ENDPOINTS=http://localhost:20500
+
+# Database connection used by the ccdscan-indexer.
+CCDSCAN_INDEXER_DATABASE_URL=postgres://postgres:secret@localhost/ccdscan_stagenet
+
+# Database connection used by the ccdscan-api.
+CCDSCAN_API_DATABASE_URL=${CCDSCAN_INDEXER_DATABASE_URL}
+
+# Run database migrations at startup.
+CCDSCAN_INDEXER_MIGRATE=true

--- a/backend-rust/.env.stagenet
+++ b/backend-rust/.env.stagenet
@@ -1,9 +1,9 @@
 # gRPC interface of the node.
-CCDSCAN_INDEXER_GRPC_ENDPOINTS=https://grpc.stagenet.concordium.com
+CCDSCAN_INDEXER_GRPC_ENDPOINTS=https://grpc.stagenet.concordium.com:20000
 # CCDSCAN_INDEXER_GRPC_ENDPOINTS=http://localhost:20500
 
 # Database connection used by the ccdscan-indexer.
-CCDSCAN_INDEXER_DATABASE_URL=postgres://postgres:secret@localhost/ccdscan_stagenet
+CCDSCAN_INDEXER_DATABASE_URL=postgres://postgres:secret@localhost/ccdscan_stagenet2
 
 # Database connection used by the ccdscan-api.
 CCDSCAN_API_DATABASE_URL=${CCDSCAN_INDEXER_DATABASE_URL}

--- a/backend-rust/.env.testnet
+++ b/backend-rust/.env.testnet
@@ -1,5 +1,5 @@
 # gRPC interface of the node.
-CCDSCAN_INDEXER_GRPC_ENDPOINTS=https://grpc.testnet.concordium.com
+CCDSCAN_INDEXER_GRPC_ENDPOINTS=https://grpc.testnet.concordium.com:20000
 # CCDSCAN_INDEXER_GRPC_ENDPOINTS=http://localhost:20001
 
 # Database connection used by the ccdscan-indexer.

--- a/backend-rust/.env.testnet
+++ b/backend-rust/.env.testnet
@@ -1,0 +1,12 @@
+# gRPC interface of the node.
+CCDSCAN_INDEXER_GRPC_ENDPOINTS=https://grpc.testnet.concordium.com
+# CCDSCAN_INDEXER_GRPC_ENDPOINTS=http://localhost:20001
+
+# Database connection used by the ccdscan-indexer.
+CCDSCAN_INDEXER_DATABASE_URL=postgres://postgres:secret@localhost/ccdscan_testnet
+
+# Database connection used by the ccdscan-api.
+CCDSCAN_API_DATABASE_URL=${CCDSCAN_INDEXER_DATABASE_URL}
+
+# Run database migrations at startup.
+CCDSCAN_INDEXER_MIGRATE=true


### PR DESCRIPTION
## Purpose

Add `--dovenv <file>`  option to both binaries, useful when running the service for several environments.

