### PR TITLE
Revert node status

### DIFF
--- a/frontend/src/queries/useNodeDetailQuery.ts
+++ b/frontend/src/queries/useNodeDetailQuery.ts
@@ -71,7 +71,6 @@ const NodeDetailQuery = gql<NodeDetailResponse>`
 
 export const useNodeDetailQuery = (id: NodeStatus['id']) => {
 	const { data, fetching, error } = useQuery({
-		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: NodeDetailQuery,
 		requestPolicy: 'cache-and-network',
 		variables: { id },

--- a/frontend/src/queries/useNodeQuery.ts
+++ b/frontend/src/queries/useNodeQuery.ts
@@ -61,7 +61,6 @@ export const useNodeQuery = (
 	variables: Partial<QueryVariables>
 ) => {
 	const { data, fetching, error } = useQuery({
-		context: { url: useRuntimeConfig().public.apiUrlRust },
 		query: BakerQuery,
 		requestPolicy: 'cache-and-network',
 		variables: { sortField, sortDirection, ...variables },


### PR DESCRIPTION
## Purpose

Temporarily revert to be using dotnet for node statuses, while we are finished searchresults.
