### PR TITLE
Provide TCP keepalive option for indexer

### DIFF
--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -4,14 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `ccdscan-indexer`: Provide option `--node-tcp-keepalive <duration>` (env `CCDSCAN_INDEXER_CONFIG_NODE_TCP_KEEPALIVE`) to enable TCP keepalive messages for connections to Concordium Nodes.
+  Takes the duration in seconds to remain idle before sending TCP keepalive probes.
+
 ### Changed
 
-- Make the `Query::transaction_metrics` use fixed buckets making it consistent with behavior of the old .NET backend.
+- `ccdscan-api`: Make the `Query::transaction_metrics` use fixed buckets making it consistent with behavior of the old .NET backend.
 
 ### Fix
 
-- Fix unit conversion for `avg_finalization_time` in `Query::block_metrics`.
-- Issue for `Query::transaction_metrics` producing an internal error when query period is beyond the genesis block.
+- `ccdscan-api`: Fix unit conversion for `avg_finalization_time` in `Query::block_metrics`.
+- `ccdscan-api`: Issue for `Query::transaction_metrics` producing an internal error when query period is beyond the genesis block.
 
 ## [0.1.19] - 2025-01-30
 

--- a/backend-rust/src/indexer.rs
+++ b/backend-rust/src/indexer.rs
@@ -83,6 +83,11 @@ pub struct IndexerServiceConfig {
     /// Connection timeout in seconds when connecting a Concordium Node.
     #[arg(long, env = "CCDSCAN_INDEXER_CONFIG_NODE_CONNECT_TIMEOUT", default_value = "10")]
     pub node_connect_timeout:             u64,
+    /// Set to enable TCP keepalive messages on accepted connections.
+    /// Takes the duration in seconds to remain idle before sending TCP
+    /// keepalive probes.
+    #[arg(long, env = "CCDSCAN_INDEXER_CONFIG_NODE_TCP_KEEPALIVE")]
+    pub node_tcp_keepalive:               Option<u64>,
     /// Maximum number of blocks being preprocessed in parallel.
     #[arg(
         long,
@@ -131,6 +136,7 @@ impl IndexerService {
                 };
                 Ok(endpoint
                     .timeout(Duration::from_secs(config.node_request_timeout))
+                    .tcp_keepalive(config.node_tcp_keepalive.map(Duration::from_secs))
                     .connect_timeout(Duration::from_secs(config.node_connect_timeout)))
             })
             .collect::<anyhow::Result<_>>()?;


### PR DESCRIPTION

## Added

- `ccdscan-indexer`: Provide option `--node-tcp-keepalive <duration>` (env `CCDSCAN_INDEXER_CONFIG_NODE_TCP_KEEPALIVE`) to enable TCP keepalive messages for connections to Concordium Nodes.
  Takes the duration in seconds to remain idle before sending TCP keepalive probes.