### PR TITLE
fix: Transfer Plt txn sender and reciver are same CRE-548

### DIFF
--- a/backend/.sqlx/query-cb76ec9ab7d605df2933c05944f72ce1c6a67f8bab3807dcbf3eb10c2ab98f9a.json
+++ b/backend/.sqlx/query-cb76ec9ab7d605df2933c05944f72ce1c6a67f8bab3807dcbf3eb10c2ab98f9a.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO plt_accounts (account_index, token_index, amount, decimal)\n                VALUES\n                    ( (SELECT index FROM accounts WHERE canonical_address = $1::bytea),\n                    (SELECT index FROM plt_tokens WHERE token_id = $2),\n                    0::numeric,\n                    (SELECT decimal FROM plt_tokens WHERE token_id = $2)\n                    )\n                ON CONFLICT (account_index, token_index) DO UPDATE\n                SET amount = plt_accounts.amount + 0\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cb76ec9ab7d605df2933c05944f72ce1c6a67f8bab3807dcbf3eb10c2ab98f9a"
+}

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Indexer crash while plt transfer involves self transfer (not updating plt amount balance if sender and recipient are the same).
+
 ## [2.0.18] - 2025-08-26
 
 Database schema version: 40

--- a/backend/src/transaction_event/protocol_level_tokens.rs
+++ b/backend/src/transaction_event/protocol_level_tokens.rs
@@ -921,7 +921,7 @@ impl PreparedTokenUpdate {
                 amount,
                 self.token_id
             );
-            
+
             // Handle self-transfer with a single database operation (net change = 0)
             sqlx::query!(
                 "INSERT INTO plt_accounts (account_index, token_index, amount, decimal)

--- a/backend/src/transaction_event/protocol_level_tokens.rs
+++ b/backend/src/transaction_event/protocol_level_tokens.rs
@@ -912,15 +912,36 @@ impl PreparedTokenUpdate {
 
         // Check if this is a self-transfer (same account sending to itself)
         if from_canonical_address == to_canonical_address {
-            // For self-transfers, no balance changes occur, but we still need to record the event
+            // For self-transfers, no balance changes occur, but we still need to record the account-token relationship
             // The amounts cancel out: -amount + amount = 0
-            // So we can skip the balance updates entirely
+            // Insert a single entry with 0 change to ensure the account appears in queries
             tracing::debug!(
                 "Detected PLT self-transfer for account {} with amount {} for token {}",
                 from,
                 amount,
                 self.token_id
             );
+            
+            // Handle self-transfer with a single database operation (net change = 0)
+            sqlx::query!(
+                "INSERT INTO plt_accounts (account_index, token_index, amount, decimal)
+                VALUES
+                    ( (SELECT index FROM accounts WHERE canonical_address = $1::bytea),
+                    (SELECT index FROM plt_tokens WHERE token_id = $2),
+                    0::numeric,
+                    (SELECT decimal FROM plt_tokens WHERE token_id = $2)
+                    )
+                ON CONFLICT (account_index, token_index) DO UPDATE
+                SET amount = plt_accounts.amount + 0
+                ",
+                from_canonical_address.0.as_slice(),
+                self.token_id,
+            )
+            .execute(tx.as_mut())
+            .await?;
+
+            // No need to update sum_amounts for self-transfers as the net change is 0
+            // This also avoids the "ON CONFLICT DO UPDATE command cannot affect row a second time" error
             return Ok(());
         }
 


### PR DESCRIPTION
## Purpose

Fix Indexer crashlooping due to plt Transfer to same account as sender and reciever

## Changes

We don't update the db for balance update if both are same so effective change is 0;

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.


