### PR TITLE
Fix graphql loading of config

### DIFF
--- a/backend-rust/CHANGELOG.md
+++ b/backend-rust/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.47]
+
+### Fixed
+
+- Fix issue where `ccdscan-api` GraphQL resolvers fail to load the config from the context.
+
 ## [0.1.46] - 2025-04-10
 
 ### Added

--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-scan"
-version = "0.1.46"
+version = "0.1.47"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-scan"
-version = "0.1.46"
+version = "0.1.47"
 edition = "2021"
 description = "CCDScan: Indexer and API for the Concordium blockchain"
 authors = ["Concordium <developers@concordium.com>"]

--- a/backend-rust/src/graphql_api.rs
+++ b/backend-rust/src/graphql_api.rs
@@ -431,7 +431,8 @@ pub fn get_pool<'a>(ctx: &Context<'a>) -> ApiResult<&'a PgPool> {
 
 /// Get service configuration from the context.
 pub fn get_config<'a>(ctx: &Context<'a>) -> ApiResult<&'a ApiServiceConfig> {
-    ctx.data::<ApiServiceConfig>().map_err(ApiError::NoServiceConfig)
+    let config = ctx.data::<Arc<ApiServiceConfig>>().map_err(ApiError::NoServiceConfig)?;
+    Ok(config.as_ref())
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## Purpose

After introducing the REST API calls the ApiServiceConfig was wrapped in reference counting, causing a runtime error for the resolvers as these rely on the exact type for extracting the config.
