### PR TITLE
Add logic for lottery power

### DIFF
--- a/backend-rust/.sqlx/query-111042cda533aaaeb74ad51acfe5ece689058acf1dd302c7d429b1e5e2d706f1.json
+++ b/backend-rust/.sqlx/query-111042cda533aaaeb74ad51acfe5ece689058acf1dd302c7d429b1e5e2d706f1.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO bakers_payday_lottery_powers (\n                id,\n                payday_lottery_power\n            )\n            SELECT\n                UNNEST($1::BIGINT[]) AS id,\n                UNNEST($2::NUMERIC[]) AS payday_lottery_power",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8Array",
+        "NumericArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "111042cda533aaaeb74ad51acfe5ece689058acf1dd302c7d429b1e5e2d706f1"
+}

--- a/backend-rust/.sqlx/query-90dfde0be8b6c6aa1d00061e92babe7a89aa36ddce688bbe996a592c3d7a12b5.json
+++ b/backend-rust/.sqlx/query-90dfde0be8b6c6aa1d00061e92babe7a89aa36ddce688bbe996a592c3d7a12b5.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                bakers.id as id,\n                staked,\n                restake_earnings,\n                open_status as \"open_status: BakerPoolOpenStatus\",\n                metadata_url,\n                transaction_commission,\n                baking_commission,\n                finalization_commission,\n                payday_transaction_commission,\n                payday_baking_commission,\n                payday_finalization_commission\n            FROM bakers \n                LEFT JOIN bakers_payday_commission_rates ON bakers_payday_commission_rates.id = bakers.id\n            WHERE bakers.id = $1\n            ",
+  "query": "\n            SELECT\n                bakers.id as id,\n                staked,\n                restake_earnings,\n                open_status as \"open_status: BakerPoolOpenStatus\",\n                metadata_url,\n                transaction_commission,\n                baking_commission,\n                finalization_commission,\n                payday_transaction_commission,\n                payday_baking_commission,\n                payday_finalization_commission,\n                payday_lottery_power as lottery_power\n            FROM bakers \n                LEFT JOIN bakers_payday_commission_rates ON bakers_payday_commission_rates.id = bakers.id\n                LEFT JOIN bakers_payday_lottery_powers ON bakers_payday_lottery_powers.id = bakers.id\n            WHERE bakers.id = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -68,6 +68,11 @@
         "ordinal": 10,
         "name": "payday_finalization_commission",
         "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "lottery_power",
+        "type_info": "Numeric"
       }
     ],
     "parameters": {
@@ -86,8 +91,9 @@
       true,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "cf076e5a9f1f3d5a536b0325584073bbbdefcadf33aa379940a1ef27e6dbb445"
+  "hash": "90dfde0be8b6c6aa1d00061e92babe7a89aa36ddce688bbe996a592c3d7a12b5"
 }

--- a/backend-rust/.sqlx/query-f7d67c27717abe9eaeb99b00d681cd75e2215f7574d27b5354610e6d8e769f09.json
+++ b/backend-rust/.sqlx/query-f7d67c27717abe9eaeb99b00d681cd75e2215f7574d27b5354610e6d8e769f09.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM\n                bakers_payday_lottery_powers",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "f7d67c27717abe9eaeb99b00d681cd75e2215f7574d27b5354610e6d8e769f09"
+}

--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+Database schema version: 4
+
+### Added
+
+- Database migration to add the lottery power of each baker pool during the last payday period.
+- Add Query `Query::Baker::state::pool::lotteryPower` which returns the `lotteryPower` of the baker pool during the last payday period.
+
 ## [0.1.24] - 2025-02-12
 
 ### Fixed

