### PR TITLE
add : migration m0041 to fix the token module reject reasons by properly serializing and deserializing the `TokenModuleReject` event using the `TokenModuleRejectReason` enum.

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 Database schema version: 40
+Database schema version: 41
 
 ### Added
 
@@ -15,6 +16,7 @@ Database schema version: 40
 - Added two new tables via migration `m0040`  
     - `metrics_specific_plt_transfer` to store plt transfer metrics (the data is being stored as cumulative increments by timestamp).
     - `metrics_plt` to store plt metrics (the data is being stored as cumulative increments by timestamp) .
+- Migration `m0041` to fix the token module reject reasons by properly serializing and deserializing the `TokenModuleReject` event using the `TokenModuleRejectReason` enum.
 
 ## [2.0.17] - 2025-07-24
 

--- a/backend/src/migrations.rs
+++ b/backend/src/migrations.rs
@@ -266,15 +266,17 @@ pub enum SchemaVersion {
     CreatePltTokenAndEventTables,
     #[display("0040: Alter PLT events add event_timestamp and index")]
     AlterPltEventsAddEventTimestampAndIndex,
+    #[display("0041: m0041_fix_token_module_reject_reasons")]
+    FixTokenModuleRejectReasons,
 }
 impl SchemaVersion {
     /// The minimum supported database schema version for the API.
     /// Fails at startup if any breaking (destructive) database schema versions
     /// have been introduced since this version.
     pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion =
-        SchemaVersion::CreatePltTokenAndEventTables;
+        SchemaVersion::AlterPltEventsAddEventTimestampAndIndex;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::AlterPltEventsAddEventTimestampAndIndex;
+    const LATEST: SchemaVersion = SchemaVersion::FixTokenModuleRejectReasons;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.
@@ -334,6 +336,7 @@ impl SchemaVersion {
             SchemaVersion::BakerApyQueryUpdateProtectAgainstOverflow => false,
             SchemaVersion::CreatePltTokenAndEventTables => false,
             SchemaVersion::AlterPltEventsAddEventTimestampAndIndex => false,
+            SchemaVersion::FixTokenModuleRejectReasons => false,
         }
     }
 
@@ -384,6 +387,7 @@ impl SchemaVersion {
             SchemaVersion::BakerApyQueryUpdateProtectAgainstOverflow => false,
             SchemaVersion::CreatePltTokenAndEventTables => false,
             SchemaVersion::AlterPltEventsAddEventTimestampAndIndex => false,
+            SchemaVersion::FixTokenModuleRejectReasons => false,
         }
     }
 
@@ -644,8 +648,16 @@ impl SchemaVersion {
                     .await?;
                 SchemaVersion::AlterPltEventsAddEventTimestampAndIndex
             }
+            SchemaVersion::AlterPltEventsAddEventTimestampAndIndex => {
+                tx.as_mut()
+                    .execute(sqlx::raw_sql(include_str!(
+                        "./migrations/m0041_fix_token_module_reject_reasons.sql"
+                    )))
+                    .await?;
+                SchemaVersion::FixTokenModuleRejectReasons
+            }
 
