### PR TITLE
Feature/cor 1471 delegators restake earnings fix

### DIFF
--- a/backend/.sqlx/query-07beeea3aaa84862e254dbb6def92838c34953e3eb4c604099f30756552f5b66.json
+++ b/backend/.sqlx/query-07beeea3aaa84862e254dbb6def92838c34953e3eb4c604099f30756552f5b66.json
@@ -60,7 +60,7 @@
       false,
       false,
       false,
-      true,
+      false,
       true
     ]
   },

--- a/backend/.sqlx/query-27401f13b2a789cb34f27718bb5b83180ba975a0d215a2c2fc9b2979794f82d0.json
+++ b/backend/.sqlx/query-27401f13b2a789cb34f27718bb5b83180ba975a0d215a2c2fc9b2979794f82d0.json
@@ -27,7 +27,7 @@
     },
     "nullable": [
       false,
-      true,
+      false,
       true
     ]
   },

--- a/backend/.sqlx/query-3718ffba49bf956233bc3484a760921428b9676f862099739852d9613e16a23e.json
+++ b/backend/.sqlx/query-3718ffba49bf956233bc3484a760921428b9676f862099739852d9613e16a23e.json
@@ -38,7 +38,7 @@
     "nullable": [
       false,
       false,
-      true,
+      false,
       false
     ]
   },

--- a/backend/.sqlx/query-45718645c0181a1da2c5b236a0ad36daf7cdaa5d4fd96fba2dacfa5214657cf0.json
+++ b/backend/.sqlx/query-45718645c0181a1da2c5b236a0ad36daf7cdaa5d4fd96fba2dacfa5214657cf0.json
@@ -66,7 +66,7 @@
       false,
       false,
       false,
-      true,
+      false,
       true
     ]
   },

--- a/backend/.sqlx/query-634cf099c8527414084d8295e2be4aa8a2db5b77fbe2339aba92b8fbabcad359.json
+++ b/backend/.sqlx/query-634cf099c8527414084d8295e2be4aa8a2db5b77fbe2339aba92b8fbabcad359.json
@@ -37,7 +37,7 @@
     "nullable": [
       false,
       false,
-      true,
+      false,
       false
     ]
   },

--- a/backend/.sqlx/query-6e861830c7b2a53a038979cbc369b086a0db61122636f98e6429ee290726a6ed.json
+++ b/backend/.sqlx/query-6e861830c7b2a53a038979cbc369b086a0db61122636f98e6429ee290726a6ed.json
@@ -66,7 +66,7 @@
       false,
       false,
       false,
-      true,
+      false,
       true
     ]
   },

--- a/backend/.sqlx/query-df348e3b818510fd64f27578e842eadac44aa7c1d1908890b5ef17228eb1cfdd.json
+++ b/backend/.sqlx/query-df348e3b818510fd64f27578e842eadac44aa7c1d1908890b5ef17228eb1cfdd.json
@@ -56,7 +56,7 @@
       false,
       false,
       false,
-      true,
+      false,
       true
     ]
   },

--- a/backend/.sqlx/query-df46fdc109db1cb09f81b2429090a1b6aa5bfc7cd37ebdd16cc0d10ee29f7000.json
+++ b/backend/.sqlx/query-df46fdc109db1cb09f81b2429090a1b6aa5bfc7cd37ebdd16cc0d10ee29f7000.json
@@ -56,7 +56,7 @@
       false,
       false,
       false,
-      true,
+      false,
       true
     ]
   },

--- a/backend/.sqlx/query-f9c7439ef2e79cdc081b5d3d3a6fd01b67231dc756aa17f9d15a1631a06d9e37.json
+++ b/backend/.sqlx/query-f9c7439ef2e79cdc081b5d3d3a6fd01b67231dc756aa17f9d15a1631a06d9e37.json
@@ -56,7 +56,7 @@
       false,
       false,
       false,
-      true,
+      false,
       true
     ]
   },

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.7] - 2025-06-12
+
+Database schema version: 37
+
+- Added fix for delegators summary - Accounts table 'delegated_restake_earnings' is a boolean field that was set to NULL in the DB. Added migrations for this column to default to false, if delegated_restake_earnings was NULL previously. Also added the NOT NULL constraint to 'delegated_restake_earnings'.
+
 ## [2.0.6] - 2025-06-06
 
 Database schema version: 36

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-scan"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-scan"
-version = "2.0.6"
+version = "2.0.7"
 edition = "2021"
 description = "CCDScan: Indexer and API for the Concordium blockchain"
 authors = ["Concordium <developers@concordium.com>"]

