### PR TITLE
Handle restaking and update stake

### DIFF
--- a/backend-rust/.sqlx/query-b6a021f65c32c86a03655066143410700595922ecfd0f4e4c0165ce0d0e41fc6.json
+++ b/backend-rust/.sqlx/query-b6a021f65c32c86a03655066143410700595922ecfd0f4e4c0165ce0d0e41fc6.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE bakers\n                    SET\n                        staked = CASE\n                                WHEN restake_earnings THEN staked + $2\n                                ELSE staked\n                            END\n                WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b6a021f65c32c86a03655066143410700595922ecfd0f4e4c0165ce0d0e41fc6"
+}

--- a/backend-rust/.sqlx/query-fc16002ac99907e9145d7d8ec90da3c19bd8ee295ce5fe582e4d1d80500ab4c2.json
+++ b/backend-rust/.sqlx/query-fc16002ac99907e9145d7d8ec90da3c19bd8ee295ce5fe582e4d1d80500ab4c2.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE accounts\n                SET\n                    delegated_stake = CASE\n                            WHEN delegated_restake_earnings THEN delegated_stake + $2\n                            ELSE delegated_stake\n                        END\n                WHERE address = $1\n                RETURNING index, delegated_restake_earnings",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "delegated_restake_earnings",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "fc16002ac99907e9145d7d8ec90da3c19bd8ee295ce5fe582e4d1d80500ab4c2"
+}

--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -4,15 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Fixed
-
-- Remove locked CCD metrics
-
-Database schema version: 5
+Database schema version: 6
 
 ### Fixed
 
-- Add database migration fixing:
+- Add database migration 6 fixing invalid baker and delegator stake due to missing handling of restake earnings.
+- Indexer now updates stake when restake earnings are enabled for bakers and delegators.
+- Remove locked CCD metrics.
+- Add database migration 5 fixing:
   - Invalid bakers caused by `DelegationEvent::RemoveBaker` event not being handled by the indexer until now.
   - Invalid delegator state, caused by validator/baker getting removed or changing status to 'ClosedForAll' without moving delegators to the passive pool.
   - Invalid account balance for account statements, where the change in amount got accounted twice.

