### PR TITLE
fix: database migration added for updating the baker apy query to pro…

### DIFF
--- a/backend/.sqlx/query-304442438b1d40dc2696739d521176516cc24f195dc36f0dc4e8645df9728680.json
+++ b/backend/.sqlx/query-304442438b1d40dc2696739d521176516cc24f195dc36f0dc4e8645df9728680.json
@@ -78,8 +78,7 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenHolder",
-                "TokenGovernance"
+                "TokenUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-423f208f0b81fc7d96656b005c2ef937c4ace01978997cd958ac7a7487b455ff.json
+++ b/backend/.sqlx/query-423f208f0b81fc7d96656b005c2ef937c4ace01978997cd958ac7a7487b455ff.json
@@ -47,8 +47,7 @@
                       "RegisterData",
                       "ConfigureBaker",
                       "ConfigureDelegation",
-                      "TokenHolder",
-                      "TokenGovernance"
+                      "TokenUpdate"
                     ]
                   }
                 }

--- a/backend/.sqlx/query-531f3269033c018f0e75869fe072d39de8cfbc091c36296f84947594d3ab8985.json
+++ b/backend/.sqlx/query-531f3269033c018f0e75869fe072d39de8cfbc091c36296f84947594d3ab8985.json
@@ -78,8 +78,7 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenHolder",
-                "TokenGovernance"
+                "TokenUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-5ce92748173d987a60a1a5d84c1e07cb414b0924871ae1caf6b8db9c0c7b3f2e.json
+++ b/backend/.sqlx/query-5ce92748173d987a60a1a5d84c1e07cb414b0924871ae1caf6b8db9c0c7b3f2e.json
@@ -78,8 +78,7 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenHolder",
-                "TokenGovernance"
+                "TokenUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-9184bfdb5aebf2a9b62399e363e1be7d7f1f79dcda47f0e0d2486b1084ea632a.json
+++ b/backend/.sqlx/query-9184bfdb5aebf2a9b62399e363e1be7d7f1f79dcda47f0e0d2486b1084ea632a.json
@@ -78,8 +78,7 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenHolder",
-                "TokenGovernance"
+                "TokenUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-9f91c92d6ee70c7e4b8abe7f7f2653b5479b6b1ca739ea0f815b6d4d2118f658.json
+++ b/backend/.sqlx/query-9f91c92d6ee70c7e4b8abe7f7f2653b5479b6b1ca739ea0f815b6d4d2118f658.json
@@ -78,8 +78,7 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenHolder",
-                "TokenGovernance"
+                "TokenUpdate"
               ]
             }
           }
@@ -191,8 +190,7 @@
                       "RegisterData",
                       "ConfigureBaker",
                       "ConfigureDelegation",
-                      "TokenHolder",
-                      "TokenGovernance"
+                      "TokenUpdate"
                     ]
                   }
                 }

--- a/backend/.sqlx/query-d36c362618159b4b373905b084993e8e716ae225c488385a1672d11219884c0e.json
+++ b/backend/.sqlx/query-d36c362618159b4b373905b084993e8e716ae225c488385a1672d11219884c0e.json
@@ -78,8 +78,7 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenHolder",
-                "TokenGovernance"
+                "TokenUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-d93facff216297d1136309f1247d0afdfc8018cdb149a5ad808a10e91e108bb8.json
+++ b/backend/.sqlx/query-d93facff216297d1136309f1247d0afdfc8018cdb149a5ad808a10e91e108bb8.json
@@ -54,8 +54,7 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenHolder",
-                "TokenGovernance"
+                "TokenUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-e410826d9bbb9699c1b4ed0b341b5e81453ee613df5c012fb6ce584d5d0ced5d.json
+++ b/backend/.sqlx/query-e410826d9bbb9699c1b4ed0b341b5e81453ee613df5c012fb6ce584d5d0ced5d.json
@@ -78,8 +78,7 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenHolder",
-                "TokenGovernance"
+                "TokenUpdate"
               ]
             }
           }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [2.0.12] - 2025-07-03
+
 ### Changed
+
+Database schema version: 38
 
 - New account_transaction_type enum values added `TokenUpdate`, Removed `TokenHolder` and `TokenGovernance`
 - TokenHolder and TokenGovernance events are now merged into `TokenUpdate` event.
+- Baker APY query db migration to change the function to prevent overflow FLOAT8
 
 ## [2.0.11] - 2025-07-01
 

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -4,15 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-## [2.0.12] - 2025-07-03
+## [2.0.13] - 2025-07-03
 
 ### Changed
 
 Database schema version: 38
 
+- Baker APY query db migration to change the function to prevent overflow FLOAT8
+
+## [2.0.12] - 2025-07-03
+
+### Changed
+
 - New account_transaction_type enum values added `TokenUpdate`, Removed `TokenHolder` and `TokenGovernance`
 - TokenHolder and TokenGovernance events are now merged into `TokenUpdate` event.
