### PR TITLE
Fix delegated_stake_cap computation

### DIFF
--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -12,6 +12,7 @@ Database schema version: 27
 
 ### Fixed
 
+- Fixed issue when computing of `ActiveBakerState::delegated_stake_cap` where the order of operations were wrong, resulting in a cap of `0` for some validator pools.
 - Add database migration 27 reindexing credential deployments to include the Credential Registration ID in the events and to update the fee cost to 0.
 - Fix `Query::bakers` when sorted by block commission rate (both ascending and descending) to include bakers, which does not have a block commission for the current reward period.
 - Add database migration 26 updating pool information for the ones missing.

--- a/backend-rust/src/graphql_api/baker.rs
+++ b/backend-rust/src/graphql_api/baker.rs
@@ -2569,9 +2569,9 @@ impl CurrentBaker {
             // `1/100_000` in the database, we multiply the numerator and
             // denominator by 100_000. To reduce loss of precision, the value is computed in
             // u128.
-            let capital_bound_cap_for_pool_numerator = capital_bound
-                * ((total_stake - delegated_stake_of_pool) as u128)
-                    .saturating_sub(100_000 * (self.staked as u128));
+            let capital_bound_cap_for_pool_numerator = (capital_bound
+                * ((total_stake - delegated_stake_of_pool) as u128))
+                .saturating_sub(100_000 * (self.staked as u128));
 
             // Denominator is not zero since we checked that `capital_bound != 100_000`.
             let capital_bound_cap_for_pool_denominator: u128 = 100_000u128 - capital_bound;


### PR DESCRIPTION
## Purpose

The underflow fix released in `0.1.33` changed the order of operations, causing the computation to become 0 for some baker pools.
#643 