-            SchemaVersion::AlterPltEventsAddEventTimestampAndIndex => unimplemented!(
+            SchemaVersion::FixTokenModuleRejectReasons => unimplemented!(
                 "No migration implemented for database schema version {}",
                 self.as_i64()
             ),

--- a/backend/src/migrations/m0041_fix_token_module_reject_reasons.sql
+++ b/backend/src/migrations/m0041_fix_token_module_reject_reasons.sql
@@ -1,0 +1,169 @@
+-- Migration to fix previously stored token module reject reasons
+-- The old code was using serde_json::to_value(details) directly
+-- Now it properly serializes using TokenModuleRejectReasonType
+
+-- Create a function to migrate token module reject reasons
+CREATE OR REPLACE FUNCTION migrate_token_module_reject_reason(old_reject_reason JSONB) 
+RETURNS JSONB AS $$
+DECLARE
+    token_id TEXT;
+    reason_type TEXT;
+    details JSONB;
+    old_details JSONB;
+    new_reject_reason JSONB;
+BEGIN
+    -- Extract the token_id and reason_type from the old format
+    IF old_reject_reason ? 'TokenUpdateTransactionFailed' THEN
+        token_id := old_reject_reason->'TokenUpdateTransactionFailed'->>'token_id';
+        reason_type := old_reject_reason->'TokenUpdateTransactionFailed'->>'reason_type';
+        details := old_reject_reason->'TokenUpdateTransactionFailed'->'details';
+        
+        -- Check if this is already in the new format (has 'type' field in details)
+        IF details ? 'type' THEN
+            RETURN old_reject_reason;
+        END IF;
+        
+        -- Extract the actual details from the nested structure based on reason_type
+        old_details := details->reason_type;
+        
+        -- Build the new properly structured reject reason based on reason_type
+        new_reject_reason := jsonb_build_object(
+            'TokenUpdateTransactionFailed',
+            jsonb_build_object(
+                'token_id', token_id,
+                'reason_type', reason_type,
+                'details', CASE 
+                    WHEN LOWER(reason_type) = 'addressnotfound' THEN
+                        jsonb_build_object(
+                            'type', 'AddressNotFound',
+                            'index', COALESCE(old_details->>'index', '0'),
+                            'address', CASE 
+                                WHEN old_details->'address'->'type' = '"account"' THEN
+                                    jsonb_build_object(
+                                        'account', 
+                                        jsonb_build_object(
+                                            'address', 
+                                            jsonb_build_object('as_string', old_details->'address'->>'address'),
+                                            'coin_info',
+                                            jsonb_build_object('coin_info_code', '919')
+                                        )
+                                    )
+                                ELSE old_details->'address'
+                            END
+                        )
+                    WHEN LOWER(reason_type) = 'tokenbalanceinsufficient' THEN
+                        jsonb_build_object(
+                            'type', 'TokenBalanceInsufficient',
+                            'index', COALESCE(old_details->>'index', '0'),
+                            'available_balance', jsonb_build_object(
+                                'value', old_details->'availableBalance'->>'value',
+                                'decimals', old_details->'availableBalance'->>'decimals'
+                            ),
+                            'required_balance', jsonb_build_object(
+                                'value', old_details->'requiredBalance'->>'value',
+                                'decimals', old_details->'requiredBalance'->>'decimals'
+                            )
+                        )
+                    WHEN LOWER(reason_type) = 'deserializationfailure' THEN
+                        jsonb_build_object(
+                            'type', 'DeserializationFailure',
+                            'cause', old_details->>'cause'
+                        )
+                    WHEN LOWER(reason_type) = 'unsupportedoperation' THEN
+                        jsonb_build_object(
+                            'type', 'UnsupportedOperation',
+                            'index', COALESCE(old_details->>'index', '0'),
+                            'operation_type', COALESCE(old_details->>'operationType', 'unknown'),
+                            'reason', old_details->>'reason'
+                        )
+                    WHEN LOWER(reason_type) = 'operationnotpermitted' THEN
+                        jsonb_build_object(
+                            'type', 'OperationNotPermitted',
+                            'index', COALESCE(old_details->>'index', '0'),
+                            'address', CASE 
+                                WHEN old_details->'address' IS NULL THEN NULL
+                                WHEN old_details->'address'->'type' = '"account"' THEN
+                                    jsonb_build_object(
+                                        'account', 
+                                        jsonb_build_object(
+                                            'address', 
+                                            jsonb_build_object('as_string', old_details->'address'->>'address'),
+                                            'coin_info',
+                                            jsonb_build_object('coin_info_code', '919')
+                                        )
+                                    )
+                                ELSE old_details->'address'
+                            END,
+                            'reason', old_details->>'reason'
+                        )
+                    WHEN LOWER(reason_type) = 'mintwouldoverflow' THEN
+                        jsonb_build_object(
+                            'type', 'MintWouldOverflow',
+                            'index', COALESCE(old_details->>'index', '0'),
+                            'requested_amount', old_details->'requestedAmount',
+                            'current_supply', old_details->'currentSupply',
+                            'max_representable_amount', old_details->'maxRepresentableAmount'
+                        )
+                    ELSE
+                        jsonb_build_object(
+                            'type', 'Unknown',
+                            'message', 'Unknown reject reason for type: ' || reason_type || '. Original details: ' || old_details::text
+                        )
+                END
+            )
+        );
+        
+        RETURN new_reject_reason;
+    ELSE
+        -- Return the original if it's not a TokenUpdateTransactionFailed
+        RETURN old_reject_reason;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Update all transactions with TokenUpdateTransactionFailed reject reasons
+DO $$
+DECLARE
+    batch_size INTEGER := 10000;
+    total_updated INTEGER := 0;
+    min_id BIGINT := -1;
+    max_id BIGINT;
+    rows_updated INTEGER;
+BEGIN
+    -- Get the maximum transaction index to know when to stop
+    SELECT COALESCE(MAX(index), 0) INTO max_id FROM transactions 
+    WHERE reject IS NOT NULL 
+    AND reject ? 'TokenUpdateTransactionFailed'
+    AND NOT (
+        reject->'TokenUpdateTransactionFailed'->'details' ? 'type'
+    ); -- Only count records that need migration
+    
+    RAISE NOTICE 'Starting migration of token module reject reasons. Processing transaction indexes from % to %', min_id, max_id;
+
+    WHILE min_id < max_id LOOP
+        UPDATE transactions 
+        SET reject = migrate_token_module_reject_reason(reject)
+        WHERE index > min_id 
+        AND index <= min_id + batch_size
+        AND reject IS NOT NULL 
+        AND reject ? 'TokenUpdateTransactionFailed'
+        AND NOT (
+            reject->'TokenUpdateTransactionFailed'->'details' ? 'type'
+        ); -- Only update if the details don't already have the 'type' field (new format)
+
+        GET DIAGNOSTICS rows_updated = ROW_COUNT;
+        total_updated := total_updated + rows_updated;
+        min_id := min_id + batch_size;
+        
+        RAISE NOTICE 'Updated % rows in this batch. Total updated: %. Progress: %/%', 
+                    rows_updated, total_updated, min_id, max_id;
+
+        -- Optional: pause to reduce load
+        PERFORM pg_sleep(0.01);
+    END LOOP;
+
+    RAISE NOTICE 'Finished migrating token module reject reasons. Total rows updated: %', total_updated;
+END $$;
+
+-- Clean up the temporary function
+DROP FUNCTION migrate_token_module_reject_reason(JSONB);

--- a/frontend/src/components/RejectionReason/Reasons/TokenModuleReject.vue
+++ b/frontend/src/components/RejectionReason/Reasons/TokenModuleReject.vue
@@ -15,18 +15,8 @@
 					Available balance :
 					<b>
 						{{
-							// Todo: fix this when we reset the devnet DB
-							reason.details[reason.reasonType]?.availableBalance?.value /
-							10 **
-								reason.details[reason.reasonType]?.availableBalance?.decimals[
-									'$serde_json::private::Number'
-								]
-								? reason.details[reason.reasonType]?.availableBalance?.value /
-								  10 **
-										reason.details[reason.reasonType]?.availableBalance
-											?.decimals['$serde_json::private::Number']
-								: Number(reason.details.available_balance.value) /
-								  10 ** Number(reason.details.available_balance.decimals)
+							Number(reason.details.available_balance.value) /
+							10 ** Number(reason.details.available_balance.decimals)
 						}}
 					</b>
 				</span>
@@ -35,18 +25,8 @@
 					Required balance :
 					<b>
 						{{
-							// Todo: fix this when we reset the devnet DB
-							reason.details[reason.reasonType]?.requiredBalance?.value /
-							10 **
-								reason.details[reason.reasonType]?.requiredBalance?.decimals[
-									'$serde_json::private::Number'
-								]
-								? reason.details[reason.reasonType]?.requiredBalance?.value /
-								  10 **
-										reason.details[reason.reasonType]?.requiredBalance
-											?.decimals['$serde_json::private::Number']
-								: Number(reason.details.required_balance.value) /
-								  10 ** Number(reason.details.required_balance.decimals)
+							Number(reason.details.required_balance.value) /
+							10 ** Number(reason.details.required_balance.decimals)
 						}}
 					</b>
 				</span>
@@ -66,11 +46,7 @@
 				<span class="px-2">
 					Details:
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType]?.cause ?? reason.details?.cause
-						}}
+						{{ reason.details?.cause }}
 					</b>
 				</span>
 			</Tooltip>
