### PR TITLE
Move query `useBlockSpecialEventsQuery` to new API

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Move query `useBlockSpecialEventsQuery` to new API.
+
 ## [1.6.2] - 2025-01-19
 
 ### Changed

--- a/frontend/src/queries/useBlockSpecialEventsQuery.ts
+++ b/frontend/src/queries/useBlockSpecialEventsQuery.ts
@@ -402,6 +402,7 @@ export const useBlockSpecialEventsQuery = ({
 		BlockSpecialEventsResponse | undefined
 	>({
 		query: BlockSpecialEventsQuery,
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		requestPolicy: 'cache-first',
 		variables: {
 			blockId,


### PR DESCRIPTION
## Purpose

Move query `useBlockSpecialEventsQuery` to new API