### PR TITLE
fix: added database migration for the bakers APY calculations to have…

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Database schema version: 37
+
+- contains database migrations to change the Bakers APY query calculations to have a max pay day of: 8760.0 (hours per year).
+for higher environments this will always be 365.25, but stagenet is much faster and to prevent overflow this migration cap was added.
+
 ## [2.0.11] - 2025-07-01
 
 ### Fixed

--- a/backend/src/migrations.rs
+++ b/backend/src/migrations.rs
@@ -254,6 +254,11 @@ pub enum SchemaVersion {
     UpdateAccountTransactionTypes,
     #[display("0036: Added index and slot time for the account statements table")]
     IndexAndSlotTimeColumnAddedAccountStatements,
+    #[display(
+        "0037: Baker APY Materialized table definitions updated to make sure we have max cap \
+         applied to paydays"
+    )]
+    BakerApyCalculationsMaxCapPayDays,
 }
 impl SchemaVersion {
     /// The minimum supported database schema version for the API.
@@ -262,7 +267,7 @@ impl SchemaVersion {
     pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion =
         SchemaVersion::IndexPartialContractsSearch;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements;
+    const LATEST: SchemaVersion = SchemaVersion::BakerApyCalculationsMaxCapPayDays;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.
@@ -318,6 +323,7 @@ impl SchemaVersion {
             SchemaVersion::IndexAccountRewards => false,
             SchemaVersion::UpdateAccountTransactionTypes => false,
             SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => false,
+            SchemaVersion::BakerApyCalculationsMaxCapPayDays => false,
         }
     }
 
@@ -364,6 +370,7 @@ impl SchemaVersion {
             SchemaVersion::IndexAccountRewards => false,
             SchemaVersion::UpdateAccountTransactionTypes => false,
             SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => false,
+            SchemaVersion::BakerApyCalculationsMaxCapPayDays => false,
         }
     }
 
@@ -600,7 +607,15 @@ impl SchemaVersion {
                     .await?;
                 SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements
             }
