### PR TITLE
Timespan format

### DIFF
--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix metrics where interval is being shown in greater units than strictly seconds
+
 ## [0.1.23] - 2025-02-11
 
 Database schema version: 3


### PR DESCRIPTION
## Purpose

We do not want to show the interval in secs, but a more appropriate unit dependent on size of the timespan