### PR TITLE
Feature/cor 1522 db connection pool stats

### DIFF
--- a/backend/.sqlx/query-25f2ebce76162f3a0b0ca7121733941de0f990c6aeeee3eab7f8e5bd38545a01.json
+++ b/backend/.sqlx/query-25f2ebce76162f3a0b0ca7121733941de0f990c6aeeee3eab7f8e5bd38545a01.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                COUNT(*) FILTER (WHERE state = 'active') AS \"active!\",\n                COUNT(*) FILTER (WHERE state = 'idle') AS \"idle!\",\n                COUNT(*) AS \"total!\"\n            FROM pg_stat_activity\n            WHERE datname = current_database()\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "active!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "idle!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "total!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "25f2ebce76162f3a0b0ca7121733941de0f990c6aeeee3eab7f8e5bd38545a01"
+}

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -12,6 +12,7 @@ Database schema version: 40
 - Query `PltUniqueAccounts` to fetch unique accounts holding PLT tokens.
 - Added query `PltEventMetrics` to fetch metrics related to plt token events.
 - Added `last_processed_block_height` and `last_processed_block_slot_time` prometheus gauge metrics so that we can easily see if we have caught up and are processing the latest blocks from the chain.
+- Added `db_connections_active_count`, `db_connections_idle_count` and `db_connections_total_count`as prometheus gauge metrics so we can easily see statistics related to database connections.
 
 ## [2.0.17] - 2025-07-24
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "futures",
  "hex",
  "iso8601-duration",
+ "mockall",
  "mockito",
  "num-derive",
  "num-traits",
@@ -1360,6 +1361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dtoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1548,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "funty"
@@ -2384,6 +2397,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "mockito"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2863,6 +2902,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy 0.8.25",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -3962,6 +4027,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -45,6 +45,7 @@ num-traits = "0.2.19"
 
 [dev-dependencies]
 mockito = "1.4"
+mockall = "0.13.1"
 
 # Recommended by SQLx to speed up incremental builds
 [profile.dev.package.sqlx-macros]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod graphql_api;
 pub mod indexer;
 pub mod migrations;
+pub mod monitoring;
 pub mod rest_api;
 pub mod router;
 

--- a/backend/src/monitoring/database_metrics.rs
+++ b/backend/src/monitoring/database_metrics.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tonic::async_trait;
 use tracing::{debug, info};
 
+/// Represent the metric name that will be registered with prometheus 
 const ACTIVE_DATABASE_CONNECTIONS_METRIC_NAME: &str = "db_connections_active_count";
 const IDLE_DATABASE_CONNECTIONS_METRIC_NAME: &str = "db_connections_idle_count";
 const TOTAL_DATABASE_CONNECTIONS_METRIC_NAME: &str = "db_connections_total_count";

