### PR TITLE
Fix validation on tokens

### DIFF
--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.28] - 2025-02-26
+
 Database schema version: 10
+
+### Fixed
+
+- Make validation of rows changed to account tokens accept the zero value changed
 
 ### Added
 

--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -10,7 +10,7 @@ Database schema version: 10
 
 ### Fixed
 
-- Make validation of rows changed to account tokens accept the zero value changed
+- Make validation of rows changed to account tokens accept the zero rows modified
 
 ### Added
 

--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-scan"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-scan"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 description = "CCDScan: Indexer and API for the Concordium blockchain"
 authors = ["Concordium <developers@concordium.com>"]

--- a/backend-rust/src/indexer.rs
+++ b/backend-rust/src/indexer.rs
@@ -3436,7 +3436,7 @@ async fn process_cis2_token_event(
                 .execute(tx.as_mut())
                 .await
                 .context("Failed inserting or updating account balance from burn event")?
-                .ensure_affected_one_row()?;
+                .ensure_affected_rows_in_range(0..=1)?;
             }
 
             // Insert the token event into the table.
@@ -3540,8 +3540,7 @@ async fn process_cis2_token_event(
                 )
                 .execute(tx.as_mut())
                 .await
-                .context("Failed inserting or updating account balance from transfer event (to)")?
-                .ensure_affected_one_row()?;
+                .context("Failed inserting or updating account balance from transfer event (to)")?;
             }
 
             // Insert the token event into the table.

--- a/backend-rust/src/indexer.rs
+++ b/backend-rust/src/indexer.rs
@@ -3540,7 +3540,8 @@ async fn process_cis2_token_event(
                 )
                 .execute(tx.as_mut())
                 .await
-                .context("Failed inserting or updating account balance from transfer event (to)")?;
+                .context("Failed inserting or updating account balance from transfer event (to)")?
+                .ensure_affected_rows_in_range(0..=1);
             }
 
             // Insert the token event into the table.

--- a/backend-rust/src/indexer.rs
+++ b/backend-rust/src/indexer.rs
@@ -3541,7 +3541,7 @@ async fn process_cis2_token_event(
                 .execute(tx.as_mut())
                 .await
                 .context("Failed inserting or updating account balance from transfer event (to)")?
-                .ensure_affected_rows_in_range(0..=1);
+                .ensure_affected_rows_in_range(0..=1)?;
             }
 
             // Insert the token event into the table.


### PR DESCRIPTION
## Purpose

We are failing because tokens related to smart contracts may not be to/from a valid account.