### PR TITLE
Migrate nodes to be using fungy ccdscan

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.7.5] - 2025-03-03
+
+### Fixed
+
+- Allowed queries `useNodeDetailQuery` and `useNodeQuery` to use a separate API.
+
 ## [1.7.4] - 2025-02-13
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ccscan-frontend",
 	"description": "CCDScan frontend",
-	"version": "1.7.4",
+	"version": "1.7.5",
 	"engine": "16",
 	"type": "module",
 	"private": true,

--- a/frontend/src/queries/useNodeDetailQuery.ts
+++ b/frontend/src/queries/useNodeDetailQuery.ts
@@ -71,6 +71,7 @@ const NodeDetailQuery = gql<NodeDetailResponse>`
 
 export const useNodeDetailQuery = (id: NodeStatus['id']) => {
 	const { data, fetching, error } = useQuery({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: NodeDetailQuery,
 		requestPolicy: 'cache-and-network',
 		variables: { id },

--- a/frontend/src/queries/useNodeQuery.ts
+++ b/frontend/src/queries/useNodeQuery.ts
@@ -61,6 +61,7 @@ export const useNodeQuery = (
 	variables: Partial<QueryVariables>
 ) => {
 	const { data, fetching, error } = useQuery({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: BakerQuery,
 		requestPolicy: 'cache-and-network',
 		variables: { sortField, sortDirection, ...variables },


### PR DESCRIPTION
## Purpose

Migrate nodes related endpoints to be using fungy CCDScan

https://linear.app/concordium/issue/CCD-200/frontend-nodes-to-fungy-ccdscan

Closes https://github.com/Concordium/concordium-scan/issues/559
