### PR TITLE
fix: enable docker file to copy the mock json files

### DIFF
--- a/backend-rust/Dockerfile
+++ b/backend-rust/Dockerfile
@@ -6,6 +6,7 @@ FROM ${build_image} AS build
 WORKDIR /usr/app
 
 COPY Cargo.toml Cargo.lock ./
+COPY stablecoin.json transaction.json transfers.json walletholdings.json ./ 
 COPY src ./src
 COPY concordium-rust-sdk /usr/app/concordium-rust-sdk
 COPY .sqlx .sqlx


### PR DESCRIPTION
## Purpose

To  enable the docker file to copy the mock json files 
## Changes

Docker file is changed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

