### PR TITLE
COR-1735 node_response_time_seconds metric covers fetching and preparing

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -22,6 +22,7 @@ Database schema version: 40
 ### Changed
 
 - Updated query `pltAccountsByTokenId` to fetch accounts holding PLT tokens by token ID.
+- The `node_response_time_seconds` prometheus gauge metric counts time both during the fetching and preparing the block.
 
 ## [2.0.17] - 2025-07-24
 

--- a/backend/src/indexer/block_preprocessor.rs
+++ b/backend/src/indexer/block_preprocessor.rs
@@ -239,8 +239,6 @@ impl concordium_rust_sdk::indexer::Indexer for BlockPreProcessor {
                 get_items,
                 get_special_items
             )?;
-            let node_response_time = start_fetching.elapsed();
-            self.node_response_time.get_or_create(label).observe(node_response_time.as_secs_f64());
             let data = BlockData {
                 finalized_block_info: fbi,
                 block_info,
@@ -257,6 +255,8 @@ impl concordium_rust_sdk::indexer::Indexer for BlockPreProcessor {
             let prepared_block = PreparedBlock::prepare(&mut client, &data)
                 .await
                 .map_err(v2::RPCError::ParseError)?;
+            let node_response_time = start_fetching.elapsed();
+            self.node_response_time.get_or_create(label).observe(node_response_time.as_secs_f64());
             Ok(prepared_block)
         }
         .await;


### PR DESCRIPTION
## Purpose

The prometheus gauge metric `node_response_time_seconds` did not reflect the whole picture as it used to count time used during the first phase of two-step block preprocessing. Since second step now also interacts with the node, the metric should have been updated to reflect the change.

## Changes

* `node_response_time_seconds` metric now covers time needed during the both data fetching and block preparing steps.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