--- a/backend/src/indexer/block/special_transaction_outcomes.rs
+++ b/backend/src/indexer/block/special_transaction_outcomes.rs
@@ -655,7 +655,11 @@ impl RestakeEarnings {
         )
         .fetch_one(tx.as_mut())
         .await?;
-        if let Some(restake) = account_row.delegated_restake_earnings {
+
+
+        let restake: bool = account_row.delegated_restake_earnings;
+
+        if restake{
             let bakers_expected_affected_range = if self.protocol_version > ProtocolVersion::P6 {
                 1..=1
             } else {
@@ -676,7 +680,7 @@ impl RestakeEarnings {
                 .await?
                 .ensure_affected_rows_in_range(bakers_expected_affected_range)?;
             }
-        } else {
+        }else {
             // When delegated_restake_earnings is None the account is not delegating, so it
             // might be baking.
             sqlx::query!(

--- a/backend/src/indexer/block/special_transaction_outcomes.rs
+++ b/backend/src/indexer/block/special_transaction_outcomes.rs
@@ -656,10 +656,9 @@ impl RestakeEarnings {
         .fetch_one(tx.as_mut())
         .await?;
 
-
         let restake: bool = account_row.delegated_restake_earnings;
 
-        if restake{
+        if restake {
             let bakers_expected_affected_range = if self.protocol_version > ProtocolVersion::P6 {
                 1..=1
             } else {
@@ -680,7 +679,7 @@ impl RestakeEarnings {
                 .await?
                 .ensure_affected_rows_in_range(bakers_expected_affected_range)?;
             }
-        }else {
+        } else {
             // When delegated_restake_earnings is None the account is not delegating, so it
             // might be baking.
             sqlx::query!(

--- a/backend/src/migrations.rs
+++ b/backend/src/migrations.rs
@@ -255,7 +255,9 @@ pub enum SchemaVersion {
     UpdateAccountTransactionTypes,
     #[display("0036: Added index and slot time for the account statements table")]
     IndexAndSlotTimeColumnAddedAccountStatements,
-    #[display("0037: Accounts restake earnings update null values to false and add not null constraint")]
+    #[display(
+        "0037: Accounts restake earnings update null values to false and add not null constraint"
+    )]
     AccountsDelegatedEarningsNullToFalseAndNotNullConstraint,
 }
 impl SchemaVersion {
@@ -265,7 +267,8 @@ impl SchemaVersion {
     pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion =
         SchemaVersion::IndexPartialContractsSearch;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::AccountsDelegatedEarningsNullToFalseAndNotNullConstraint;
+    const LATEST: SchemaVersion =
+        SchemaVersion::AccountsDelegatedEarningsNullToFalseAndNotNullConstraint;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.

--- a/backend/src/migrations.rs
+++ b/backend/src/migrations.rs
@@ -17,6 +17,7 @@ mod m0023_add_init_parameter;
 mod m0025_fix_passive_delegator_stake;
 mod m0026_update_genesis_validator_info;
 mod m0027_reindex_credential_deployments;
+mod m0037_accounts_delegated_restake_earnings_migrate_null_to_false_and_add_not_null_contraint;
 
 /// Ensure the current database schema version is compatible with the supported
 /// schema version.
@@ -254,6 +255,8 @@ pub enum SchemaVersion {
     UpdateAccountTransactionTypes,
     #[display("0036: Added index and slot time for the account statements table")]
     IndexAndSlotTimeColumnAddedAccountStatements,
+    #[display("0037: Accounts restake earnings update null values to false and add not null constraint")]
+    AccountsDelegatedEarningsNullToFalseAndNotNullConstraint,
 }
 impl SchemaVersion {
     /// The minimum supported database schema version for the API.
@@ -262,7 +265,7 @@ impl SchemaVersion {
     pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion =
         SchemaVersion::IndexPartialContractsSearch;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements;
+    const LATEST: SchemaVersion = SchemaVersion::AccountsDelegatedEarningsNullToFalseAndNotNullConstraint;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.
@@ -318,6 +321,7 @@ impl SchemaVersion {
             SchemaVersion::IndexAccountRewards => false,
             SchemaVersion::UpdateAccountTransactionTypes => false,
             SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => false,
+            SchemaVersion::AccountsDelegatedEarningsNullToFalseAndNotNullConstraint => false,
         }
     }
 
@@ -364,6 +368,7 @@ impl SchemaVersion {
             SchemaVersion::IndexAccountRewards => false,
             SchemaVersion::UpdateAccountTransactionTypes => false,
             SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => false,
+            SchemaVersion::AccountsDelegatedEarningsNullToFalseAndNotNullConstraint => false,
         }
     }
 
@@ -600,7 +605,10 @@ impl SchemaVersion {
                     .await?;
                 SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements
             }
-            SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => unimplemented!(
+            SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => {
+                m0037_accounts_delegated_restake_earnings_migrate_null_to_false_and_add_not_null_contraint::run(&mut tx).await?
+            }
+            SchemaVersion::AccountsDelegatedEarningsNullToFalseAndNotNullConstraint => unimplemented!(
                 "No migration implemented for database schema version {}",
                 self.as_i64()
             ),

--- a/backend/src/migrations/m0037_accounts_delegated_restake_earnings_migrate_null_to_false_and_add_not_null_contraint.rs
+++ b/backend/src/migrations/m0037_accounts_delegated_restake_earnings_migrate_null_to_false_and_add_not_null_contraint.rs
@@ -1,0 +1,62 @@
+use super::SchemaVersion;
+use std::time::Duration;
+use tokio::time::Instant;
+
+/// Database schema version representing the partial migration.
+const PARTIAL_MIGRATION_SCHEMA_VERSION: SchemaVersion = SchemaVersion::AccountsDelegatedEarningsNullToFalseAndNotNullConstraint;
+
+
+/// Run database migration and returns the new database schema version when
+/// successful.
+pub async fn run(
+    tx: &mut sqlx::PgTransaction<'_>,
+) -> anyhow::Result<SchemaVersion> {
+
+
+    // find all accounts with restake earnings currently set to null
+    let accounts_restake_earnings_null: Vec<i64> =
+        sqlx::query_scalar(
+            "SELECT index FROM ACCOUNTS 
+            WHERE delegated_restake_earnings IS NULL"
+        )
+        .fetch_all(tx.as_mut())
+        .await?;
+
+    let mut process = accounts_restake_earnings_null.len();
+    tracing::debug!("About to process {} accounts", process);
+    
+    // if we have accounts to update, we will perform a partial update for each account 
+    if !accounts_restake_earnings_null.is_empty() {
+
+        // for each account that currently has null set as their 'delegated_restake_earnings' we will update them to the new default false
+        for account_index in accounts_restake_earnings_null{
+            let start = Instant::now();
+            if start.elapsed() > Duration::from_secs(60) {
+               break;
+            }
+
+            sqlx::query(
+            "UPDATE ACCOUNTS
+	                SET delegated_restake_earnings = false
+                WHERE index = $1",
+            )
+            .bind(account_index)
+            .execute(tx.as_mut())
+            .await?;
+
+            process -= 1;
+            tracing::debug!("{} accounts remaining", process);
+        }
+    }
+
+    // finally set not null constraint on the ACCOUNTS table 'delegated_restake_earnings' column
+    tracing::debug!("Adding NOT NULL constraint now on ACCOUNTS table 'delegated_restake_earnings' column");
+
+    sqlx::query(
+    "ALTER TABLE ACCOUNTS ALTER COLUMN delegated_restake_earnings SET NOT NULL",
+    )
+    .execute(tx.as_mut())
+    .await?;
+
+    Ok(PARTIAL_MIGRATION_SCHEMA_VERSION)
+}

--- a/backend/src/migrations/m0037_accounts_delegated_restake_earnings_migrate_null_to_false_and_add_not_null_contraint.rs
+++ b/backend/src/migrations/m0037_accounts_delegated_restake_earnings_migrate_null_to_false_and_add_not_null_contraint.rs
@@ -3,40 +3,36 @@ use std::time::Duration;
 use tokio::time::Instant;
 
 /// Database schema version representing the partial migration.
-const PARTIAL_MIGRATION_SCHEMA_VERSION: SchemaVersion = SchemaVersion::AccountsDelegatedEarningsNullToFalseAndNotNullConstraint;
-
+const PARTIAL_MIGRATION_SCHEMA_VERSION: SchemaVersion =
+    SchemaVersion::AccountsDelegatedEarningsNullToFalseAndNotNullConstraint;
 
 /// Run database migration and returns the new database schema version when
 /// successful.
-pub async fn run(
-    tx: &mut sqlx::PgTransaction<'_>,
-) -> anyhow::Result<SchemaVersion> {
-
-
+pub async fn run(tx: &mut sqlx::PgTransaction<'_>) -> anyhow::Result<SchemaVersion> {
     // find all accounts with restake earnings currently set to null
-    let accounts_restake_earnings_null: Vec<i64> =
-        sqlx::query_scalar(
-            "SELECT index FROM ACCOUNTS 
-            WHERE delegated_restake_earnings IS NULL"
-        )
-        .fetch_all(tx.as_mut())
-        .await?;
+    let accounts_restake_earnings_null: Vec<i64> = sqlx::query_scalar(
+        "SELECT index FROM ACCOUNTS 
+            WHERE delegated_restake_earnings IS NULL",
+    )
+    .fetch_all(tx.as_mut())
+    .await?;
 
     let mut process = accounts_restake_earnings_null.len();
     tracing::debug!("About to process {} accounts", process);
-    
-    // if we have accounts to update, we will perform a partial update for each account 
-    if !accounts_restake_earnings_null.is_empty() {
 
-        // for each account that currently has null set as their 'delegated_restake_earnings' we will update them to the new default false
-        for account_index in accounts_restake_earnings_null{
+    // if we have accounts to update, we will perform a partial update for each
+    // account
+    if !accounts_restake_earnings_null.is_empty() {
+        // for each account that currently has null set as their
+        // 'delegated_restake_earnings' we will update them to the new default false
+        for account_index in accounts_restake_earnings_null {
             let start = Instant::now();
             if start.elapsed() > Duration::from_secs(60) {
-               break;
+                break;
             }
 
             sqlx::query(
-            "UPDATE ACCOUNTS
+                "UPDATE ACCOUNTS
 	                SET delegated_restake_earnings = false
                 WHERE index = $1",
             )
@@ -49,14 +45,15 @@ pub async fn run(
         }
     }
 
-    // finally set not null constraint on the ACCOUNTS table 'delegated_restake_earnings' column
-    tracing::debug!("Adding NOT NULL constraint now on ACCOUNTS table 'delegated_restake_earnings' column");
+    // finally set not null constraint on the ACCOUNTS table
+    // 'delegated_restake_earnings' column
+    tracing::debug!(
+        "Adding NOT NULL constraint now on ACCOUNTS table 'delegated_restake_earnings' column"
+    );
 
-    sqlx::query(
-    "ALTER TABLE ACCOUNTS ALTER COLUMN delegated_restake_earnings SET NOT NULL",
-    )
-    .execute(tx.as_mut())
-    .await?;
+    sqlx::query("ALTER TABLE ACCOUNTS ALTER COLUMN delegated_restake_earnings SET NOT NULL")
+        .execute(tx.as_mut())
+        .await?;
 
     Ok(PARTIAL_MIGRATION_SCHEMA_VERSION)
 }


### PR DESCRIPTION
## Purpose

Investigate and Fix the 'something went wrong' error for the delegators summary page/tab for a validator in CCD scan

## Changes

Delegators summary page for a Validator, is currently broken where accounts have a null value specified in the DB for the `delegated_restake_earnings` which is a boolean. 

The Delegators summary query tries to find all the accounts associated with a `delegated_target_baker_id` and retrieves details about whether that account is restaking their earnings and the amount associated. 

The problem is the DB currently allows for NULL values, and the object for building the delegation summary creates an error when trying to build the summary for those accounts containing null for `delegated_restake_earnings`.

- Added a data migration to change all NULL's for this column (defaulted now to false)
- Added NOT NULL constraint on the column to make sure no NULL's are inserted

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
