### PR TITLE
Fix useTransactionQuery error due to field names clashing

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Move query `useBlockSpecialEventsQuery` to new API.
+- Rename `ContractUpgraded.from` and `ContractUpgraded.to` in query `useTransactionQuery` to avoid error of fields which cannot be merged, as these were clashing with `Transferred.from` and `Transferred.to`.
 
 ## [1.6.2] - 2025-01-19
 

--- a/frontend/src/components/TransactionEventList/Events/ContractUpgraded.vue
+++ b/frontend/src/components/TransactionEventList/Events/ContractUpgraded.vue
@@ -6,8 +6,10 @@
 			:contract-address-index="event.contractAddress.index"
 			:contract-address-sub-index="event.contractAddress.subIndex"
 		/>
-		upgraded module from <ModuleLink :module-reference="event.from" /> to module
-		<ModuleLink :module-reference="event.to" />.
+		<!-- @vue-expect-error Typescript is not aware that event.from got renamed to fromModule in the query -->
+		upgraded module from <ModuleLink :module-reference="event.fromModule" /> to
+		<!-- @vue-expect-error Typescript is not aware that event.to got renamed to toModule in the query -->
+		module <ModuleLink :module-reference="event.toModule" />.
 	</span>
 </template>
 

--- a/frontend/src/queries/useTransactionQuery.ts
+++ b/frontend/src/queries/useTransactionQuery.ts
@@ -101,8 +101,8 @@ __typename
 		index
 		subIndex
 	}
-	from
-	to
+	fromModule: from # Renamed to avoid errors due to clashing with 'Transferred.from'.
+	toModule: to     # Renamed to avoid errors due to clashing with 'Transferred.to'.
 }
 ... on CredentialKeysUpdated {
 	credId


### PR DESCRIPTION
## Purpose

Fixes #436 

Bug was introduced as part of the [PR fixing type warnings](https://github.com/Concordium/concordium-scan/pull/291).

Here I revert the changes, disable the warning for these lines and document why.