--- a/backend-rust/src/graphql_api/baker.rs
+++ b/backend-rust/src/graphql_api/baker.rs
@@ -84,7 +84,7 @@ pub struct Baker {
     payday_transaction_commission: Option<i64>,
     payday_baking_commission: Option<i64>,
     payday_finalization_commission: Option<i64>,
-    lottery_power: BigDecimal,
+    lottery_power: Option<BigDecimal>,
 }
 impl Baker {
     pub async fn query_by_id(pool: &PgPool, baker_id: i64) -> ApiResult<Option<Self>> {
@@ -214,7 +214,8 @@ impl Baker {
                 payday_commission_rates,
                 lottery_power: self
                     .lottery_power
-                    .clone()
+                    .as_ref()
+                    .unwrap_or(&BigDecimal::default())
                     .try_into()
                     .map_err(|e: anyhow::Error| ApiError::InternalError(e.to_string()))?,
                 metadata_url: self.metadata_url.as_deref(),
@@ -469,7 +470,8 @@ struct BakerPool<'a> {
     ///   from the bakers table upon detecting the `BakerEvent::Removed`,
     ///   whereas `payday_commission_rates` persist until the next payday.
     payday_commission_rates: Option<CommissionRates>,
-    /// comments
+    /// The lottery power of the baker pool during the last payday period
+    /// captured from the `get_election_info` node endpoint.`
     lottery_power:           Decimal,
     // /// Ranking of the baker pool by total staked amount. Value may be null for
     // /// brand new bakers where statistics have not been calculated yet. This

--- a/backend-rust/src/graphql_api/baker.rs
+++ b/backend-rust/src/graphql_api/baker.rs
@@ -12,6 +12,7 @@ use crate::{
     },
 };
 use async_graphql::{connection, types, Context, Enum, InputObject, Object, SimpleObject, Union};
+use bigdecimal::BigDecimal;
 use concordium_rust_sdk::types::AmountFraction;
 use futures::TryStreamExt;
 use sqlx::PgPool;
@@ -83,6 +84,7 @@ pub struct Baker {
     payday_transaction_commission: Option<i64>,
     payday_baking_commission: Option<i64>,
     payday_finalization_commission: Option<i64>,
+    lottery_power: BigDecimal,
 }
 impl Baker {
     pub async fn query_by_id(pool: &PgPool, baker_id: i64) -> ApiResult<Option<Self>> {
@@ -100,9 +102,11 @@ impl Baker {
                 finalization_commission,
                 payday_transaction_commission,
                 payday_baking_commission,
-                payday_finalization_commission
+                payday_finalization_commission,
+                payday_lottery_power as lottery_power
             FROM bakers 
                 LEFT JOIN bakers_payday_commission_rates ON bakers_payday_commission_rates.id = bakers.id
+                LEFT JOIN bakers_payday_lottery_powers ON bakers_payday_lottery_powers.id = bakers.id
             WHERE bakers.id = $1
             "#,
             baker_id
@@ -208,6 +212,11 @@ impl Baker {
                     finalization_commission,
                 },
                 payday_commission_rates,
+                lottery_power: self
+                    .lottery_power
+                    .clone()
+                    .try_into()
+                    .map_err(|e: anyhow::Error| ApiError::InternalError(e.to_string()))?,
                 metadata_url: self.metadata_url.as_deref(),
                 total_stake_percentage,
                 total_stake: total_pool_stake.try_into()?,
@@ -460,7 +469,8 @@ struct BakerPool<'a> {
     ///   from the bakers table upon detecting the `BakerEvent::Removed`,
     ///   whereas `payday_commission_rates` persist until the next payday.
     payday_commission_rates: Option<CommissionRates>,
-    // lottery_power:           Decimal,
+    /// comments
+    lottery_power:           Decimal,
     // /// Ranking of the baker pool by total staked amount. Value may be null for
     // /// brand new bakers where statistics have not been calculated yet. This
     // /// should be rare and only a temporary condition.

--- a/backend-rust/src/indexer.rs
+++ b/backend-rust/src/indexer.rs
@@ -4093,11 +4093,11 @@ impl PreparedPayDayBlock {
         let payday_commission_rates =
             PreparedPaydayCommissionRates::prepare(baker_reward_period_infos)?;
 
-        let consensus_info = node_client
+        let election_info = node_client
             .get_election_info(BlockIdentifier::AbsoluteHeight(block_height))
             .await?
             .response;
-        let bakers_lottery_powers = PreparedPaydayLotteryPowers::prepare(consensus_info.bakers)?;
+        let bakers_lottery_powers = PreparedPaydayLotteryPowers::prepare(election_info.bakers)?;
 
         Ok(Self {
             block_height: block_height.height.try_into()?,
@@ -4218,7 +4218,7 @@ impl PreparedPaydayLotteryPowers {
             bakers_lottery_powers.push(
                 BigDecimal::from_f64(baker.baker_lottery_power)
                     .context(
-                        "Expected 64 type (baker_lottery_power) to be converted correctly into \
+                        "Expected f64 type (baker_lottery_power) to be converted correctly into \
                          BigDecimal type",
                     )
                     .map_err(RPCError::ParseError)?,

--- a/backend-rust/src/migrations.rs
+++ b/backend-rust/src/migrations.rs
@@ -173,15 +173,16 @@ pub enum SchemaVersion {
     IndexBlocksWithNoCumulativeFinTime,
     #[display("0003:PayDayPoolCommissionRates")]
     PayDayPoolCommissionRates,
+    #[display("0004:PayDayLotteryPowers")]
+    PayDayLotteryPowers,
 }
 impl SchemaVersion {
     /// The minimum supported database schema version for the API.
     /// Fails at startup if any breaking database schema versions have been
     /// introduced since this version.
-    pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion =
-        SchemaVersion::PayDayPoolCommissionRates;
+    pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion = SchemaVersion::PayDayLotteryPowers;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::PayDayPoolCommissionRates;
+    const LATEST: SchemaVersion = SchemaVersion::PayDayLotteryPowers;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.
@@ -200,6 +201,7 @@ impl SchemaVersion {
             SchemaVersion::InitialFirstHalf => false,
             SchemaVersion::IndexBlocksWithNoCumulativeFinTime => false,
             SchemaVersion::PayDayPoolCommissionRates => false,
+            SchemaVersion::PayDayLotteryPowers => false,
         }
     }
 
@@ -227,7 +229,11 @@ impl SchemaVersion {
                 tx.as_mut().execute(sqlx::raw_sql(include_str!("./migrations/m0003.sql"))).await?;
                 SchemaVersion::PayDayPoolCommissionRates
             }
-            SchemaVersion::PayDayPoolCommissionRates => unimplemented!(
+            SchemaVersion::PayDayPoolCommissionRates => {
+                tx.as_mut().execute(sqlx::raw_sql(include_str!("./migrations/m0004.sql"))).await?;
+                SchemaVersion::PayDayLotteryPowers
+            }
+            SchemaVersion::PayDayLotteryPowers => unimplemented!(
                 "No migration implemented for database schema version {}",
                 self.as_i64()
             ),

--- a/backend-rust/src/migrations/m0004.sql
+++ b/backend-rust/src/migrations/m0004.sql
@@ -1,0 +1,11 @@
+CREATE TABLE bakers_payday_lottery_powers(
+    -- Baker/validator ID, corresponding to the account index.
+    id
+        BIGINT
+        PRIMARY KEY,
+    -- Fraction of transaction rewards rewarded at payday to this baker pool.
+    -- Stored as a fraction of an amount with a precision of `1/100_000`.
+    payday_lottery_power
+        NUMERIC
+        NOT NULL
+);

--- a/backend-rust/src/migrations/m0004.sql
+++ b/backend-rust/src/migrations/m0004.sql
@@ -3,8 +3,7 @@ CREATE TABLE bakers_payday_lottery_powers(
     id
         BIGINT
         PRIMARY KEY,
-    -- Fraction of transaction rewards rewarded at payday to this baker pool.
-    -- Stored as a fraction of an amount with a precision of `1/100_000`.
+    -- Lottery power in the consensus algorithm at the last payday period of the above baker.
     payday_lottery_power
         NUMERIC
         NOT NULL

--- a/backend-rust/src/scalar_types.rs
+++ b/backend-rust/src/scalar_types.rs
@@ -135,10 +135,10 @@ impl From<concordium_rust_sdk::types::AmountFraction> for Decimal {
     }
 }
 
-impl TryFrom<BigDecimal> for Decimal {
+impl TryFrom<&BigDecimal> for Decimal {
     type Error = anyhow::Error;
 
-    fn try_from(value: BigDecimal) -> Result<Self, Self::Error> {
+    fn try_from(value: &BigDecimal) -> Result<Self, Self::Error> {
         let float_value =
             value.to_f64().ok_or_else(|| anyhow::anyhow!("Failed to convert BigDecimal to f64"))?;
 

--- a/backend-rust/src/scalar_types.rs
+++ b/backend-rust/src/scalar_types.rs
@@ -1,5 +1,7 @@
 use anyhow::Context;
 use async_graphql::{scalar, InputValueError, InputValueResult, Scalar, ScalarType, Value};
+use bigdecimal::BigDecimal;
+use num_traits::{FromPrimitive, ToPrimitive};
 use std::fmt;
 
 pub type Amount = UnsignedLong;
@@ -130,6 +132,20 @@ impl ScalarType for Decimal {
 impl From<concordium_rust_sdk::types::AmountFraction> for Decimal {
     fn from(fraction: concordium_rust_sdk::types::AmountFraction) -> Self {
         Self(concordium_rust_sdk::types::PartsPerHundredThousands::from(fraction).into())
+    }
+}
+
+impl TryFrom<BigDecimal> for Decimal {
+    type Error = anyhow::Error;
+
+    fn try_from(value: BigDecimal) -> Result<Self, Self::Error> {
+        let float_value =
+            value.to_f64().ok_or_else(|| anyhow::anyhow!("Failed to convert BigDecimal to f64"))?;
+
+        let decimal = rust_decimal::Decimal::from_f64(float_value)
+            .ok_or_else(|| anyhow::anyhow!("Failed to convert f64 to rust_decimal::Decimal"))?;
+
+        Ok(Decimal(decimal))
     }
 }
 


### PR DESCRIPTION
Addresses https://github.com/Concordium/concordium-scan/issues/367

## Purpose
```
query ($bakerId: Long!) {
  bakerByBakerId(bakerId: $bakerId) {
    state {
      __typename
      ... on ActiveBakerState {
        pool {
          lotteryPower
        }
      }
    }
  }
}
```
Related https://linear.app/concordium/issue/CCD-142/implement-bakerpool

## Changes

Add `lottery power` logic.
