### PR TITLE
Feat: Display Verify and access information on transaction list page

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- TransactionList graphql query now queries the actual event data only for `RegisterData` transactions, which is then decoded to tag the transactions on the transaction list page.
+
 ## [1.7.31] - 2026-02-20
 
 ### Fixed

--- a/frontend/src/pages/transactions/index.vue
+++ b/frontend/src/pages/transactions/index.vue
@@ -70,6 +70,18 @@
 							<span class="whitespace-normal">
 								{{ translateTransactionType(transaction.transactionType) }}
 							</span>
+							<chip
+								v-if="(transaction.result as Success)?.events?.nodes?.find(e => e.__typename === 'DataRegistered')"
+							>
+								{{
+									getRegisteredDataType(
+										(transaction.result as Success)?.events?.nodes?.find(
+											e => e.__typename === 'DataRegistered'
+										) as DataRegistered
+									)
+								}}
+							</chip>
+
 							<SponsorIcon
 								v-if="transaction.sponsorAccountAddress"
 								:glow-on="true"
@@ -106,7 +118,12 @@
 
 <script lang="ts" setup>
 import Tooltip from '~/components/atoms/Tooltip.vue'
-import { formatTimestamp, convertTimestampToRelative } from '~/utils/format'
+import {
+	formatTimestamp,
+	convertTimestampToRelative,
+	formatCborData,
+	formatHexData,
+} from '~/utils/format'
 import { translateTransactionType } from '~/utils/translateTransactionTypes'
 import { useDateNow } from '~/composables/useDateNow'
 import { usePagedData } from '~/composables/usePagedData'
@@ -118,12 +135,15 @@ import {
 	MetricsPeriod,
 	type Transaction,
 	type Subscription,
+	type Success,
+	type DataRegistered,
 } from '~/types/generated'
 import Amount from '~/components/atoms/Amount.vue'
 import MetricCard from '~/components/atoms/MetricCard.vue'
 import TransactionResult from '~/components/molecules/TransactionResult.vue'
 import TransactionCountChart from '~/components/molecules/ChartCards/TransactionCountChart.vue'
 import CumulativeTransactionsChart from '~/components/molecules/ChartCards/CumulativeTransactionsChart.vue'
+import { ref, onMounted, onUnmounted, watch } from 'vue'
 
 const { NOW } = useDateNow()
 const { breakpoint } = useBreakpoint()
@@ -155,6 +175,38 @@ onUnmounted(() => {
 const refetch = () => {
 	fetchNew(newItems.value)
 	newItems.value = 0
+}
+
+const safeParse = (value: string) => {
+	try {
+		// 1️ Convert h'...' to standard double-quoted string
+		value = value.replace(/h'([^']+)'/g, '"$1"')
+		// 2️ Remove trailing commas before } or ]
+		value = value.replace(/,(\s*[}\]])/g, '$1')
+		return JSON.parse(value)
+	} catch {
+		return null
+	}
+}
+
+const getRegisteredDataType = (data: DataRegistered) => {
+	const text = data?.decoded?.text as string
+	if (!text?.trim()) return null
+
+	switch (data?.decoded?.decodeType) {
+		case 'HEX': {
+			const result = formatHexData(text, true)
+			return typeof result === 'string' ? safeParse(result)?.type : null
+		}
+
+		case 'CBOR': {
+			const result = formatCborData(text, true)
+			return typeof result === 'string' ? safeParse(result)?.type : null
+		}
+
+		default:
+			return null
+	}
 }
 
 const { data } = useTransactionsListQuery({

--- a/frontend/src/queries/useTransactionListQuery.ts
+++ b/frontend/src/queries/useTransactionListQuery.ts
@@ -40,6 +40,19 @@ const TransactionsQuery = gql<TransactionListResponse>`
 				}
 				result {
 					__typename
+					... on Success {
+						events {
+							nodes {
+								... on DataRegistered {
+									dataAsHex
+									decoded {
+										text
+										decodeType
+									}
+								}
+							}
+						}
+					}
 				}
 				transactionType {
 					__typename


### PR DESCRIPTION
## Purpose

Display Verify and access information on transaction list page

## Ticket 

https://linear.app/concordium/issue/CRE-835/display-verify-and-access-information-on-transaction-list-page

## Changes

The API/GraphQL call will return the registered data along with the transaction list.
The frontend now decodes/parses that data and tag the transaction type. 

<img width="1614" height="695" alt="image" src="https://github.com/user-attachments/assets/0f22eac2-8c90-4a9f-a7a5-ba4ba8808ae2" />


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

