### PR TITLE
fix: added configurable property for the account statement max days export 

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 
+## [2.0.9] - 2025-06-23
+
+- Added configurable environment variable in the code for Account Statements Export for the max allowed days: 'CCDSCAN_API_EXPORT_STATEMENTS_MAX_DAYS' which defaults currently to 32 for all environments.
+
 ## [2.0.8] - 2025-06-20
 
 - Fix errors in migration 0024 when running against PostgreSQL `17.5`.

--- a/backend/src/graphql_api.rs
+++ b/backend/src/graphql_api.rs
@@ -92,6 +92,9 @@ pub struct ApiServiceConfig {
         default_value = "100"
     )]
     account_schedule_connection_limit: u64,
+    /// specified max days allowed for account statements export.
+    #[arg(long, env = "CCDSCAN_API_EXPORT_STATEMENTS_MAX_DAYS", default_value_t = 32)]
+    pub export_statement_max_days: u64,
     #[arg(long, env = "CCDSCAN_API_CONFIG_BAKER_CONNECTION_LIMIT", default_value = "100")]
     baker_connection_limit: u64,
     #[arg(long, env = "CCDSCAN_API_CONFIG_CONTRACT_CONNECTION_LIMIT", default_value = "100")]

--- a/backend/src/rest_api.rs
+++ b/backend/src/rest_api.rs
@@ -118,10 +118,6 @@ impl Service {
             .from_time
             .unwrap_or_else(|| to - TimeDelta::days(account_statements_export_max_days));
         if to - from > TimeDelta::days(account_statements_export_max_days) {
-            error!(
-                "Time range selected for Account Statement Export was > max days configured: {}",
-                account_statements_export_max_days
-            );
             return Err(ApiError::ExceedsMaxAllowedDaysForAccountStatementExport(
                 account_statements_export_max_days,
             ));

--- a/backend/src/rest_api.rs
+++ b/backend/src/rest_api.rs
@@ -37,8 +37,6 @@ struct RouterState {
     config: Arc<ApiServiceConfig>,
 }
 
-/// The maximum number days to cover in the exported account statements.
-
 impl Service {
     pub fn new(pool: PgPool, config: Arc<ApiServiceConfig>, registry: &mut Registry) -> Self {
         Self {

--- a/backend/src/rest_api.rs
+++ b/backend/src/rest_api.rs
@@ -17,6 +17,7 @@ use reqwest::StatusCode;
 use sqlx::PgPool;
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
+use tracing::error;
 
 /// Service providing the router for the REST API.
 #[derive(Debug)]
@@ -37,7 +38,6 @@ struct RouterState {
 }
 
 /// The maximum number days to cover in the exported account statements.
-const EXPORT_MAX_DAYS: i64 = 31;
 
 impl Service {
     pub fn new(pool: PgPool, config: Arc<ApiServiceConfig>, registry: &mut Registry) -> Self {
@@ -114,10 +114,21 @@ impl Service {
         State(state): State<RouterState>,
     ) -> ApiResult<(AppendHeaders<[(HeaderName, String); 2]>, String)> {
         let to = params.to_time.unwrap_or_else(Utc::now);
-        let from = params.from_time.unwrap_or_else(|| to - TimeDelta::days(EXPORT_MAX_DAYS));
-        if to - from > TimeDelta::days(EXPORT_MAX_DAYS) {
-            return Err(ApiError::ExceedsMaxAllowed);
+        let account_statements_export_max_days =
+            i64::try_from(state.config.export_statement_max_days).unwrap_or(32);
+        let from = params
+            .from_time
+            .unwrap_or_else(|| to - TimeDelta::days(account_statements_export_max_days));
+        if to - from > TimeDelta::days(account_statements_export_max_days) {
+            error!(
+                "Time range selected for Account Statement Export was > max days configured: {}",
+                account_statements_export_max_days
+            );
+            return Err(ApiError::ExceedsMaxAllowedDaysForAccountStatementExport(
+                account_statements_export_max_days,
+            ));
         }
+
         let mut rows = sqlx::query_as!(
             ExportAccountStatementEntry,
             r#"SELECT
@@ -216,8 +227,8 @@ enum Unit {
 enum ApiError {
     #[error("Information was not found.")]
     NotFound,
-    #[error("Chosen time span exceeds max allowed days: '{EXPORT_MAX_DAYS}'")]
-    ExceedsMaxAllowed,
+    #[error("Chosen time span exceeds max allowed days for account statement export: {0}")]
+    ExceedsMaxAllowedDaysForAccountStatementExport(i64),
     #[error("Internal error (FailedDatabaseQuery): {0}")]
     FailedDatabaseQuery(Arc<sqlx::Error>),
     #[error("Invalid integer: {0}")]
@@ -232,7 +243,7 @@ type ApiResult<A> = Result<A, ApiError>;
 impl IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
         let status = match self {
-            ApiError::ExceedsMaxAllowed => StatusCode::BAD_REQUEST,
+            ApiError::ExceedsMaxAllowedDaysForAccountStatementExport(_) => StatusCode::BAD_REQUEST,
             ApiError::FailedDatabaseQuery(_) => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::InvalidInt(_) => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::NotFound => StatusCode::NOT_FOUND,


### PR DESCRIPTION
## Purpose

Fix Account Statement export (Currently October 2024 fails for exporting due to violating max day range)

## Changes

The existing max was hardcoded at 31, and the logic from the UI to parse monthly account statement data is to provide the first of the month, and first of the next month to export. For October 2024 - this would be technically 32 days.

Added a new environment property to allow for configuration - defaulting to 32 for now until we have further requirements to investigate and expand the max range.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
