### PR TITLE
Migrate queries to new backend

### DIFF
--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Change `Versions::backend_versions` to `Versions::backend_version`.
+
 ## [0.1.38] - 2025-03-21
 
 Database schema version: 18

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -452,7 +452,7 @@ struct BaseQuery;
 impl BaseQuery {
     async fn versions(&self, ctx: &Context<'_>) -> ApiResult<Versions> {
         Ok(Versions {
-            backend_versions: VERSION.to_string(),
+            backend_version: VERSION.to_string(),
             database_schema_version: current_schema_version(get_pool(ctx)?)
                 .await
                 .map_err(|e| ApiError::InternalError(e.to_string()))?
@@ -782,7 +782,7 @@ pub struct ChainParametersV1 {
 
 #[derive(SimpleObject)]
 struct Versions {
-    backend_versions: String,
+    backend_version: String,
     database_schema_version: String,
     api_supported_database_schema_version: String,
 }

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Change queries `useVersionsQuery`, `useTopDelegatorsQuery` and `usePaydayStatusQuery` to use the new `rust-backend` API.
+
 ## [1.7.8] - 2025-03-21
 
-### Fixed
+### Changed
 
-- Allowed queries `useBakerQuery` and `useBakerListQuery` to use the new `rust-backend` API.
+- Change queries `useBakerQuery` and `useBakerListQuery` to use the new `rust-backend` API.
 
 ### Added
 

--- a/frontend/src/queries/usePaydayStatusQuery.ts
+++ b/frontend/src/queries/usePaydayStatusQuery.ts
@@ -24,6 +24,7 @@ const PaydayStatusQuery = gql<PaydayStatusQueryResponse>`
 
 export const usePaydayStatusQuery = () => {
 	const { data, error, fetching } = useQuery({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: PaydayStatusQuery,
 		requestPolicy: 'cache-and-network',
 	})

--- a/frontend/src/queries/useTopDelegatorsQuery.ts
+++ b/frontend/src/queries/useTopDelegatorsQuery.ts
@@ -48,6 +48,7 @@ const TopDelegatorsQuery = gql<TopDelegatorsResponse>`
 
 export const useTopDelegatorsQuery = (variables: Partial<QueryVariables>) => {
 	const { data, error, fetching } = useQuery({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: TopDelegatorsQuery,
 		requestPolicy: 'cache-and-network',
 		variables,

--- a/frontend/src/queries/useVersionsQuery.ts
+++ b/frontend/src/queries/useVersionsQuery.ts
@@ -16,6 +16,7 @@ const VersionsQuery = gql<VersionsResponse>`
 
 export const useVersionsQuery = () => {
 	const { data } = useQuery({
+		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: VersionsQuery,
 		requestPolicy: 'cache-and-network',
 	})


### PR DESCRIPTION
## Purpose

Addresses https://github.com/Concordium/concordium-scan/issues/600

## Changes

-  Change queries `useVersionsQuery`, `useTopDelegatorsQuery` and `usePaydayStatusQuery` to use the new `rust-backend` API.
