### PR TITLE
fix: update docker rust version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-ARG build_image=rust:1.83-bookworm
+ARG build_image=rust:1.85-bookworm
 ARG base_image=debian:bookworm-slim
 ARG target_binary
 FROM ${build_image} AS build


### PR DESCRIPTION
## Purpose

rust version has to be updated to 1.85 for docker release build

## Changes

bump rust version in docker

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
