### PR TITLE
Frontend: Only support transaction hash as identifier and not ID

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix transaction links from transaction list page. These failed due to using a transaction ID which is incompatible with the new API, instead only the transaction hash can be used now.
+
 ## [1.7.2] - 2025-02-11
+
+### Changed
 
 - Move query `useTransactionMetricsQuery` and `useTransactionsListQuery` to new API.
 

--- a/frontend/src/components/molecules/TransactionLink.vue
+++ b/frontend/src/components/molecules/TransactionLink.vue
@@ -1,10 +1,10 @@
 ﻿<template>
-	<div v-if="props.hash || props.id" class="inline-block whitespace-nowrap">
+	<div v-if="props.hash" class="inline-block whitespace-nowrap">
 		<TransactionIcon class="h-4 w-4 align-text-top" />
 		<LinkButton
 			class="numerical px-2"
 			@blur="emitBlur"
-			@click="() => handleOnClick(props.hash, props.id)"
+			@click="() => handleOnClick(props.hash)"
 		>
 			<div v-if="props.hideTooltip" text-class="text-theme-body">
 				{{ shortenHash(props.hash) }}
@@ -14,7 +14,7 @@
 			</Tooltip>
 		</LinkButton>
 		<TextCopy
-			:text="props.hash ?? ''"
+			:text="props.hash"
 			label="Click to copy transaction hash to clipboard"
 			class="h-5 inline align-baseline"
 			tooltip-class="font-sans"
@@ -27,8 +27,7 @@ import { useDrawer } from '~/composables/useDrawer'
 import LinkButton from '~/components/atoms/LinkButton.vue'
 import TransactionIcon from '~/components/icons/TransactionIcon.vue'
 type Props = {
-	hash?: string
-	id?: string
+	hash: string
 	hideTooltip?: boolean
 }
 const props = defineProps<Props>()
@@ -38,8 +37,7 @@ const emitBlur = (newTarget: FocusEvent) => {
 	emit('blur', newTarget)
 }
 
-const handleOnClick = (hash?: string, id?: string) => {
-	if (hash || id)
-		drawer.push({ entityTypeName: 'transaction', hash: hash || '', id })
+const handleOnClick = (hash: string) => {
+	drawer.push({ entityTypeName: 'transaction', hash })
 }
 </script>

--- a/frontend/src/pages/transactions/index.vue
+++ b/frontend/src/pages/transactions/index.vue
@@ -53,10 +53,7 @@
 					:key="transaction.transactionHash"
 				>
 					<TableTd>
-						<TransactionLink
-							:id="transaction.id"
-							:hash="transaction.transactionHash"
-						/>
+						<TransactionLink :hash="transaction.transactionHash" />
 					</TableTd>
 					<TableTd>
 						<TransactionResult :result="transaction.result" :show-text="true" />


### PR DESCRIPTION
## Purpose

Fix transaction links from transaction list page. These failed due to using a transaction ID which is incompatible with the new API, instead only the transaction hash can be used now.

Fix #514 