### PR TITLE
Frontend fix for contract details and release

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Rename `ContractUpgraded.from` and `ContractUpgraded.to` in query `useTransactionQuery` to avoid error of fields which cannot be merged, as these were clashing with `Transferred.from` and `Transferred.to`.
+- Rename `ContractUpgraded.from` and `ContractUpgraded.to` in query `useTransactionQuery` and `useContractQuery` to avoid error of fields which cannot be merged, as these were clashing with `Transferred.from` and `Transferred.to`.
 
 ## [1.6.2] - 2025-01-19
 

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.7.0] - 2025-02-03
+
 ### Added
 
 - Add "Last" button for pagination based on cursors.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.6.2",
+	"version": "1.7.0",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/components/Contracts/ContractDetailsEvents.vue
+++ b/frontend/src/components/Contracts/ContractDetailsEvents.vue
@@ -52,15 +52,15 @@
 					<div>
 						<div>From Module</div>
 						<div>
-							<!-- Uses alias from query -->
-							<ModuleLink :module-reference="contractEvent.event.from" />
+							<!-- @vue-expect-error Typescript is not aware that event.from got renamed to fromModule in the query -->
+							<ModuleLink :module-reference="contractEvent.event.fromModule" />
 						</div>
 					</div>
 					<div>
 						<div>To Module</div>
 						<div>
-							<!-- Uses alias from query -->
-							<ModuleLink :module-reference="contractEvent.event.to" />
+							<!-- @vue-expect-error Typescript is not aware that event.to got renamed to toModule in the query -->
+							<ModuleLink :module-reference="contractEvent.event.toModule" />
 						</div>
 					</div>
 				</DetailsView>

--- a/frontend/src/queries/useContractQuery.ts
+++ b/frontend/src/queries/useContractQuery.ts
@@ -125,8 +125,8 @@ event {
 			index
 			subIndex
 		}
-		from
-		to
+		moduleFrom: from
+		moduleTo: to
 	}
 	... on Transferred {
 		amount


### PR DESCRIPTION
## Purpose

Fix bug preventing contract details from being shown and prepare release 1.7.0.

The bug was introduced as part of the [PR fixing type warnings](https://github.com/Concordium/concordium-scan/pull/291).

Here I revert the changes, disable the warning for these lines and document why.
