### PR TITLE
fix: added two prometheus gauge metrics for last_processed_block_heig…

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -11,6 +11,7 @@ Database schema version: 40
 - TokenModuleRejectReason enum to proper serialization and deserialization of the `TokenModuleReject` event.
 - Query `PltUniqueAccounts` to fetch unique accounts holding PLT tokens.
 - Added query `PltEventMetrics` to fetch metrics related to plt token events.
+- Added `last_processed_block_height` and `last_processed_block_slot_time` prometheus gauge metrics so that we can easily see if we have caught up and are processing the latest blocks from the chain.
 
 ## [2.0.17] - 2025-07-24
 

--- a/backend/src/indexer/block.rs
+++ b/backend/src/indexer/block.rs
@@ -35,7 +35,7 @@ pub struct PreparedBlock {
     /// Absolute height of the block.
     pub height: i64,
     /// Block slot time (UTC).
-    slot_time: DateTime<Utc>,
+    pub slot_time: DateTime<Utc>,
     /// Id of the validator which constructed the block. Is only None for the
     /// genesis block.
     baker_id: Option<i64>,


### PR DESCRIPTION

## Purpose

Add prometheus metrics to easily see if we have caught up with the latest block processing

## Changes

Added `last_processed_block_height` and `last_processed_block_slot_time` as prometheus metrics so that we easily expose the last processed block height and the slot time to see if we have caught up to processing the latest blocks from the chain

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