@@ -88,12 +64,7 @@
 				<span class="px-2">
 					Address:
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType].address.address ??
-							reason.details.address.account.address.as_string
-						}}
+						{{ reason.details.address.account.address.as_string }}
 					</b>
 				</span>
 			</Tooltip>
@@ -111,23 +82,14 @@
 				<span class="px-2">
 					Operation Type :
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType].operationType ??
-							reason.details.operationType
-						}}
+						{{ reason?.details?.operation_type }}
 					</b>
 				</span>
 				<br />
 				<span class="px-2">
 					Details:
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType].reason ?? reason.details.reason
-						}}
+						{{ reason?.details?.reason }}
 					</b>
 				</span>
 			</Tooltip>
@@ -139,57 +101,27 @@
 				</span>
 				<br />
 				<span class="px-2">
-					Token Id : <b> {{ reason.tokenId }} </b>
+					Token Id : <b> {{ reason?.tokenId }} </b>
 				</span>
 				<br />
-				<span
-					v-if="
-						// Todo: fix this when we reset the devnet DB
-
-						reason.details[reason.reasonType]?.address ??
-						reason.details.address?.account?.address
-					"
-					class="px-2"
-				>
+				<span v-if="reason?.details.address?.account?.address" class="px-2">
 					Token Holder :
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType]?.address?.address ??
-							reason.details.address?.account?.address?.as_string
-						}}
+						{{ reason?.details.address?.account?.address?.as_string }}
 					</b>
 				</span>
 				<br />
