### PR TITLE
Fix misleading variable names in connection.rs

### DIFF
--- a/backend-rust/src/connection.rs
+++ b/backend-rust/src/connection.rs
@@ -55,14 +55,19 @@ pub fn connection_from_slice<T: AsRef<[A]>, A: async_graphql::OutputType + Clone
     Ok(connection)
 }
 
-/// Upper and lower limits for the Cursor in a GraphQL Cursor Connection.
+/// Bounds for the Cursor in a GraphQL Cursor Connection, used as the fallback
+/// when no explicit range is provided as `after`/`before`.
 pub trait ConnectionCursor {
-    const MIN: Self;
-    const MAX: Self;
+    /// A non-inclusive bound for the start of the collection provided as the
+    /// connection.
+    const START_BOUND: Self;
+    /// A non-inclusive bound for the end of the collection provided as the
+    /// connection.
+    const END_BOUND: Self;
 }
 impl ConnectionCursor for i64 {
-    const MAX: i64 = i64::MAX;
-    const MIN: i64 = i64::MIN;
+    const END_BOUND: i64 = i64::MAX;
+    const START_BOUND: i64 = i64::MIN;
 }
 
 /// GraphQL Connection Cursor representing a collection where the pages are
@@ -72,8 +77,8 @@ impl ConnectionCursor for i64 {
 pub struct DescendingI64(i64);
 
 impl ConnectionCursor for DescendingI64 {
-    const MAX: Self = Self(i64::MIN);
-    const MIN: Self = Self(i64::MAX);
+    const END_BOUND: Self = Self(i64::MIN);
+    const START_BOUND: Self = Self(i64::MAX);
 }
 
 /// Prepared query arguments for SQL query, based on arguments from a GraphQL
@@ -81,17 +86,17 @@ impl ConnectionCursor for DescendingI64 {
 #[derive(Debug)]
 pub struct ConnectionQuery<A> {
     /// The lower to use for the SQL query.
-    pub from:  A,
+    pub from:    A,
     /// The upper to use for the SQL query.
-    pub to:    A,
+    pub to:      A,
     /// The limit to use for the SQL query.
-    pub limit: i64,
+    pub limit:   i64,
     /// If the `last` elements are requested instead of the `first` elements
     /// (indicated by the `last` key being set when creating a new
     /// `ConnectionQuery`), the edges/nodes should be ordered in reverse
     /// (DESC) order before applying the range. This allows the range from
     /// `from` to `to` to be applied starting from the last element.
-    pub desc:  bool,
+    pub is_last: bool,
 }
 impl<A> ConnectionQuery<A> {
     /// Validate and prepare GraphQL Cursor Connection arguments to be used for
@@ -113,13 +118,13 @@ impl<A> ConnectionQuery<A> {
         let from = if let Some(a) = after {
             a.parse::<A>().map_err(|e| e.into())?
         } else {
-            A::MIN
+            A::START_BOUND
         };
 
         let to = if let Some(b) = before {
             b.parse::<A>().map_err(|e| e.into())?
         } else {
-            A::MAX
+            A::END_BOUND
         };
 
         let limit =
@@ -129,7 +134,7 @@ impl<A> ConnectionQuery<A> {
             from,
             to,
             limit,
-            desc: last.is_some(),
+            is_last: last.is_some(),
         })
     }
 }

--- a/backend-rust/src/connection.rs
+++ b/backend-rust/src/connection.rs
@@ -85,17 +85,17 @@ impl ConnectionCursor for DescendingI64 {
 /// Cursor Connection resolver.
 #[derive(Debug)]
 pub struct ConnectionQuery<A> {
-    /// The lower to use for the SQL query.
+    /// The non-inclusive starting bound to use for the SQL sub-query.
     pub from:    A,
-    /// The upper to use for the SQL query.
+    /// The non-inclusive end bound to use for the SQL sub-query.
     pub to:      A,
-    /// The limit to use for the SQL query.
+    /// The limit to use for the SQL sub-query.
     pub limit:   i64,
     /// If the `last` elements are requested instead of the `first` elements
     /// (indicated by the `last` key being set when creating a new
-    /// `ConnectionQuery`), the edges/nodes should be ordered in reverse
-    /// (DESC) order before applying the range. This allows the range from
-    /// `from` to `to` to be applied starting from the last element.
+    /// `ConnectionQuery`), the edges/nodes should first be ordered in reverse
+    /// order with the limit in a sub-query and the result then ordered again to
+    /// keep the page ordering consistent.
     pub is_last: bool,
 }
 impl<A> ConnectionQuery<A> {

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -870,7 +870,7 @@ impl SearchResult {
             query.from,
             query.to,
             query.limit,
-            query.desc,
+            query.is_last,
             lower_case_query.parse::<i64>().ok(),
             lower_case_query
         )
@@ -1007,7 +1007,7 @@ impl SearchResult {
             query.from,
             query.to,
             query.limit,
-            query.desc,
+            query.is_last,
             self.query
         )
         .fetch_all(pool)

--- a/backend-rust/src/graphql_api/account.rs
+++ b/backend-rust/src/graphql_api/account.rs
@@ -140,7 +140,7 @@ impl QueryAccounts {
             matches!(order.field, AccountOrderField::TransactionCount),
             matches!(order.field, AccountOrderField::DelegatedStake),
             filter.map(|f| f.is_delegator).unwrap_or_default(),
-            query.desc != matches!(order.dir, OrderDir::Desc),
+            query.is_last != matches!(order.dir, OrderDir::Desc),
             query.limit,
             matches!(order.dir, OrderDir::Desc),
         )
@@ -458,7 +458,7 @@ impl Account {
             query.from,
             query.to,
             query.limit,
-            query.desc,
+            query.is_last,
             &self.index
         )
         .fetch(pool);
@@ -559,7 +559,7 @@ impl Account {
             self.index,
             query.from,
             query.to,
-            query.desc,
+            query.is_last,
             query.limit,
         )
         .fetch(pool);
@@ -670,7 +670,7 @@ impl Account {
             query.from,
             query.to,
             query.limit,
-            query.desc,
+            query.is_last,
             &self.index
         )
         .fetch(pool);
@@ -771,7 +771,7 @@ impl Account {
             query.from,
             query.to,
             query.limit,
-            query.desc,
+            query.is_last,
             &self.index
         )
         .fetch(pool);
@@ -882,7 +882,7 @@ impl AccountReleaseSchedule {
             query.from,
             query.to,
             query.limit,
-            query.desc,
+            query.is_last,
             self.account_index
         )
         .fetch_all(pool)

--- a/backend-rust/src/graphql_api/baker.rs
+++ b/backend-rust/src/graphql_api/baker.rs
@@ -250,7 +250,7 @@ impl Baker {
             ) ORDER BY index DESC"#,
             query.from,
             query.to,
-            query.desc,
+            query.is_last,
             query.limit,
             self.id.0,
             account_transaction_type_filter as &[AccountTransactionType]

--- a/backend-rust/src/graphql_api/block.rs
+++ b/backend-rust/src/graphql_api/block.rs
@@ -78,7 +78,7 @@ impl QueryBlocks {
             i64::from(query.from),
             i64::from(query.to),
             query.limit,
-            query.desc
+            query.is_last
         )
         .fetch_all(pool)
         .await?;
@@ -252,7 +252,7 @@ impl Block {
             ) ORDER BY block_outcome_index ASC"#,
             query.from,
             query.to,
-            query.desc,
+            query.is_last,
             query.limit,
             self.height,
             disable_filtering,
@@ -344,7 +344,7 @@ impl Block {
             ) ORDER BY index ASC"#,
             query.from,
             query.to,
-            query.desc,
+            query.is_last,
             query.limit,
             self.height
         )

--- a/backend-rust/src/graphql_api/contract.rs
+++ b/backend-rust/src/graphql_api/contract.rs
@@ -122,7 +122,7 @@ impl QueryContract {
             i64::from(query.from),
             i64::from(query.to),
             query.limit,
-            query.desc
+            query.is_last
         )
         .fetch(pool);
 

--- a/backend-rust/src/graphql_api/token.rs
+++ b/backend-rust/src/graphql_api/token.rs
@@ -75,7 +75,7 @@ impl QueryToken {
             i64::from(query.from),
             i64::from(query.to),
             query.limit,
-            query.desc
+            query.is_last
         )
         .fetch(pool);
         let mut connection = connection::Connection::new(false, false);

--- a/backend-rust/src/graphql_api/transaction.rs
+++ b/backend-rust/src/graphql_api/transaction.rs
@@ -87,7 +87,7 @@ impl QueryTransactions {
             ) ORDER BY index ASC"#,
             query.from,
             query.to,
-            query.desc,
+            query.is_last,
             query.limit,
         )
         .fetch(pool);


### PR DESCRIPTION
## Purpose

Rename some variables in `connection.rs` which are named differently from how these are used.
This should not change any semantics of the code.
