### PR TITLE
fix: update active connections gauge to acquired

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -12,7 +12,7 @@ Database schema version: 40
 - Query `PltUniqueAccounts` to fetch unique accounts holding PLT tokens.
 - Added query `PltEventMetrics` to fetch metrics related to plt token events.
 - Added `last_processed_block_height` and `last_processed_block_slot_time` prometheus gauge metrics so that we can easily see if we have caught up and are processing the latest blocks from the chain.
-- Added `db_connections_active_gauge`, `db_connections_idle_gauge` and `db_connections_max_gauge` as prometheus gauge metrics so we can easily see statistics related to database connections.
+- Added `db_connections_acquired_gauge`, `db_connections_idle_gauge` and `db_connections_max_gauge` as prometheus gauge metrics so we can easily see statistics related to database connections.
 - GraphQL API: Optimized the query that fetches paging information for the `blocks` query
 
 ### Changed


### PR DESCRIPTION
## Purpose

Update prometheus metrics gauge from active db connections to acquired to be more explanatory

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
