### PR TITLE
Fix P3->P4 protocol update

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Fix P3->P4 protocol update migration to allow for bakers pending removal to be absent from the bakers table.
+
 ## [2.0.7] - 2025-06-16
 
 - Added fix for delegators summary query - Delegator summary is now populated by values where the delegated restake earnings is NOT NULL

--- a/backend/src/indexer/block/protocol_update_migration.rs
+++ b/backend/src/indexer/block/protocol_update_migration.rs
@@ -159,7 +159,7 @@ impl P4ProtocolUpdateMigration {
         )
         .execute(tx.as_mut())
         .await?
-        .ensure_affected_rows(self.baker_ids.len().try_into()?)?;
+        .ensure_affected_rows_in_range(0..=self.baker_ids.len().try_into()?)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Purpose

Closes [COR-1592](https://linear.app/concordium/issue/COR-1592/bug-ccdscan-fails-to-handle-p3-p4-protocol-update-on-mainnet)

When processing the mainnet P3->P4 protocol update, it fails because it expects bakers pending removal to be in the bakers table, but they are not. This should not cause problems, so we just relax the constraint on the number of rows in the baker table that should be affected by the migration.

## Changes

- Weaken rows constraint to allow P4 protocol update.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
