### PR TITLE
Fix account balance in account statements

### DIFF
--- a/backend-rust/.sqlx/query-a7813d35171e674b7ba19410fbbc4be6b521f51783281839d7b858227cbc424f.json
+++ b/backend-rust/.sqlx/query-a7813d35171e674b7ba19410fbbc4be6b521f51783281839d7b858227cbc424f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH account_info AS (\n            SELECT index AS account_index, amount + $3 AS current_balance\n            FROM accounts\n            WHERE address = $1\n        )\n        INSERT INTO account_statements (\n            account_index,\n            entry_type,\n            amount,\n            block_height,\n            transaction_id,\n            account_balance\n        )\n        SELECT\n            account_index,\n            $2,\n            $3,\n            $4,\n            $5,\n            current_balance\n        FROM account_info",
+  "query": "WITH account_info AS (\n            SELECT index AS account_index, amount AS current_balance\n            FROM accounts\n            WHERE address = $1\n        )\n        INSERT INTO account_statements (\n            account_index,\n            entry_type,\n            amount,\n            block_height,\n            transaction_id,\n            account_balance\n        )\n        SELECT\n            account_index,\n            $2,\n            $3,\n            $4,\n            $5,\n            current_balance\n        FROM account_info",
   "describe": {
     "columns": [],
     "parameters": {
@@ -31,5 +31,5 @@
     },
     "nullable": []
   },
-  "hash": "db4f484caba8ef401bef8838ef4dd2307f78aa97664509767d50ff6a7c3cee03"
+  "hash": "a7813d35171e674b7ba19410fbbc4be6b521f51783281839d7b858227cbc424f"
 }

--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -15,8 +15,10 @@ Database schema version: 5
 - Add database migration fixing:
   - Invalid bakers caused by `DelegationEvent::RemoveBaker` event not being handled by the indexer until now.
   - Invalid delegator state, caused by validator/baker getting removed or changing status to 'ClosedForAll' without moving delegators to the passive pool.
+  - Invalid account balance for account statements, where the change in amount got accounted twice.
 - Fixed indexer missing handling of moving delegators as pool got removed or closed.
 - Fixed indexer missing handling of event of baker switching directly to delegation.
+- Fixed indexer account twice for the changed amount in account statements.
 
 ## [0.1.25] - 2025-02-14
 

--- a/backend-rust/src/migrations/m0005-fix-dangling-delegators.sql
+++ b/backend-rust/src/migrations/m0005-fix-dangling-delegators.sql
@@ -19,3 +19,9 @@ ALTER TABLE accounts
     ADD CONSTRAINT fk_delegated_target_baker_id
         FOREIGN KEY (delegated_target_baker_id)
         REFERENCES bakers (id);
+
+-- Migration fixing invalid data for table `account_statements`. Here the changed amount (`amount`)
+-- got accounted for twice in `account_balance`.
+
+UPDATE account_statements
+    SET account_balance = account_balance - amount;


### PR DESCRIPTION
## Purpose

The changed amount got accounted for twice in the balance stored in the account statements.
This PR fixes that and adds a data fix to the migration.