### PR TITLE
fix: fix buiild error due to bigInt literals es2019

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-# Fixed
+### Fixed
 
 - fix build failure due to the bigint literal in es2019
 

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+# Fixed
+
+- fix build failure due to the bigint literal in es2019
+
 ## [1.7.23] - 2025-08-26
 
 ### Fixed

--- a/frontend/src/components/atoms/PltAmount.vue
+++ b/frontend/src/components/atoms/PltAmount.vue
@@ -20,10 +20,10 @@ const props = defineProps<Props>()
 
 const numberFormatter = (significantBigInt: bigint, decimals: number) => {
 	const units = [
-		{ threshold: 1000000000000n, suffix: 'T' },
-		{ threshold: 1000000000n, suffix: 'B' },
-		{ threshold: 1000000n, suffix: 'M' },
-		{ threshold: 1000n, suffix: 'K' },
+		{ threshold: BigInt(1000000000000), suffix: 'T' },
+		{ threshold: BigInt(1000000000), suffix: 'B' },
+		{ threshold: BigInt(1000000), suffix: 'M' },
+		{ threshold: BigInt(1000), suffix: 'K' },
 	]
 
 	const unit = units.find(u => significantBigInt >= u.threshold)

--- a/frontend/src/pages/protocol-token/index.vue
+++ b/frontend/src/pages/protocol-token/index.vue
@@ -29,7 +29,7 @@
 														String(coin?.totalSupply),
 														Number(coin?.decimal)
 													),
-												0n
+												BigInt(0)
 											)
 											.toString()
 									"


### PR DESCRIPTION
## Purpose

Fix build error due to bigInt literals and es2019

## Changes

Converted literals to BigInt Object ( `0n`  --->  Bigint(0)) 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
