### PR TITLE
Log level only apply for crate logs

### DIFF
--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -16,6 +16,7 @@ Database schema version: 20
 - Change `Versions::backend_versions` to `Versions::backend_version`.
 - When `effective_time` is zero then it translates into `Block::slot_time`.
 - Split up migration 18 into several SQL transactions to avoid timeouts for long running migrations.
+- Change CLI option `--log-level` to only apply for logs produced directly from this project, instead of including every dependency.
 
 ## [0.1.38] - 2025-03-21
 

--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -2412,6 +2412,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,8 +3169,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3172,8 +3190,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4459,10 +4483,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "1.0"
 tokio = { version = "1.37", features = ["rt-multi-thread", "sync", "signal"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rust_decimal = "1.35"
 iso8601-duration = { version = "0.2", features = ["chrono"] }
 tokio-util = "0.7"

--- a/backend-rust/src/bin/ccdscan-api.rs
+++ b/backend-rust/src/bin/ccdscan-api.rs
@@ -116,6 +116,8 @@ async fn main() -> anyhow::Result<()> {
         .with(
             tracing_subscriber::EnvFilter::builder()
                 .with_default_directive(
+                    // Only apply the --log-level option to logs produced from this crate and not
+                    // from the dependencies.
                     format!("{}={}", env!("CARGO_PKG_NAME").replace('-', "_"), cli.log_level)
                         .parse()?,
                 )

--- a/backend-rust/src/bin/ccdscan-indexer.rs
+++ b/backend-rust/src/bin/ccdscan-indexer.rs
@@ -16,6 +16,7 @@ use std::{net::SocketAddr, path::PathBuf, time::Duration};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 #[derive(Parser)]
 #[command(version, author, about)]
@@ -83,7 +84,17 @@ async fn main() -> anyhow::Result<()> {
         let _ = dotenvy::dotenv();
     }
     let cli = Cli::parse();
-    tracing_subscriber::fmt().with_max_level(cli.log_level).init();
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(
+                    format!("{}={}", env!("CARGO_PKG_NAME").replace('-', "_"), cli.log_level)
+                        .parse()?,
+                )
+                .from_env_lossy(),
+        )
+        .init();
     let pool = PgPoolOptions::new()
         .min_connections(cli.min_connections)
         .max_connections(cli.max_connections)

--- a/backend-rust/src/bin/ccdscan-indexer.rs
+++ b/backend-rust/src/bin/ccdscan-indexer.rs
@@ -89,6 +89,8 @@ async fn main() -> anyhow::Result<()> {
         .with(
             tracing_subscriber::EnvFilter::builder()
                 .with_default_directive(
+                    // Only apply the --log-level option to logs produced from this crate and not
+                    // from the dependencies.
                     format!("{}={}", env!("CARGO_PKG_NAME").replace('-', "_"), cli.log_level)
                         .parse()?,
                 )


### PR DESCRIPTION
## Purpose

Before setting `--log-level=debug` would result in debug logs from dependency, now it only applies to logs from this crate.
The old behavior can still be triggered by setting environment variable `RUST_LOG=debug`.