-				<span
-					v-if="
-						// Todo: fix this when we reset the devnet DB
-
-						reason.details[reason.reasonType]?.address?.coinInfo ??
-						reason.details.address?.account?.coin_info
-					"
-					class="px-2"
-				>
+				<span v-if="reason?.details?.address?.account?.coin_info" class="px-2">
 					Coin Info :
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType]?.address?.coinInfo ??
-							reason.details.address?.account?.coin_info
-						}}
+						{{ reason?.details?.address?.account?.coin_info }}
 					</b>
 				</span>
 				<br />
 				<span class="px-2">
 					Details:
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType]?.reason ?? reason.details.reason
-						}}
+						{{ reason?.details?.reason }}
 					</b>
 				</span>
 			</Tooltip>
@@ -207,36 +139,21 @@
 				<span class="px-2">
 					Requested amount :
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType]?.requested_amount ??
-							reason.details.requested_amount
-						}}
+						{{ reason?.details?.requested_amount }}
 					</b>
 				</span>
 				<br />
 				<span class="px-2">
 					Current supply :
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType]?.current_supply ??
-							reason.details.current_supply
-						}}
+						{{ reason?.details?.current_supply }}
 					</b>
 				</span>
 				<br />
 				<span class="px-2">
 					Max representable ammount :
 					<b>
-						{{
-							// Todo: fix this when we reset the devnet DB
-
-							reason.details[reason.reasonType]?.max_representable_amount ??
-							reason.details.max_representable_amount
-						}}
+						{{ reason?.details?.max_representable_amount }}
 					</b>
 				</span>
 			</Tooltip>


### PR DESCRIPTION
## Purpose

- Proper serialization of `TokenModuleReject` is introduced and this Pr aims to clean up old TokenModuleReject and replace them with proper serialization

## Changes

- m0041 migration is added.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.


