### PR TITLE
Use saturated sub at capital bound formula

### DIFF
--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -9,6 +9,7 @@ Database schema version: 11
 ### Fixed
 
 - Return `None` as ranking instead of an internal error for non-baker accounts and bakers that just got added until the next payday.
+- Fix underflow in `capital_bound` formula by saturating the value to 0.
 
 ### Added
 

--- a/backend-rust/src/graphql_api/baker.rs
+++ b/backend-rust/src/graphql_api/baker.rs
@@ -499,7 +499,7 @@ impl Baker {
             // u128.
             let capital_bound_cap_for_pool_numerator = capital_bound
                 * ((total_stake - delegated_stake_of_pool) as u128)
-                - (100_000 * (self.staked as u128));
+                    .saturating_sub(100_000 * (self.staked as u128));
 
             // Denominator is not zero since we checked that `capital_bound != 100_000`.
             let capital_bound_cap_for_pool_denominator: u128 = 100_000u128 - capital_bound;


### PR DESCRIPTION
## Purpose

Addresses https://github.com/Concordium/concordium-scan/issues/562

This helps to use the baker query again. Investigation into the formula still needs to be done (the issue stays open and is not addressed).
