### PR TITLE
fix: navigation CRE-545

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed per plt page navigation to open in the same tab.
 - Fixed issue with footer links not redirecting to proper telegram channel.
 
 ### Added

--- a/frontend/src/components/Charts/ChartBarST.vue
+++ b/frontend/src/components/Charts/ChartBarST.vue
@@ -193,7 +193,7 @@ const handleBarClick = (event: MouseEvent) => {
 		if (y >= pixel - 10 && y <= pixel + 10 && x < yScale.left) {
 			const label = chartData.labels?.[i]
 			if (label) {
-				window.open(`/protocol-token/${label}`, '_blank')
+				window.open(`/protocol-token/${label}`, '_self')
 			}
 			return
 		}
@@ -210,7 +210,7 @@ const handleBarClick = (event: MouseEvent) => {
 		const index = elements[0].index
 		const label = chartData.labels?.[index] as string
 		if (label) {
-			window.open(`/protocol-token/${label}`, '_blank')
+			window.open(`/protocol-token/${label}`, '_self')
 		}
 	}
 }

--- a/frontend/src/components/Charts/DoughnutChart.vue
+++ b/frontend/src/components/Charts/DoughnutChart.vue
@@ -88,7 +88,7 @@ const defaultOptions: ChartOptions<'doughnut'> = {
 				if (index !== undefined) {
 					const label = chartData.value.labels?.[index]
 					if (label) {
-						window.open(`/protocol-token/${label}`, '_blank')
+						window.open(`/protocol-token/${label}`, '_self')
 					}
 				}
 				return
@@ -135,7 +135,7 @@ const handleSliceClick = (event: MouseEvent) => {
 		const index = elements[0].index
 		const label = chartInstance.data.labels?.[index] as string
 		if (label) {
-			window.open(`/protocol-token/${label}`, '_blank')
+			window.open(`/protocol-token/${label}`, '_self')
 		}
 	}
 }

--- a/frontend/src/components/PageFooter/OpenLinkButton.vue
+++ b/frontend/src/components/PageFooter/OpenLinkButton.vue
@@ -9,7 +9,7 @@ type Props = {
 }
 const props = defineProps<Props>()
 const handleClick = () => {
-	window.open(props.url, '_blank')
+	window.open(props.url, '_self')
 }
 </script>
 <style>

--- a/frontend/src/pages/protocol-token/index.vue
+++ b/frontend/src/pages/protocol-token/index.vue
@@ -149,7 +149,7 @@
 						<TableTd>
 							<a
 								:href="`/protocol-token/${event.tokenId}`"
-								target="_blank"
+								target="_self"
 								class="font-normal text-md text-theme-interactive flex flex-row items-center"
 							>
 								{{ event.tokenName }}


### PR DESCRIPTION
## Purpose

Open per plt page open in the same browser tab

## Changes

Changed `window.open(`/protocol-token/${label}`, '_blank')`  to `window.open(`/protocol-token/${label}`, '_self')` 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

