### PR TITLE
fix: use cbor::cbor_decode for InitializationParameter ( COR-1663 )

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Introduced batches in migrations m0037 and logging.
+- (Bugfix) Proper handling of serialization and deserialization of `InitializationParameters` in `CreatePlt`, `CreatePltUpdate`, `TokenCreationDetails` events.
 
 ## [2.0.15] - 2025-07-16
 

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -845,6 +845,11 @@ type BurnEvent {
 
 scalar Byte
 
+type CborHolderAccount {
+	address: AccountAddress!
+	coinInfo: CoinInfo
+}
+
 type ChainParametersV1 {
 	rewardPeriodLength: UnsignedLong!
 }
@@ -895,6 +900,10 @@ type CisTransferEvent {
 
 type CisUnknownEvent {
 	dummy: UnsignedLong!
+}
+
+type CoinInfo {
+	coinInfoCode: String!
 }
 
 "Information about the offset pagination."
@@ -1064,17 +1073,6 @@ type CooldownParametersChainUpdatePayload {
 	delegatorCooldown: UnsignedLong!
 }
 
-type CreatePLTInitializationParameters {
-	name: String!
-	metadata: MetadataUrl!
-	allowList: Boolean
-	denyList: Boolean
-	mintable: Boolean
-	burnable: Boolean
-	initialSupply: TokenAmount
-	governanceAccount: TokenHolder
-}
-
 type CreatePlt {
 	"The symbol of the token."
 	tokenId: String!
@@ -1087,7 +1085,7 @@ type CreatePlt {
 	"""
 	decimals: Int!
 	"The initialization parameters of the token, encoded in CBOR."
-	initializationParameters: CreatePLTInitializationParameters!
+	initializationParameters: InitializationParameters!
 }
 
 type CreatePltUpdate {
@@ -1339,6 +1337,17 @@ type ImportState {
 	epochDuration: TimeSpan!
 }
 
+type InitializationParameters {
+	name: String!
+	metadata: MetadataUrl!
+	allowList: Boolean
+	denyList: Boolean
+	mintable: Boolean
+	burnable: Boolean
+	initialSupply: TokenAmount
+	governanceAccount: CborHolderAccount!
+}
+
 """
 The status of parsing `message` into its JSON representation using the
 smart contract module schema.
@@ -1500,6 +1509,8 @@ type Metadata {
 
 type MetadataUrl {
 	url: String!
+	checksumSha256: String
+	additional: JSON
 }
 
 enum MetricsPeriod {
@@ -2587,7 +2598,7 @@ type Token {
 
 type TokenAmount {
 	value: String!
-	decimals: Int!
+	decimals: String!
 }
 
 type TokenConnection {

--- a/backend/src/graphql_api/plt.rs
+++ b/backend/src/graphql_api/plt.rs
@@ -578,7 +578,7 @@ impl PLTAccountAmount {
         let decimals = self.decimal.unwrap_or(0) as u8;
         Ok(TokenAmount {
             value: value.to_string(),
-            decimals,
+            decimals: decimals.to_string(),
         })
     }
 }

--- a/backend/src/graphql_api/plt.rs
+++ b/backend/src/graphql_api/plt.rs
@@ -577,7 +577,7 @@ impl PLTAccountAmount {
         let value = self.amount.clone().and_then(|amt| amt.to_u64()).unwrap_or(0);
         let decimals = self.decimal.unwrap_or(0) as u8;
         Ok(TokenAmount {
-            value: value.to_string(),
+            value:    value.to_string(),
             decimals: decimals.to_string(),
         })
     }

--- a/backend/src/indexer/block/block_item/plt_token_creation.rs
+++ b/backend/src/indexer/block/block_item/plt_token_creation.rs
@@ -1,6 +1,9 @@
 use anyhow::Ok;
 use bigdecimal::BigDecimal;
-use concordium_rust_sdk::{common::cbor, protocol_level_tokens::TokenModuleInitializationParameters, types::TokenCreationDetails};
+use concordium_rust_sdk::{
+    common::cbor, protocol_level_tokens::TokenModuleInitializationParameters,
+    types::TokenCreationDetails,
+};
 
 use crate::transaction_event::protocol_level_tokens::{
     CreatePlt, InitializationParameters, TokenUpdate,
@@ -25,10 +28,10 @@ impl PreparedTokenCreationDetails {
             .into();
         Ok(PreparedTokenCreationDetails {
             create_plt: CreatePlt {
-                token_id:                  details.create_plt.token_id.clone().into(),
-                token_module:              details.create_plt.token_module.to_string(),
-                decimals:                  details.create_plt.decimals,
-                initialization_parameters: initialization_parameters.into(),
+                token_id: details.create_plt.token_id.clone().into(),
+                token_module: details.create_plt.token_module.to_string(),
+                decimals: details.create_plt.decimals,
+                initialization_parameters,
             },
             events:     details
                 .events

--- a/backend/src/indexer/block/block_item/plt_token_creation.rs
+++ b/backend/src/indexer/block/block_item/plt_token_creation.rs
@@ -1,6 +1,6 @@
 use anyhow::Ok;
 use bigdecimal::BigDecimal;
-use concordium_rust_sdk::types::TokenCreationDetails;
+use concordium_rust_sdk::{common::cbor, protocol_level_tokens::TokenModuleInitializationParameters, types::TokenCreationDetails};
 
 use crate::transaction_event::protocol_level_tokens::{
     CreatePlt, InitializationParameters, TokenUpdate,
@@ -18,11 +18,11 @@ impl PreparedTokenCreationDetails {
     /// version.
     pub fn prepare(details: &TokenCreationDetails) -> anyhow::Result<Self> {
         let initialization_parameters: InitializationParameters =
-            ciborium::de::from_reader::<InitializationParameters, _>(
+            cbor::cbor_decode::<TokenModuleInitializationParameters>(
                 details.create_plt.initialization_parameters.as_ref(),
             )
-            .map_err(|e| anyhow::anyhow!("Failed to decode initialization parameters: {}", e))?;
-
+            .map_err(|e| anyhow::anyhow!("Failed to decode initialization parameters: {}", e))?
+            .into();
         Ok(PreparedTokenCreationDetails {
             create_plt: CreatePlt {
                 token_id:                  details.create_plt.token_id.clone().into(),
@@ -59,14 +59,8 @@ impl PreparedTokenCreationDetails {
             .map(|supply| supply.value.parse::<u64>().unwrap_or(0))
             .unwrap_or(0);
         let initial_supply = BigDecimal::from(value);
-        let issuer = self
-            .create_plt
-            .initialization_parameters
-            .governance_account
-            .clone()
-            .map(|account| account.address.to_string())
-            .ok_or(anyhow::anyhow!("Missing governance account in token creation details"))?;
-
+        let issuer =
+            self.create_plt.initialization_parameters.governance_account.address.to_string();
         sqlx::query!(
             "INSERT INTO plt_tokens (
                 index,

--- a/backend/src/transaction_event/chain_update.rs
+++ b/backend/src/transaction_event/chain_update.rs
@@ -419,15 +419,16 @@ impl From<UpdatePayload> for ChainUpdatePayload {
                 token_id:                  update.token_id.clone().into(),
                 token_module:              update.token_module.into(),
                 decimals:                  update.decimals,
-                initialization_parameters:
-                    cbor::cbor_decode::<TokenModuleInitializationParameters>(
+                initialization_parameters: {
+                    let params = cbor::cbor_decode::<TokenModuleInitializationParameters>(
                         update.initialization_parameters.as_ref(),
                     )
-                    .map(|params| {
-                        serde_json::to_value::<InitializationParameters>(params.into())
-                            .unwrap_or(serde_json::Value::Null)
-                    })
-                    .unwrap_or(serde_json::Value::Null),
+                    .expect("Failed to decode PLT initialization parameters");
+                    serde_json::to_value::<InitializationParameters>(params.into()).expect(
+                        "Failed to serialize PLT initialization parameters to JSON (Probably \
+                         unsupported type)",
+                    )
+                },
             }),
         }
     }

--- a/backend/src/transaction_event/chain_update.rs
+++ b/backend/src/transaction_event/chain_update.rs
@@ -4,7 +4,11 @@ use crate::{
     transaction_event::protocol_level_tokens::InitializationParameters,
 };
 use async_graphql::{SimpleObject, Union};
-use concordium_rust_sdk::{common::cbor, protocol_level_tokens::TokenModuleInitializationParameters, types::{ExchangeRate, UpdatePayload}};
+use concordium_rust_sdk::{
+    common::cbor,
+    protocol_level_tokens::TokenModuleInitializationParameters,
+    types::{ExchangeRate, UpdatePayload},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(SimpleObject, Serialize, Deserialize)]

--- a/backend/src/transaction_event/mod.rs
+++ b/backend/src/transaction_event/mod.rs
@@ -3,15 +3,14 @@ use crate::{
     decoded_text::DecodedText,
     graphql_api::{ApiResult, InternalError},
     scalar_types::{BigInteger, Byte, DateTime, UnsignedLong},
-    transaction_event::{
-        protocol_level_tokens::{CreatePlt},
-        transfers::TimestampedAmount,
-    },
+    transaction_event::{protocol_level_tokens::CreatePlt, transfers::TimestampedAmount},
 };
 use anyhow::Context;
 use async_graphql::{ComplexObject, Object, SimpleObject, Union};
 use bigdecimal::BigDecimal;
-use concordium_rust_sdk::{cis2, common::cbor, protocol_level_tokens::TokenModuleInitializationParameters, types::Address};
+use concordium_rust_sdk::{
+    cis2, common::cbor, protocol_level_tokens::TokenModuleInitializationParameters, types::Address,
+};
 use tracing::error;
 
 pub mod baker;

--- a/backend/src/transaction_event/protocol_level_tokens.rs
+++ b/backend/src/transaction_event/protocol_level_tokens.rs
@@ -6,7 +6,6 @@ use concordium_rust_sdk::protocol_level_tokens::{self};
 use serde::{Deserialize, Serialize};
 const CONCORDIUM_SLIP_0044_CODE: u64 = 919;
 
-
 #[derive(Debug, Enum, Clone, Copy, PartialEq, Eq, sqlx::Type)]
 #[sqlx(type_name = "event_type")]
 pub enum TokenUpdateEventType {

--- a/backend/src/transaction_event/protocol_level_tokens.rs
+++ b/backend/src/transaction_event/protocol_level_tokens.rs
@@ -1,11 +1,11 @@
 use crate::address::AccountAddress;
 use async_graphql::{Enum, SimpleObject, Union};
 use bigdecimal::BigDecimal;
-use concordium_rust_sdk::{
-    base::protocol_level_tokens,
-    id::types::{AccountAddress as CborAccountAddress, ACCOUNT_ADDRESS_SIZE},
-};
-use serde::{Deserialize, Deserializer, Serialize};
+
+use concordium_rust_sdk::protocol_level_tokens::{self};
+use serde::{Deserialize, Serialize};
+const CONCORDIUM_SLIP_0044_CODE: u64 = 919;
+
 
 #[derive(Debug, Enum, Clone, Copy, PartialEq, Eq, sqlx::Type)]
 #[sqlx(type_name = "event_type")]
@@ -39,16 +39,18 @@ pub struct CreatePlt {
     /// token.
     pub decimals:                  u8,
     /// The initialization parameters of the token, encoded in CBOR.
-    pub initialization_parameters: CreatePLTInitializationParameters,
+    pub initialization_parameters: InitializationParameters,
 }
 
 #[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
 pub struct MetadataUrl {
-    pub url: String,
+    pub url:              String,
+    pub checksum_sha_256: Option<String>,
+    pub additional:       Option<serde_json::Value>,
 }
 
 #[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
-pub struct CreatePLTInitializationParameters {
+pub struct InitializationParameters {
     pub name:               String,
     pub metadata:           MetadataUrl,
     pub allow_list:         Option<bool>,
@@ -56,89 +58,99 @@ pub struct CreatePLTInitializationParameters {
     pub mintable:           Option<bool>,
     pub burnable:           Option<bool>,
     pub initial_supply:     Option<TokenAmount>,
-    pub governance_account: Option<TokenHolder>,
+    // Todo: Refactior convert this to CborTokenHolder (to ensure backwards compatibility will
+    // update the type when we reset devnet db)
+    pub governance_account: CborHolderAccount,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct InitializationParameters {
-    /// The name of the token
-    pub name:               String,
-    /// A URL pointing to the token metadata
-    pub metadata:           MetadataUrl,
-    /// Whether the token supports a deny list.
-    #[serde(rename = "denyList")]
-    pub deny_list:          Option<bool>,
-    #[serde(rename = "allowList")]
-    pub allow_list:         Option<bool>,
-    /// Whether the token is burnable.
-    pub burnable:           Option<bool>,
-    /// Whether the token is mintable.
-    pub mintable:           Option<bool>,
-    /// Initial supply as decimal fraction
-    #[serde(rename = "initialSupply")]
-    pub initial_supply:     Option<CborTokenAmount>,
-    /// Governance account
-    #[serde(rename = "governanceAccount", deserialize_with = "deserialize_governance_account")]
-    pub governance_account: Option<concordium_rust_sdk::protocol_level_tokens::TokenHolder>,
+#[derive(SimpleObject, Debug, Serialize, Deserialize, Clone)]
+pub struct CborTokenHolder {
+    pub account: CborHolderAccount,
 }
 
-impl From<InitializationParameters> for CreatePLTInitializationParameters {
-    fn from(params: InitializationParameters) -> Self {
-        CreatePLTInitializationParameters {
+impl From<concordium_rust_sdk::protocol_level_tokens::CborTokenHolder> for CborTokenHolder {
+    fn from(holder: concordium_rust_sdk::protocol_level_tokens::CborTokenHolder) -> Self {
+        match holder {
+            concordium_rust_sdk::protocol_level_tokens::CborTokenHolder::Account(account) => {
+                CborTokenHolder {
+                    account: CborHolderAccount {
+                        address:   account.address.into(),
+                        coin_info: account.coin_info.map(|info| CoinInfo {
+                            coin_info_code: match info {
+                                concordium_rust_sdk::protocol_level_tokens::CoinInfo::CCD => {
+                                    CONCORDIUM_SLIP_0044_CODE.to_string()
+                                }
+                            },
+                        }),
+                    },
+                }
+            }
+        }
+    }
+}
+
+impl From<concordium_rust_sdk::protocol_level_tokens::CborTokenHolder> for CborHolderAccount {
+    fn from(holder: concordium_rust_sdk::protocol_level_tokens::CborTokenHolder) -> Self {
+        match holder {
+            concordium_rust_sdk::protocol_level_tokens::CborTokenHolder::Account(account) => {
+                CborHolderAccount {
+                    address:   account.address.into(),
+                    coin_info: account.coin_info.map(|info| CoinInfo {
+                        coin_info_code: match info {
+                            concordium_rust_sdk::protocol_level_tokens::CoinInfo::CCD => {
+                                CONCORDIUM_SLIP_0044_CODE.to_string()
+                            }
+                        },
+                    }),
+                }
+            }
+        }
+    }
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct CborHolderAccount {
+    pub address:   AccountAddress,
+    pub coin_info: Option<CoinInfo>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct CoinInfo {
+    pub coin_info_code: String,
+}
+
+impl From<concordium_rust_sdk::protocol_level_tokens::TokenModuleInitializationParameters>
+    for InitializationParameters
+{
+    fn from(
+        params: concordium_rust_sdk::protocol_level_tokens::TokenModuleInitializationParameters,
+    ) -> Self {
+        InitializationParameters {
             name:               params.name,
-            metadata:           params.metadata,
+            metadata:           MetadataUrl {
+                url:              params.metadata.url,
+                checksum_sha_256: params.metadata.checksum_sha_256.map(|h| hex::encode(h.as_ref())),
+                additional:       if params.metadata.additional.is_empty() {
+                    None
+                } else {
+                    Some(serde_json::Value::Object(
+                        params
+                            .metadata
+                            .additional
+                            .into_iter()
+                            .map(|(key, value)| {
+                                (key, serde_json::Value::String(format!("{:?}", value)))
+                            })
+                            .collect(),
+                    ))
+                },
+            },
             allow_list:         params.allow_list,
             deny_list:          params.deny_list,
             mintable:           params.mintable,
             burnable:           params.burnable,
             initial_supply:     params.initial_supply.map(Into::into),
-            governance_account: params.governance_account.map(Into::into),
-        }
-    }
-}
-
-fn deserialize_governance_account<'de, D>(
-    deserializer: D,
-) -> Result<Option<concordium_rust_sdk::protocol_level_tokens::TokenHolder>, D::Error>
-where
-    D: Deserializer<'de>, {
-    // The CBOR structure is: tag(40307) -> map(1) -> { 3: bytes(32) }
-    use serde::de::Error;
-    use std::collections::HashMap;
-    let map: HashMap<u8, Vec<u8>> = Deserialize::deserialize(deserializer)?;
-    if let Some(address_bytes) = map.get(&3) {
-        if address_bytes.len() == ACCOUNT_ADDRESS_SIZE {
-            let mut bytes_array = [0u8; ACCOUNT_ADDRESS_SIZE];
-            bytes_array.copy_from_slice(address_bytes);
-            Ok(Some(concordium_rust_sdk::protocol_level_tokens::TokenHolder::Account {
-                address: CborAccountAddress(bytes_array),
-            }))
-        } else {
-            Err(D::Error::custom(format!(
-                "Invalid address length: expected {}, got {}",
-                ACCOUNT_ADDRESS_SIZE,
-                address_bytes.len()
-            )))
-        }
-    } else {
-        Err(D::Error::custom("Expected key 3 in governance account map"))
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct CborTokenAmount(pub i8, pub u64);
-
-impl From<CborTokenAmount> for TokenAmount {
-    fn from(cbor: CborTokenAmount) -> Self {
-        if cbor.0 > 0 {
-            panic!("Expected negative exponent for decimal fraction");
-        }
-        let decimals = cbor.0.unsigned_abs();
-        let value = cbor.1;
-        TokenAmount {
-            value: value.to_string(),
-            decimals,
+            governance_account: params.governance_account.into(),
         }
     }
 }
@@ -193,7 +205,7 @@ pub struct TokenHolder {
 #[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
 pub struct TokenAmount {
     pub value:    String,
-    pub decimals: u8,
+    pub decimals: String,
 }
 
 #[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
@@ -237,7 +249,7 @@ impl From<concordium_rust_sdk::protocol_level_tokens::TokenAmount> for TokenAmou
     fn from(amount: concordium_rust_sdk::protocol_level_tokens::TokenAmount) -> Self {
         Self {
             value:    amount.value().to_string(),
-            decimals: amount.decimals(),
+            decimals: amount.decimals().to_string(),
         }
     }
 }

--- a/frontend/src/pages/protocol-token/index.vue
+++ b/frontend/src/pages/protocol-token/index.vue
@@ -162,8 +162,8 @@
 							{{
 								(
 									Number(event.tokenEvent.amount.value) /
-									Math.pow(10, event.tokenEvent.amount.decimals)
-								).toFixed(event.tokenEvent.amount.decimals)
+									Math.pow(10,Number(event.tokenEvent.amount.decimals))
+								).toFixed(Number(event.tokenEvent.amount.decimals))
 							}}
 						</TableTd>
 					</TableRow>

--- a/frontend/src/pages/protocol-token/index.vue
+++ b/frontend/src/pages/protocol-token/index.vue
@@ -162,7 +162,7 @@
 							{{
 								(
 									Number(event.tokenEvent.amount.value) /
-									Math.pow(10,Number(event.tokenEvent.amount.decimals))
+									Math.pow(10, Number(event.tokenEvent.amount.decimals))
 								).toFixed(Number(event.tokenEvent.amount.decimals))
 							}}
 						</TableTd>

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -937,6 +937,12 @@ export type BurnEvent = {
   target: TokenHolder;
 };
 
+export type CborHolderAccount = {
+  __typename?: 'CborHolderAccount';
+  address: AccountAddress;
+  coinInfo?: Maybe<CoinInfo>;
+};
+
 export type ChainParametersV1 = {
   __typename?: 'ChainParametersV1';
   rewardPeriodLength: Scalars['UnsignedLong'];
@@ -995,6 +1001,11 @@ export type CisTransferEvent = {
 export type CisUnknownEvent = {
   __typename?: 'CisUnknownEvent';
   dummy: Scalars['UnsignedLong'];
+};
+
+export type CoinInfo = {
+  __typename?: 'CoinInfo';
+  coinInfoCode: Scalars['String'];
 };
 
 /** Information about the offset pagination. */
@@ -1202,18 +1213,6 @@ export type CooldownParametersChainUpdatePayload = {
   poolOwnerCooldown: Scalars['UnsignedLong'];
 };
 
-export type CreatePltInitializationParameters = {
-  __typename?: 'CreatePLTInitializationParameters';
-  allowList?: Maybe<Scalars['Boolean']>;
-  burnable?: Maybe<Scalars['Boolean']>;
-  denyList?: Maybe<Scalars['Boolean']>;
-  governanceAccount?: Maybe<TokenHolder>;
-  initialSupply?: Maybe<TokenAmount>;
-  metadata: MetadataUrl;
-  mintable?: Maybe<Scalars['Boolean']>;
-  name: Scalars['String'];
-};
-
 export type CreatePlt = {
   __typename?: 'CreatePlt';
   /**
@@ -1223,7 +1222,7 @@ export type CreatePlt = {
    */
   decimals: Scalars['Int'];
   /** The initialization parameters of the token, encoded in CBOR. */
-  initializationParameters: CreatePltInitializationParameters;
+  initializationParameters: InitializationParameters;
   /** The symbol of the token. */
   tokenId: Scalars['String'];
   /** A SHA256 hash that identifies the token module implementation. */
@@ -1509,6 +1508,18 @@ export type ImportState = {
   epochDuration: Scalars['TimeSpan'];
 };
 
+export type InitializationParameters = {
+  __typename?: 'InitializationParameters';
+  allowList?: Maybe<Scalars['Boolean']>;
+  burnable?: Maybe<Scalars['Boolean']>;
+  denyList?: Maybe<Scalars['Boolean']>;
+  governanceAccount: CborHolderAccount;
+  initialSupply?: Maybe<TokenAmount>;
+  metadata: MetadataUrl;
+  mintable?: Maybe<Scalars['Boolean']>;
+  name: Scalars['String'];
+};
+
 /**
  * The status of parsing `message` into its JSON representation using the
  * smart contract module schema.
@@ -1702,6 +1713,8 @@ export type Metadata = {
 
 export type MetadataUrl = {
   __typename?: 'MetadataUrl';
+  additional?: Maybe<Scalars['JSON']>;
+  checksumSha256?: Maybe<Scalars['String']>;
   url: Scalars['String'];
 };
 
@@ -3086,7 +3099,7 @@ export type TokenTokenEventsArgs = {
 
 export type TokenAmount = {
   __typename?: 'TokenAmount';
-  decimals: Scalars['Int'];
+  decimals: Scalars['String'];
   value: Scalars['String'];
 };
 


### PR DESCRIPTION
## Purpose

Fix for - `2025-07-22T13:39:06.641650Z  INFO concordium_scan::indexer::block_preprocessor: Failed preprocessing 11 times in row: Failed to query: RPC error: Error parsing JSON result: Failed to decode initialization parameters: Semantic(None, "invalid value: integer `-250`, expected i8")` 

## Changes

Remove custom deserialization of InitializationParameter  and used rust-sdk type `TokenModuleInitializationParameters` for proper deserialization of `InitializationParameter`. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
