### PR TITLE
Add statement-timeout option for API

### DIFF
--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Add query `Query::poolRewardMetricsForPassiveDelegation`.
 - Add REST API `/rest/export/statement` for exporting account statements as CSV.
+- Add `ccdscan-api` option `--statement-timeout-secs` (env `CCDSCAN_API_DATABASE_STATEMENT_TIMEOUT_SECS`) for configuring a statement timeout the database connections and abort any statement that takes more than the specified amount of time. Defaults to 30 seconds.
 
 ## [0.1.45] - 2025-04-03
 


### PR DESCRIPTION
## Purpose

To help protect against resources being taken up by accidental long-running queries in the API, this PR introduces an option for configuring the [`statement_timeout`](https://www.postgresql.org/docs/16/runtime-config-client.html#GUC-STATEMENT-TIMEOUT) for the connections in the pool of `ccdscan-api`.
Queries exceeding this time will be aborted, freeing up the resources.

