### PR TITLE
fix: hotfix for balance statistics api for callers to allow call for …

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 
+## [2.0.9-hotfix.1] - 2025-07-18
+
+- create hotfix for backwards compatability balance statistics api to support calls for: field=TotalAmountReleased and field=TotalAmount which is used by clients
+
 ## [2.0.9] - 2025-06-23
 
 - Added configurable environment variable in the code for Account Statements Export for the max allowed days: 'CCDSCAN_API_EXPORT_STATEMENTS_MAX_DAYS' which defaults currently to 32 for all environments.

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-scan"
-version = "2.0.9"
+version = "2.0.9-hotfix.1"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-scan"
-version = "2.0.9"
+version = "2.0.9-hotfix.1"
 edition = "2021"
 description = "CCDScan: Indexer and API for the Concordium blockchain"
 authors = ["Concordium <developers@concordium.com>"]

--- a/backend/src/rest_api.rs
+++ b/backend/src/rest_api.rs
@@ -197,13 +197,24 @@ struct ExportAccountStatementEntry {
 #[serde(rename_all = "lowercase")]
 struct LatestBalanceStatistics {
     field: Balance,
+    #[serde(default = "default_balance_statistics_unit_microccd")]
     unit:  Unit,
 }
+
+/// default unit for balance statistics to support backwards compatibility for callers
+fn default_balance_statistics_unit_microccd() -> Unit {
+    Unit::MicroCcd
+}
+
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[allow(clippy::enum_variant_names)]
 enum Balance {
+    /// deprecated alias to support backwards compatibility for old callers to .NET backend - total amount can be provided as 'TotalAmount'
+    #[serde(alias = "TotalAmount")]
     TotalAmount,
+    /// deprecated alias to support backwards compatibility for old callers to .NET backend - TotalAmountReleased is equivalent to TotalAmountCirculating
+    #[serde(alias = "TotalAmountReleased")]
     TotalAmountCirculating,
     TotalAmountUnlocked,
     TotalAmounUnlocked, /* deprecated: please use 'totalAmountUnlocked' going forward over


### PR DESCRIPTION

## Purpose

Create a hotfix for the balance statistics API to support the old .NET fields of 'TotalAmountReleased' and 'TotalAmount' 

## Changes

Added alias's (specifying deprecated to the circulating supply field and total amount field in) in the balance statistics API - and also added a default value for the unit as MicroCCD

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

