### PR TITLE
Always display hexDecimal logs and messages

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Always display the `hexDecimal` representation of logs and messages.
+- Always display the `hexDecimal` representation of smart contract logs and messages.
 
 ## [1.7.0] - 2025-02-03
 

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Always display the `hexDecimal` representation of logs and messages.
+
 ## [1.7.0] - 2025-02-03
 
 ### Added

--- a/frontend/src/components/Contracts/ContractDetailsEvents.vue
+++ b/frontend/src/components/Contracts/ContractDetailsEvents.vue
@@ -74,7 +74,7 @@
 						:events="contractEvent.event.events"
 					/>
 					<LogsHEX
-						v-else-if="contractEvent.event.eventsAsHex?.nodes?.length"
+						v-if="contractEvent.event.eventsAsHex?.nodes?.length"
 						:events-as-hex="contractEvent.event.eventsAsHex"
 					/>
 				</DetailsView>

--- a/frontend/src/components/Contracts/ContractDetailsRejectEvents.vue
+++ b/frontend/src/components/Contracts/ContractDetailsRejectEvents.vue
@@ -78,7 +78,7 @@
 						:message="contractRejectEvent.rejectedEvent.message"
 					/>
 					<MessageHEX
-						v-else-if="contractRejectEvent.rejectedEvent.messageAsHex"
+						v-if="contractRejectEvent.rejectedEvent.messageAsHex"
 						:message-as-hex="contractRejectEvent.rejectedEvent.messageAsHex"
 					/>
 				</DetailsView>

--- a/frontend/src/components/Contracts/Events/ContractCall.vue
+++ b/frontend/src/components/Contracts/Events/ContractCall.vue
@@ -39,7 +39,7 @@
 		:message="props.contractEvent.contractUpdated.message"
 	/>
 	<MessageHEX
-		v-else-if="props.contractEvent.contractUpdated.messageAsHex"
+		v-if="props.contractEvent.contractUpdated.messageAsHex"
 		:message-as-hex="props.contractEvent.contractUpdated.messageAsHex"
 	/>
 	<Logs
@@ -47,7 +47,7 @@
 		:events="props.contractEvent.contractUpdated.events"
 	/>
 	<LogsHEX
-		v-else-if="props.contractEvent.contractUpdated.eventsAsHex?.nodes?.length"
+		v-if="props.contractEvent.contractUpdated.eventsAsHex?.nodes?.length"
 		:events-as-hex="props.contractEvent.contractUpdated.eventsAsHex"
 	/>
 </template>

--- a/frontend/src/components/Contracts/Events/ContractInitialized.vue
+++ b/frontend/src/components/Contracts/Events/ContractInitialized.vue
@@ -27,7 +27,7 @@
 		:events="props.contractEvent.events"
 	/>
 	<LogsHEX
-		v-else-if="props.contractEvent.eventsAsHex?.nodes?.length"
+		v-if="props.contractEvent.eventsAsHex?.nodes?.length"
 		:events-as-hex="props.contractEvent.eventsAsHex"
 	/>
 </template>

--- a/frontend/src/components/Contracts/Events/ContractUpdated.vue
+++ b/frontend/src/components/Contracts/Events/ContractUpdated.vue
@@ -45,7 +45,7 @@
 		:message="props.contractEvent.message"
 	/>
 	<MessageHEX
-		v-else-if="props.contractEvent.messageAsHex"
+		v-if="props.contractEvent.messageAsHex"
 		:message-as-hex="props.contractEvent.messageAsHex"
 	/>
 	<Logs
@@ -53,7 +53,7 @@
 		:events="props.contractEvent.events"
 	/>
 	<LogsHEX
-		v-else-if="props.contractEvent.eventsAsHex?.nodes?.length"
+		v-if="props.contractEvent.eventsAsHex?.nodes?.length"
 		:events-as-hex="props.contractEvent.eventsAsHex"
 	/>
 </template>


### PR DESCRIPTION
## Purpose

Fix https://github.com/Concordium/concordium-scan/issues/461

## Changes

- Always display the `hexDecimal` representation of logs and messages.