-- Baker APY query db migration to change the function to prevent overflow FLOAT8
 - The ccdscan-api now connects to the grpc node to fetch token list and details (This will be removed later).
 
 ## [2.0.11] - 2025-07-01

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-scan"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-scan"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-scan"
-version = "2.0.12"
+version = "2.0.13"
 edition = "2021"
 description = "CCDScan: Indexer and API for the Concordium blockchain"
 authors = ["Concordium <developers@concordium.com>"]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-scan"
-version = "2.0.11"
+version = "2.0.12"
 edition = "2021"
 description = "CCDScan: Indexer and API for the Concordium blockchain"
 authors = ["Concordium <developers@concordium.com>"]

--- a/backend/src/migrations.rs
+++ b/backend/src/migrations.rs
@@ -260,6 +260,8 @@ pub enum SchemaVersion {
          TokenGovernance"
     )]
     UpdateTransactionTypeAddTokenUpdate,
+    #[display("0038: Baker APY query update, protect against overflow")]
+    BakerApyQueryUpdateProtectAgainstOverflow,
 }
 impl SchemaVersion {
     /// The minimum supported database schema version for the API.
@@ -268,7 +270,7 @@ impl SchemaVersion {
     pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion =
         SchemaVersion::IndexPartialContractsSearch;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::UpdateTransactionTypeAddTokenUpdate;
+    const LATEST: SchemaVersion = SchemaVersion::BakerApyQueryUpdateProtectAgainstOverflow;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.
@@ -325,6 +327,7 @@ impl SchemaVersion {
             SchemaVersion::UpdateAccountTransactionTypes => false,
             SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => false,
             SchemaVersion::UpdateTransactionTypeAddTokenUpdate => false,
+            SchemaVersion::BakerApyQueryUpdateProtectAgainstOverflow => false,
         }
     }
 
@@ -372,6 +375,7 @@ impl SchemaVersion {
             SchemaVersion::UpdateAccountTransactionTypes => false,
             SchemaVersion::IndexAndSlotTimeColumnAddedAccountStatements => false,
             SchemaVersion::UpdateTransactionTypeAddTokenUpdate => false,
+            SchemaVersion::BakerApyQueryUpdateProtectAgainstOverflow => false,
         }
     }
 
@@ -612,7 +616,16 @@ impl SchemaVersion {
                 m0037_update_transaction_type_add_tokenupdate::run(&mut tx, endpoints).await?
             }
 
-            SchemaVersion::UpdateTransactionTypeAddTokenUpdate => unimplemented!(
+            SchemaVersion::UpdateTransactionTypeAddTokenUpdate => {
+                tx.as_mut()
+                    .execute(sqlx::raw_sql(include_str!(
+                        "./migrations/m0038_bakers_apy_function_prevent_overflow.sql"
+                    )))
+                    .await?;
+                SchemaVersion::BakerApyQueryUpdateProtectAgainstOverflow
+            }
+
+            SchemaVersion::BakerApyQueryUpdateProtectAgainstOverflow => unimplemented!(
                 "No migration implemented for database schema version {}",
                 self.as_i64()
             ),

--- a/backend/src/migrations/m0038_bakers_apy_function_prevent_overflow.sql
+++ b/backend/src/migrations/m0038_bakers_apy_function_prevent_overflow.sql
@@ -1,0 +1,30 @@
+-- APY query calculation defensive updates to protect against division by zero and overflow.
+CREATE OR REPLACE FUNCTION public.apy(rewards FLOAT8, stake FLOAT8, paydays_per_year FLOAT8) RETURNS FLOAT8 AS $$
+DECLARE
+    base FLOAT8;
+    result FLOAT8;
+BEGIN
+    -- if stake is NULL or 0, or paydays_per_year is NULL
+    IF stake IS NULL OR stake = 0 OR paydays_per_year IS NULL OR paydays_per_year = 0 THEN
+        RETURN NULL;
+    END IF;
+
+    base := 1 + (rewards / stake);
+
+	-- if the base is too small or too large, we skip the calculation
+	IF base <= 0 OR base > 10 THEN
+		Raise notice 'Skipping calculation - base for APY was either too small or too large: %', base;
+		RETURN NULL;
+	END IF;
+
+	-- Try to perform and return the power calculation to calculate APY. If this fails due to overflow, NULL is returned. 
+	BEGIN 
+    	result := POWER(base, paydays_per_year) - 1;
+	EXCEPTION
+		WHEN numeric_value_out_of_range THEN
+		Raise notice 'APY possible overflow, returning NULL. Base: %, Paydays per year: %', result, paydays_per_year;
+	END;
+	
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION

## Purpose

Investigate and resolve Baker APY query issues for stagenet

## Changes

In stagenet the paydays are set to 43,830 paydays per year (1 ever 12 mins) - The current Baker APY power calculation results in overflow because fundamentally values passed to the power function result in a very high APY.

Added a DB migration to protect in this query - we will try to get the power of the caclulation and if its too large, we will return NULL now. This issue does not effect higher environments because paydays are set to 365.25 per year

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
