### PR TITLE
fix: re-add the baker related transactions index again, after it was …

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Database schema version: 41
+
+### Fixed
+
+- index for baker related transactions `baker_related_tx_idx` re-added. This was dropped inherently due to the column drop & rename `type_account` on the transactions table in migration file 0037
+
 ## [2.0.19] - 2025-09-05
 
 ### Fixed

--- a/backend/src/migrations.rs
+++ b/backend/src/migrations.rs
@@ -280,6 +280,8 @@ pub enum SchemaVersion {
     CreatePltTokenAndEventTables,
     #[display("0040: Alter PLT events add event_timestamp and index")]
     AlterPltEventsAddEventTimestampAndIndex,
+    #[display("0041: Re-Add the index `baker_related_tx_idx` that was dropped in mistake due to column drop")]
+    ReAddBakerRelatedTransactionsIndex,
 }
 impl SchemaVersion {
     /// The minimum supported database schema version for the API.
@@ -288,7 +290,7 @@ impl SchemaVersion {
     pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion =
         SchemaVersion::CreatePltTokenAndEventTables;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::AlterPltEventsAddEventTimestampAndIndex;
+    const LATEST: SchemaVersion = SchemaVersion::ReAddBakerRelatedTransactionsIndex;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.
@@ -350,6 +352,7 @@ impl SchemaVersion {
             SchemaVersion::BakerApyQueryUpdateProtectAgainstOverflow => false,
             SchemaVersion::CreatePltTokenAndEventTables => false,
             SchemaVersion::AlterPltEventsAddEventTimestampAndIndex => false,
+            SchemaVersion::ReAddBakerRelatedTransactionsIndex => false,
         }
     }
 
@@ -400,6 +403,7 @@ impl SchemaVersion {
             SchemaVersion::BakerApyQueryUpdateProtectAgainstOverflow => false,
             SchemaVersion::CreatePltTokenAndEventTables => false,
             SchemaVersion::AlterPltEventsAddEventTimestampAndIndex => false,
+            SchemaVersion::ReAddBakerRelatedTransactionsIndex => false,
         }
     }
 
@@ -674,8 +678,16 @@ impl SchemaVersion {
                     .await?;
                 SchemaVersion::AlterPltEventsAddEventTimestampAndIndex
             }
+            SchemaVersion::AlterPltEventsAddEventTimestampAndIndex => {
+                tx.as_mut()
+                    .execute(sqlx::raw_sql(include_str!(
+                        "./migrations/m0041_re_add_index_baker_related_transactions.sql"
+                    )))
+                    .await?;
+                SchemaVersion::ReAddBakerRelatedTransactionsIndex
+            }
 
-            SchemaVersion::AlterPltEventsAddEventTimestampAndIndex => unimplemented!(
+            SchemaVersion::ReAddBakerRelatedTransactionsIndex => unimplemented!(
                 "No migration implemented for database schema version {}",
                 self.as_i64()
             ),

--- a/backend/src/migrations/m0041_re_add_index_baker_related_transactions.sql
+++ b/backend/src/migrations/m0041_re_add_index_baker_related_transactions.sql
@@ -1,0 +1,3 @@
+-- This index was added in migration file 0001, but due to a later migration script (0037) - dropping of the column 'type_account' inherently causes the index to also drop. THis index needs to be re-added here
+-- Important for quickly filtering transactions related to a baker_id.
+CREATE INDEX IF NOT EXISTS baker_related_tx_idx ON transactions (sender_index, type_account, index) WHERE type_account IN ('AddBaker', 'RemoveBaker', 'UpdateBakerStake', 'UpdateBakerRestakeEarnings', 'UpdateBakerKeys', 'ConfigureBaker');


### PR DESCRIPTION
## Purpose

Re-Add the `baker_related_tx_idx` that was inherently dropped due to column drop on transactions table, that was re-added. This caused the index to be dropped, which now needs to be re-added.

## Changes

Added a migration file to re-introduce the index now that is missing

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

