### PR TITLE
fix: CRE-531

### DIFF
--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -1512,6 +1512,7 @@ scalar Long
 
 type Memo {
 	bytes: String!
+	decoded: DecodedText!
 }
 
 type Metadata {

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Fixed plt transfer memo was not visible.
+
 ## [1.7.24] - 2025-08-29
 
 ### Fixed

--- a/frontend/src/components/TransactionEventList/Events/PltTransferMemo.vue
+++ b/frontend/src/components/TransactionEventList/Events/PltTransferMemo.vue
@@ -1,0 +1,23 @@
+<template>
+	<div
+		v-if="memo?.__typename === 'Memo'"
+		class="bg-gray rounded flex items-center gap-2"
+	>
+		<span>Memo:</span>
+		<span class="break-all whitespace-pre-line text-xs">{{
+			memo?.bytes ? Buffer.from(memo.bytes, 'hex').toString('utf-8') : ''
+		}}</span>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { Buffer } from 'buffer'
+
+import type { Memo } from '../../../types/generated'
+
+type Props = {
+	memo?: Memo
+}
+
+defineProps<Props>()
+</script>

--- a/frontend/src/components/TransactionEventList/Events/PltTransferMemo.vue
+++ b/frontend/src/components/TransactionEventList/Events/PltTransferMemo.vue
@@ -1,11 +1,8 @@
 <template>
-	<div
-		v-if="memo?.__typename === 'Memo'"
-		class="bg-gray rounded flex items-center gap-2"
-	>
-		<span v-if="memo?.__typename === 'Memo'" class="text-gray-500">
+	<div class="bg-gray rounded flex items-center gap-2">
+		<span class="text-gray-500">
 			Memo :
-			{{ memo?.decoded?.text || '' }}
+			{{ memo.decoded.text }}
 		</span>
 	</div>
 </template>

--- a/frontend/src/components/TransactionEventList/Events/PltTransferMemo.vue
+++ b/frontend/src/components/TransactionEventList/Events/PltTransferMemo.vue
@@ -3,20 +3,18 @@
 		v-if="memo?.__typename === 'Memo'"
 		class="bg-gray rounded flex items-center gap-2"
 	>
-		<span>Memo:</span>
-		<span class="break-all whitespace-pre-line text-xs">{{
-			memo?.bytes ? Buffer.from(memo.bytes, 'hex').toString('utf-8') : ''
-		}}</span>
+		<span v-if="memo?.__typename === 'Memo'" class="text-gray-500">
+			Memo :
+			{{ memo?.decoded?.text || '' }}
+		</span>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { Buffer } from 'buffer'
-
-import type { Memo } from '../../../types/generated'
+import type { Memo } from '~/types/generated'
 
 type Props = {
-	memo?: Memo
+	memo: Memo
 }
 
 defineProps<Props>()

--- a/frontend/src/components/TransactionEventList/Events/TokenEvents.vue
+++ b/frontend/src/components/TransactionEventList/Events/TokenEvents.vue
@@ -15,6 +15,9 @@
 			To
 			<AccountLink :address="event.event.to.address.asString" />
 		</span>
+		<span>
+			<PltTransferMemo :memo="event.event.memo ?? undefined" />
+		</span>
 	</span>
 
 	<span v-else-if="event.event.__typename === 'MintEvent'">
@@ -66,7 +69,7 @@
 
 <script setup lang="ts">
 import type { TokenUpdate } from '~/types/generated'
-import AccountLink from '~/components/molecules/AccountLink.vue'
+import PltTransferMemo from './PltTransferMemo.vue'
 
 type Props = {
 	event: TokenUpdate

--- a/frontend/src/components/TransactionEventList/Events/TokenEvents.vue
+++ b/frontend/src/components/TransactionEventList/Events/TokenEvents.vue
@@ -16,7 +16,7 @@
 			<AccountLink :address="event.event.to.address.asString" />
 		</span>
 		<span>
-			<PltTransferMemo :memo="event.event.memo ?? undefined" />
+			<PltTransferMemo v-if="event.event.memo" :memo="event.event.memo" />
 		</span>
 	</span>
 

--- a/frontend/src/queries/usePltEventsQuery.ts
+++ b/frontend/src/queries/usePltEventsQuery.ts
@@ -59,7 +59,10 @@ const PLT_TOKEN_QUERY = gql<PltEventsQueryResponse>`
 							decimals
 						}
 						memo {
-							bytes
+							decoded {
+								text
+								decodeType
+							}
 						}
 					}
 					... on TokenModuleEvent {
@@ -166,7 +169,10 @@ const PLT_EVENT_BY_ID_QUERY = gql<PltEventsByTokenIdQueryResponse>`
 							decimals
 						}
 						memo {
-							bytes
+							decoded {
+								text
+								decodeType
+							}
 						}
 					}
 					... on TokenModuleEvent {

--- a/frontend/src/queries/useTransactionQuery.ts
+++ b/frontend/src/queries/useTransactionQuery.ts
@@ -392,7 +392,10 @@ __typename
         }
         ... on TokenTransferEvent {
             memo {
-                bytes
+                decoded {
+                    text
+                    decodeType
+                }
             }
             amount {
                 value
@@ -481,7 +484,10 @@ __typename
                     decimals
                 }
                 memo {
-                    bytes
+                    decoded {
+                        text
+                        decodeType
+                    }
                 }
             }
             ... on MintEvent {

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -1716,6 +1716,7 @@ export type LinkedContractsCollectionSegment = {
 export type Memo = {
   __typename?: 'Memo';
   bytes: Scalars['String'];
+  decoded: DecodedText;
 };
 
 export type Metadata = {


### PR DESCRIPTION
## Purpose

When transferring PLT tokens with a memo, the memo text is not visible on CCDScan. This behavior is inconsistent with CCD transfers, where the memo is displayed correctly.

## Changes

- A new `PltTransferMemo` component is added

<img width="773" height="330" alt="image" src="https://github.com/user-attachments/assets/39c0c485-aa28-41d2-ba2a-d43a7f0fc827" />


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
