### PR TITLE
Run CI checks when PR is edited (base branch changes)

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -7,7 +7,7 @@ on:
         - backend-rust/**
         - .github/**
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [ main ]
     paths:
         - backend-rust/**

--- a/.github/workflows/backend-net-checks.yml
+++ b/.github/workflows/backend-net-checks.yml
@@ -2,7 +2,7 @@ name: Check backend (.NET)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [ main ]
     paths:
         - backend/**

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -6,7 +6,7 @@ on:
     paths:
         - frontend/**
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [ main ]
     paths:
         - frontend/**


### PR DESCRIPTION
## Purpose

Enable CI checks to run when `edited` to ensure they are run, when PR use another PR as the base branch and the first gets merged.
This event also includes changes to the title of the PR, which is unfortunate but seems like a small thing.