### PR TITLE
Fix Query::blocks issue when before/after parameter are provided

### DIFF
--- a/backend-rust/.sqlx/query-90eb6256da2b7725f64955ba77448390047c2f65468ec6a5dad561fb8dc66d65.json
+++ b/backend-rust/.sqlx/query-90eb6256da2b7725f64955ba77448390047c2f65468ec6a5dad561fb8dc66d65.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * FROM (\n                SELECT\n                    hash,\n                    height,\n                    slot_time,\n                    block_time,\n                    finalization_time,\n                    baker_id,\n                    total_amount\n                FROM blocks\n                WHERE height > $1 AND height < $2\n                ORDER BY\n                    (CASE WHEN $4 THEN height END) ASC,\n                    (CASE WHEN NOT $4 THEN height END) DESC\n                LIMIT $3\n            ) ORDER BY height DESC",
+  "query": "SELECT * FROM (\n                SELECT\n                    hash,\n                    height,\n                    slot_time,\n                    block_time,\n                    finalization_time,\n                    baker_id,\n                    total_amount\n                FROM blocks\n                WHERE height < $1 AND height > $2\n                ORDER BY\n                    (CASE WHEN $4 THEN height END) ASC,\n                    (CASE WHEN NOT $4 THEN height END) DESC\n                LIMIT $3\n            ) ORDER BY height DESC",
   "describe": {
     "columns": [
       {
@@ -57,5 +57,5 @@
       false
     ]
   },
-  "hash": "3c68bcd07cc8ddee8de17f2996ece8aa625aa70aef64153347f79d84e9dd9a6b"
+  "hash": "90eb6256da2b7725f64955ba77448390047c2f65468ec6a5dad561fb8dc66d65"
 }

--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - Revert the API breaking change of renaming `Versions::backend_versions` to `Versions::backend_version`.
 - Fix order of module reference reject events to DESC
 - Fix order of chained contracts events to DESC
-
+- Fix issue in API `Query::blocks`, where providing `before` or `after` did not consider the blocks to be descending block height order.
 
 ## [0.1.21] - 2025-02-10
 

--- a/backend-rust/src/graphql_api/block.rs
+++ b/backend-rust/src/graphql_api/block.rs
@@ -1,6 +1,7 @@
 use super::{get_config, get_pool, ApiError, ApiResult, ConnectionQuery};
 use crate::{
     block_special_event::{SpecialEvent, SpecialEventTypeFilter},
+    connection::DescendingI64,
     graphql_api::Transaction,
     scalar_types::{Amount, BakerId, BlockHash, BlockHeight, DateTime},
     transaction_event::Event,
@@ -45,7 +46,7 @@ impl QueryBlocks {
     ) -> ApiResult<connection::Connection<String, Block>> {
         let config = get_config(ctx)?;
         let pool = get_pool(ctx)?;
-        let query = ConnectionQuery::<BlockHeight>::new(
+        let query = ConnectionQuery::<DescendingI64>::new(
             first,
             after,
             last,
@@ -68,14 +69,14 @@ impl QueryBlocks {
                     baker_id,
                     total_amount
                 FROM blocks
-                WHERE height > $1 AND height < $2
+                WHERE height < $1 AND height > $2
                 ORDER BY
                     (CASE WHEN $4 THEN height END) ASC,
                     (CASE WHEN NOT $4 THEN height END) DESC
                 LIMIT $3
             ) ORDER BY height DESC",
-            query.from,
-            query.to,
+            i64::from(query.from),
+            i64::from(query.to),
             query.limit,
             query.desc
         )


### PR DESCRIPTION
## Purpose

Fix #495 
