### PR TITLE
Use transaction metrics and transaction list from rust backend

### DIFF
--- a/backend-rust/.sqlx/query-809b53801320323a3355be773064d4fe31dcea326624663b1bfe5fd24d2963af.json
+++ b/backend-rust/.sqlx/query-809b53801320323a3355be773064d4fe31dcea326624663b1bfe5fd24d2963af.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                    SELECT MAX(index) as max_id, MIN(index) as min_id \n                    FROM transactions\n                ",
+  "query": "SELECT MAX(index) as max_id, MIN(index) as min_id FROM transactions",
   "describe": {
     "columns": [
       {
@@ -22,5 +22,5 @@
       null
     ]
   },
-  "hash": "70d1654528edc7b593c9b4ca7af379b4cbd670399ae7fad23e2415606f293a75"
+  "hash": "809b53801320323a3355be773064d4fe31dcea326624663b1bfe5fd24d2963af"
 }

--- a/backend-rust/.sqlx/query-9184bfdb5aebf2a9b62399e363e1be7d7f1f79dcda47f0e0d2486b1084ea632a.json
+++ b/backend-rust/.sqlx/query-9184bfdb5aebf2a9b62399e363e1be7d7f1f79dcda47f0e0d2486b1084ea632a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * FROM (\n                SELECT\n                    index,\n                    block_height,\n                    hash,\n                    ccd_cost,\n                    energy_cost,\n                    sender_index,\n                    type as \"tx_type: DbTransactionType\",\n                    type_account as \"type_account: AccountTransactionType\",\n                    type_credential_deployment as \"type_credential_deployment: CredentialDeploymentTransactionType\",\n                    type_update as \"type_update: UpdateTransactionType\",\n                    success,\n                    events as \"events: sqlx::types::Json<Vec<Event>>\",\n                    reject as \"reject: sqlx::types::Json<TransactionRejectReason>\"\n                FROM transactions\n                WHERE $1 < index AND index < $2\n                ORDER BY\n                    (CASE WHEN $3 THEN index END) DESC,\n                    (CASE WHEN NOT $3 THEN index END) ASC\n                LIMIT $4\n            ) ORDER BY index ASC",
+  "query": "SELECT * FROM (\n                SELECT\n                    index,\n                    block_height,\n                    hash,\n                    ccd_cost,\n                    energy_cost,\n                    sender_index,\n                    type as \"tx_type: DbTransactionType\",\n                    type_account as \"type_account: AccountTransactionType\",\n                    type_credential_deployment as \"type_credential_deployment: CredentialDeploymentTransactionType\",\n                    type_update as \"type_update: UpdateTransactionType\",\n                    success,\n                    events as \"events: sqlx::types::Json<Vec<Event>>\",\n                    reject as \"reject: sqlx::types::Json<TransactionRejectReason>\"\n                FROM transactions\n                WHERE $2 < index AND index < $1\n                ORDER BY\n                    (CASE WHEN $3 THEN index END) ASC,\n                    (CASE WHEN NOT $3 THEN index END) DESC\n                LIMIT $4\n            ) ORDER BY index DESC",
   "describe": {
     "columns": [
       {
@@ -175,5 +175,5 @@
       true
     ]
   },
-  "hash": "d22e09eb2c0419201f6c81e0d183947129e28d081d83704562a1672d9345ca45"
+  "hash": "9184bfdb5aebf2a9b62399e363e1be7d7f1f79dcda47f0e0d2486b1084ea632a"
 }

--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Fix API issue where `Query::block_metrics` computed summary of metrics period using the wrong starting point, causing metrics to be off some of the time.
 - Fix API issue where `Query::block_metrics` computed summary of metrics period using blocks which had no finalization time set.
 - Fix now on application side in `Query::block_metrics` to ensure data calculated on across different queries are the same.
+- Query `Query::transactions` now outputs items in the order of newest->oldest, instead of oldest->newest.
 
 ## [0.1.22] - 2025-02-11
 

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.7.2] - 2025-02-11
+
+- Move query `useTransactionMetricsQuery` to new API.
+
 ## [1.7.1] - 2025-02-07
 
 ### Changed

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.7.2] - 2025-02-11
 
-- Move query `useTransactionMetricsQuery` to new API.
+- Move query `useTransactionMetricsQuery` and `useTransactionsListQuery` to new API.
 
 ## [1.7.1] - 2025-02-07
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/queries/useTransactionListQuery.ts
+++ b/frontend/src/queries/useTransactionListQuery.ts
@@ -60,6 +60,7 @@ export const useTransactionsListQuery = (
 	variables: Partial<QueryVariables>
 ) => {
 	const { data, executeQuery } = useQuery({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: TransactionsQuery,
 		requestPolicy: 'cache-and-network',
 		variables,

--- a/frontend/src/queries/useTransactionMetrics.ts
+++ b/frontend/src/queries/useTransactionMetrics.ts
@@ -22,6 +22,7 @@ const TransactionMetricsQuery = gql<TransactionMetricsQueryResponse>`
 
 export const useTransactionMetricsQuery = (period: Ref<MetricsPeriod>) => {
 	const { data, executeQuery, fetching } = useQuery({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: TransactionMetricsQuery,
 		requestPolicy: 'cache-and-network',
 		variables: { period },


### PR DESCRIPTION
## Purpose

Use transaction metrics and transaction list from the Rust API.

Also changed the transaction list order from newest -> oldest to match the .NET backend.