-            SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => unimplemented!(
+            SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => {
+                tx.as_mut()
+                    .execute(sqlx::raw_sql(include_str!(
+                        "./migrations/m0037_bakers_apy_function_cap_max_paydays.sql"
+                    )))
+                    .await?;
+                SchemaVersion::BakerApyCalculationsMaxCapPayDays
+            }
+            SchemaVersion::BakerApyCalculationsMaxCapPayDays => unimplemented!(
                 "No migration implemented for database schema version {}",
                 self.as_i64()
             ),

--- a/backend/src/migrations/m0037_bakers_apy_function_cap_max_paydays.sql
+++ b/backend/src/migrations/m0037_bakers_apy_function_cap_max_paydays.sql
@@ -1,0 +1,87 @@
+-- DROP the old materialized views if they exist, as we are replacing the function for them
+DROP MATERIALIZED VIEW IF EXISTS latest_baker_apy_30_days;
+DROP MATERIALIZED VIEW IF EXISTS latest_baker_apy_7_days;
+
+
+-- Function for computing the APY for every baker for the provided interval ending at the latest
+-- processed block.
+-- The WITH statment computes the paydays_per_year based on the epoch duration and reward period length,
+-- capping it to a maximum of 8760 (hourly). For lower testing environments the paydays are often more
+-- regular, so we cap it to a maximum of 8760 to avoid too high APY values which can cause FLOAT8 overflow.
+CREATE OR REPLACE FUNCTION compute_latest_baker_apys(INTERVAL)
+RETURNS TABLE(id BIGINT, total_apy FLOAT8, delegators_apy FLOAT8, baker_apy FLOAT8) AS '
+WITH
+    chain_parameter AS (
+        SELECT
+            id,
+            LEAST(
+                (EXTRACT(''epoch'' FROM INTERVAL ''1 year'') * 1000)
+                    / (epoch_duration * reward_period_length),
+                8760.0
+            )::FLOAT8 AS paydays_per_year
+        FROM public.current_chain_parameters
+        WHERE id = true
+    )
+SELECT
+    payday_baker_pool_stakes.baker AS id,
+    public.geometric_mean(1 + public.apy(
+        (payday_total_transaction_rewards
+          + payday_total_baking_rewards
+          + payday_total_finalization_rewards)::FLOAT8,
+        (baker_stake + delegators_stake)::FLOAT8,
+        paydays_per_year
+    )) - 1 AS total_apy,
+    public.geometric_mean(1 + public.apy(
+        (payday_delegators_transaction_rewards
+          + payday_delegators_baking_rewards
+          + payday_delegators_finalization_rewards)::FLOAT8,
+        NULLIF(delegators_stake, 0)::FLOAT8,
+        paydays_per_year
+        )) - 1 AS delegators_apy,
+    public.geometric_mean(1 + public.apy(
+        (payday_total_transaction_rewards
+           - payday_delegators_transaction_rewards
+           + payday_total_baking_rewards
+           - payday_delegators_baking_rewards
+           + payday_total_finalization_rewards
+           - payday_delegators_finalization_rewards)::FLOAT8,
+        baker_stake::FLOAT8,
+        paydays_per_year
+    )) - 1 AS baker_apy
+FROM public.payday_baker_pool_stakes
+    JOIN public.blocks ON blocks.height = payday_baker_pool_stakes.payday_block
+    JOIN public.bakers_payday_pool_rewards
+        ON blocks.height = bakers_payday_pool_rewards.payday_block_height
+        AND pool_owner_for_primary_key = payday_baker_pool_stakes.baker
+    JOIN chain_parameter ON chain_parameter.id = true
+WHERE
+    blocks.slot_time > (SELECT slot_time FROM public.blocks ORDER BY height DESC LIMIT 1) - $1
+GROUP BY payday_baker_pool_stakes.baker;
+' LANGUAGE SQL;
+
+
+
+
+-- Materialized view with APYs for pool, computed from the rewards and stake of the last 30 days.
+CREATE MATERIALIZED VIEW latest_baker_apy_30_days AS
+    SELECT id, baker_apy, delegators_apy, total_apy
+    FROM compute_latest_baker_apys('30 days'::INTERVAL);
+
+-- Index to lookup APY for a particular baker efficient.
+CREATE UNIQUE INDEX latest_baker_apy_30_days_baker_index ON latest_baker_apy_30_days (id);
+-- Index to make sorting by baker_apy and then baker_id more efficient.
+CREATE INDEX latest_baker_apy_30_days_baker_apy_index ON latest_baker_apy_30_days (baker_apy, id);
+-- Index to make sorting by delegators_apy and then baker_id more efficient.
+CREATE INDEX latest_baker_apy_30_days_delegators_apy_index ON latest_baker_apy_30_days (delegators_apy, id);
+
+-- Materialized view with APYs for pool, computed from the rewards and stake of the last 7 days.
+CREATE MATERIALIZED VIEW latest_baker_apy_7_days AS
+    SELECT id, baker_apy, delegators_apy, total_apy
+    FROM compute_latest_baker_apys('7 days'::INTERVAL);
+
+-- Index to lookup APY for a particular baker efficient.
+CREATE UNIQUE INDEX latest_baker_apy_7_days_baker_index ON latest_baker_apy_7_days (id);
+-- Index to make sorting by baker_apy and then baker_id more efficient.
+CREATE INDEX latest_baker_apy_7_days_baker_apy_index ON latest_baker_apy_7_days (baker_apy, id);
+-- Index to make sorting by delegators_apy and then baker_id more efficient.
+CREATE INDEX latest_baker_apy_7_days_delegators_apy_index ON latest_baker_apy_7_days (delegators_apy, id);


### PR DESCRIPTION

## Purpose

Investigate and fix the bakers APY query refresh problem that is occurring in stagenet.

## Changes

Bakers APY query has an overflow problem as our paydays are much more often for stagenet - right now stagenet was set to: 43,830 paydays per year - there is a max of 8760 hours in a year so they are much more often than 1 hr. 

In this database migration change, I am suggesting we cap the max pay days to be to a max of the total number of hours per year, and we will select the smaller value if paydays are set to 365.25 - that will be chosen for the higher environments.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