--- a/backend-rust/src/migrations.rs
+++ b/backend-rust/src/migrations.rs
@@ -194,7 +194,7 @@ impl SchemaVersion {
     /// introduced since this version.
     pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion = SchemaVersion::PayDayLotteryPowers;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::FixDanglingDelegators;
+    const LATEST: SchemaVersion = SchemaVersion::FixStakedAmounts;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.

--- a/backend-rust/src/migrations.rs
+++ b/backend-rust/src/migrations.rs
@@ -8,6 +8,7 @@ use tracing::info;
 type Transaction = sqlx::Transaction<'static, sqlx::Postgres>;
 
 mod m0005_fix_dangling_delegators;
+mod m0006_fix_stake;
 
 /// Ensure the current database schema version is compatible with the supported
 /// schema version.
@@ -184,6 +185,8 @@ pub enum SchemaVersion {
     PayDayLotteryPowers,
     #[display("0005:Fix invalid data of dangling delegators.")]
     FixDanglingDelegators,
+    #[display("0006:Fix staked amounts")]
+    FixStakedAmounts,
 }
 impl SchemaVersion {
     /// The minimum supported database schema version for the API.
@@ -212,6 +215,7 @@ impl SchemaVersion {
             SchemaVersion::PayDayPoolCommissionRates => false,
             SchemaVersion::PayDayLotteryPowers => false,
             SchemaVersion::FixDanglingDelegators => false,
+            SchemaVersion::FixStakedAmounts => false,
         }
     }
 
@@ -250,7 +254,10 @@ impl SchemaVersion {
             SchemaVersion::PayDayLotteryPowers => {
                 m0005_fix_dangling_delegators::run(&mut tx, endpoints).await?
             }
-            SchemaVersion::FixDanglingDelegators => unimplemented!(
+            SchemaVersion::FixDanglingDelegators => {
+                m0006_fix_stake::run(&mut tx, endpoints).await?
+            }
+            SchemaVersion::FixStakedAmounts => unimplemented!(
                 "No migration implemented for database schema version {}",
                 self.as_i64()
             ),

--- a/backend-rust/src/migrations/m0006_fix_stake.rs
+++ b/backend-rust/src/migrations/m0006_fix_stake.rs
@@ -1,0 +1,85 @@
+//! Migration fixing corrupt data in table `bakers` column `staked` and
+//! `accounts` column `delegated_stake`.
+
+use super::{SchemaVersion, Transaction};
+use anyhow::Context;
+use concordium_rust_sdk::{types::AbsoluteBlockHeight, v2};
+use tokio_stream::StreamExt;
+
+/// Resulting database schema version from running this migration.
+const NEXT_SCHEMA_VERSION: SchemaVersion = SchemaVersion::FixStakedAmounts;
+
+/// Run database migration and returns the new database schema version when
+/// successful.
+pub async fn run(
+    tx: &mut Transaction,
+    endpoints: &[v2::Endpoint],
+) -> anyhow::Result<SchemaVersion> {
+    // Get the last processed block height.
+    let block_height: Option<i64> =
+        sqlx::query_scalar("SELECT height FROM blocks ORDER BY height DESC LIMIT 1")
+            .fetch_optional(tx.as_mut())
+            .await?;
+    let Some(block_height) = block_height else {
+        // If result is None, we did not index any block yet and we are done migrating.
+        return Ok(NEXT_SCHEMA_VERSION);
+    };
+    let block_height = AbsoluteBlockHeight::from(u64::try_from(block_height)?);
+    let endpoint = endpoints.first().context(format!(
+        "Migration '{}' must be provided access to a Concordium node",
+        NEXT_SCHEMA_VERSION
+    ))?;
+    let mut client = v2::Client::new(endpoint.clone()).await?;
+    let mut bakers = client.get_baker_list(block_height).await?.response;
+
+    let mut baker_ids = Vec::new();
+    let mut baker_stakes = Vec::new();
+    let mut delegator_addresses = Vec::new();
+    let mut delegator_stakes = Vec::new();
+    while let Some(baker) = bakers.try_next().await? {
+        let account_info = client
+            .get_account_info(&v2::AccountIdentifier::Index(baker.id), block_height)
+            .await?
+            .response;
+
+        let baker_id: i64 = baker.id.index.try_into()?;
+        let staked =
+            account_info.account_stake.context("Expected account to be baker")?.staked_amount();
+        baker_ids.push(baker_id);
+        baker_stakes.push(i64::try_from(staked.micro_ccd())?);
+
+        let mut pool_delegators = client.get_pool_delegators(block_height, baker).await?.response;
+        while let Some(delegator) = pool_delegators.try_next().await? {
+            delegator_addresses.push(delegator.account.to_string());
+            delegator_stakes.push(i64::try_from(delegator.stake.micro_ccd())?)
+        }
+    }
+
+    sqlx::query(
+        "UPDATE bakers
+                 SET staked = input.staked
+             FROM (SELECT
+                 UNNEST($1::BIGINT[]) AS id,
+                 UNNEST($2::BIGINT[]) AS staked) AS input
+             WHERE bakers.id = input.id",
+    )
+    .bind(baker_ids.as_slice())
+    .bind(baker_stakes.as_slice())
+    .execute(tx.as_mut())
+    .await?;
+
+    sqlx::query(
+        "UPDATE accounts
+                 SET delegated_stake = input.staked
+             FROM (SELECT
+                 UNNEST($1::VARCHAR[]) AS address,
+                 UNNEST($2::BIGINT[]) AS staked) AS input
+             WHERE accounts.address = input.address",
+    )
+    .bind(delegator_addresses.as_slice())
+    .bind(delegator_stakes.as_slice())
+    .execute(tx.as_mut())
+    .await?;
+
+    Ok(NEXT_SCHEMA_VERSION)
+}


### PR DESCRIPTION
## Purpose

Add handling of restake_earnings in the indexer and introduce migration 6 for updating the current stake from chain.