--- a/backend/src/monitoring/database_metrics.rs
+++ b/backend/src/monitoring/database_metrics.rs
@@ -1,0 +1,193 @@
+use anyhow::Result;
+use prometheus_client::{metrics::gauge::Gauge, registry::Registry};
+use sqlx::PgPool;
+use std::sync::Arc;
+use tonic::async_trait;
+use tracing::{debug, info};
+
+const ACTIVE_DATABASE_CONNECTIONS_METRIC_NAME: &str = "db_connections_active_count";
+const IDLE_DATABASE_CONNECTIONS_METRIC_NAME: &str = "db_connections_idle_count";
+const TOTAL_DATABASE_CONNECTIONS_METRIC_NAME: &str = "db_connections_total_count";
+
+/// Database connection stats. Holds all the details about active connections,
+/// idle connections and total connections
+#[derive(sqlx::FromRow)]
+struct DatabaseConnectionStats {
+    /// Active database connections
+    active: i64,
+    /// Idle database connections
+    idle:   i64,
+    /// Total database connections
+    total:  i64,
+}
+
+/// Abstract trait definition of the Database statistics provider
+#[async_trait]
+pub trait DatabaseStatisticsProvider: Send + Sync {
+    async fn query_database_connections_stats(&self) -> Result<(i64, i64, i64)>;
+}
+
+/// Real Database statistics provider. Takes an Arc of the pool so that we can
+/// later clone it for querying
+pub struct RealDatabaseStatisticsProvider {
+    pool: Arc<PgPool>,
+}
+
+/// Implementation for the Real Database Statistics Provider, creates a new Arc
+/// for the provided pool
+impl RealDatabaseStatisticsProvider {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool: Arc::new(pool),
+        }
+    }
+}
+
+/// Database statistics provider implementation for the Real database statistics
+/// provider. Here we will clone the arc of the pool and perform the SQL query
+/// to check the database connections and return the active, idle and total
+/// connections in the result
+#[async_trait]
+impl DatabaseStatisticsProvider for RealDatabaseStatisticsProvider {
+    async fn query_database_connections_stats(&self) -> Result<(i64, i64, i64)> {
+        let pool = self.pool.clone();
+        let database_connection_statistics: DatabaseConnectionStats = sqlx::query_as!(
+            DatabaseConnectionStats,
+            r#"
+            SELECT
+                COUNT(*) FILTER (WHERE state = 'active') AS "active!",
+                COUNT(*) FILTER (WHERE state = 'idle') AS "idle!",
+                COUNT(*) AS "total!"
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+            "#
+        )
+        .fetch_one(&*pool)
+        .await?;
+
+        Ok((
+            database_connection_statistics.active,
+            database_connection_statistics.idle,
+            database_connection_statistics.total,
+        ))
+    }
+}
+
+/// Use to capture statistics and metrics related to the database, specifically
+/// database connection details
+#[derive(Clone)]
+pub struct DatabaseMetrics<P: DatabaseStatisticsProvider> {
+    /// database connection statistics provider
+    provider:              P,
+    /// prometheus gauge representing the active database connections
+    active_db_connections: Gauge<i64>,
+    /// prometheus gauge representing the idle database connections
+    idle_db_connections:   Gauge<i64>,
+    /// prometheus gauge representing the total database connections
+    total_db_connections:  Gauge<i64>,
+}
+
+/// Implementation for Database Metrics. It specifies a Generic Provider Type,
+/// so that it can easily be mocked for testing later
+impl<P: DatabaseStatisticsProvider> DatabaseMetrics<P> {
+    pub fn new(provider: P, registry: &mut Registry) -> Self {
+        info!("Creating Database Metrics collector now for database statistics gathering");
+        let active_db_connections = Gauge::default();
+        let idle_db_connections = Gauge::default();
+        let total_db_connections = Gauge::default();
+
+        registry.register(
+            ACTIVE_DATABASE_CONNECTIONS_METRIC_NAME,
+            "Active DB connections",
+            active_db_connections.clone(),
+        );
+        registry.register(
+            IDLE_DATABASE_CONNECTIONS_METRIC_NAME,
+            "Idle DB connections",
+            idle_db_connections.clone(),
+        );
+        registry.register(
+            TOTAL_DATABASE_CONNECTIONS_METRIC_NAME,
+            "Total DB connections",
+            total_db_connections.clone(),
+        );
+
+        info!(
+            "The following metrics are registered successfully for prometheus: {}, {}, {}",
+            ACTIVE_DATABASE_CONNECTIONS_METRIC_NAME,
+            IDLE_DATABASE_CONNECTIONS_METRIC_NAME,
+            TOTAL_DATABASE_CONNECTIONS_METRIC_NAME
+        );
+
+        Self {
+            provider,
+            active_db_connections,
+            idle_db_connections,
+            total_db_connections,
+        }
+    }
+
+    /// Update database metrics. Uses the dedicated provider to query the
+    /// database connection stats, so that they can be updated in the registry
+    /// for Prometheus
+    pub async fn update(&self) -> Result<()> {
+        let (active_db_connection_count, idle_db_connection_count, total_db_connection_count) =
+            self.provider.query_database_connections_stats().await?;
+
+        debug!(
+            "Database connection statistics are as follows: active: {}, idle: {}, total: {}",
+            &active_db_connection_count, &idle_db_connection_count, &total_db_connection_count
+        );
+
+        self.active_db_connections.set(active_db_connection_count);
+        self.idle_db_connections.set(idle_db_connection_count);
+        self.total_db_connections.set(total_db_connection_count);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use mockall::{mock, predicate::*};
+    use prometheus_client::registry::Registry;
+    use tonic::async_trait;
+
+    // Create a mock for the trait
+    mock! {
+        pub DatabaseStatisticsProvider {}
+        #[async_trait]
+        impl DatabaseStatisticsProvider for DatabaseStatisticsProvider {
+            async fn query_database_connections_stats(&self) -> Result<(i64, i64, i64)>;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_sets_gauges_correctly() {
+        // setup mocks and dependencies
+        let mut mock_provider = MockDatabaseStatisticsProvider::new();
+        let mut registry = Registry::default();
+
+        // Mock return call from querying the database connection stats
+        mock_provider.expect_query_database_connections_stats().returning(|| Ok((5, 3, 8)));
+
+        // invoke real update function
+        let metrics = DatabaseMetrics::new(mock_provider, &mut registry);
+        metrics.update().await.unwrap();
+
+        // assert all the database connections are set correctly
+        assert_eq!(5, metrics.active_db_connections.get());
+        assert_eq!(3, metrics.idle_db_connections.get());
+        assert_eq!(8, metrics.total_db_connections.get());
+
+        // Gte the encoded metrics from the prometheus registry
+        let mut encoded = String::new();
+        prometheus_client::encoding::text::encode(&mut encoded, &registry).unwrap();
+
+        // assert that the encoded contains the correct metrics now too
+        assert!(encoded.contains("db_connections_active_count 5"));
+        assert!(encoded.contains("db_connections_idle_count 3"));
+        assert!(encoded.contains("db_connections_total_count 8"));
+    }
+}

--- a/backend/src/monitoring/mod.rs
+++ b/backend/src/monitoring/mod.rs
@@ -1,0 +1,1 @@
+pub mod database_metrics;


### PR DESCRIPTION
## Purpose

Expose database monitoring metrics for prometheus to be able to see the total, active and idle DB connections easily

## Changes

Added async task to the ccd scan api so that we can see easily the database monitoring metrics related to total, active and idle db connections.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

