### PR TITLE
[COR-2459] Add support for Locks

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -58,8 +58,12 @@ jobs:
     name: GraphQL schema diff
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Install diff tool
-        run: npm i --global @graphql-inspector/ci graphql @graphql-inspector/diff-command @graphql-inspector/graphql-loader
+        run: npm install --prefix "$RUNNER_TEMP/graphql-inspector" @graphql-inspector/ci@5.0.7 graphql@16.11.0
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -70,4 +74,4 @@ jobs:
           cargo run --bin ccdscan-api -- --schema-out $RUNNER_TEMP/schema.graphql
       - name: Compare schemas
         working-directory: backend
-        run: graphql-inspector diff schema.graphql $RUNNER_TEMP/schema.graphql
+        run: $RUNNER_TEMP/graphql-inspector/node_modules/.bin/graphql-inspector diff schema.graphql $RUNNER_TEMP/schema.graphql

--- a/backend/.sqlx/query-0f50437cc7538a89ef6825f41924e301fc6848bcc5a62ac0179b8bd8e7567226.json
+++ b/backend/.sqlx/query-0f50437cc7538a89ef6825f41924e301fc6848bcc5a62ac0179b8bd8e7567226.json
@@ -1,0 +1,82 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                lock_id,\n                creator_account_index,\n                created_transaction_index,\n                created_at,\n                expiry,\n                canceled_transaction_index,\n                canceled_at,\n                config as \"config: Json<LockCreateConfig>\",\n                raw_config,\n                metadata_name,\n                metadata_description\n            FROM plt_locks\n            WHERE lock_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "lock_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "creator_account_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_transaction_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "expiry",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "canceled_transaction_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "canceled_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "config: Json<LockCreateConfig>",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 8,
+        "name": "raw_config",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "metadata_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "metadata_description",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "0f50437cc7538a89ef6825f41924e301fc6848bcc5a62ac0179b8bd8e7567226"
+}

--- a/backend/.sqlx/query-1a8b2c837874720c9402516d5ce7f6480a2621333ae7028ac2a094385493cb16.json
+++ b/backend/.sqlx/query-1a8b2c837874720c9402516d5ce7f6480a2621333ae7028ac2a094385493cb16.json
@@ -83,7 +83,8 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenUpdate"
+                "TokenUpdate",
+                "MetaUpdate"
               ]
             }
           }
@@ -136,7 +137,8 @@
                 "BlockEnergyLimitUpdate",
                 "FinalizationCommitteeParametersUpdate",
                 "ValidatorScoreParametersUpdate",
-                "CreatePltUpdate"
+                "CreatePltUpdate",
+                "MaxLockDurationUpdate"
               ]
             }
           }
@@ -195,7 +197,8 @@
                       "RegisterData",
                       "ConfigureBaker",
                       "ConfigureDelegation",
-                      "TokenUpdate"
+                      "TokenUpdate",
+                      "MetaUpdate"
                     ]
                   }
                 }

--- a/backend/.sqlx/query-2303402baafb3069deb38ea4b852143fa9db465fd34693d977360c278b124a87.json
+++ b/backend/.sqlx/query-2303402baafb3069deb38ea4b852143fa9db465fd34693d977360c278b124a87.json
@@ -83,7 +83,8 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenUpdate"
+                "TokenUpdate",
+                "MetaUpdate"
               ]
             }
           }
@@ -136,7 +137,8 @@
                 "BlockEnergyLimitUpdate",
                 "FinalizationCommitteeParametersUpdate",
                 "ValidatorScoreParametersUpdate",
-                "CreatePltUpdate"
+                "CreatePltUpdate",
+                "MaxLockDurationUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-2ad6a1a0e83c4bce5aae90756dc8a555e44ddfc0c50587c5b0ba12f44c24e353.json
+++ b/backend/.sqlx/query-2ad6a1a0e83c4bce5aae90756dc8a555e44ddfc0c50587c5b0ba12f44c24e353.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                plt_lock_balances.lock_id,\n                plt_lock_balances.account_index,\n                plt_lock_balances.token_index,\n                plt_tokens.token_id,\n                plt_lock_balances.amount,\n                plt_lock_balances.decimal\n            FROM plt_lock_balances\n            JOIN plt_tokens ON plt_tokens.index = plt_lock_balances.token_index\n            WHERE plt_lock_balances.lock_id = $1\n                AND plt_lock_balances.account_index = $2\n                AND plt_lock_balances.amount <> 0\n            ORDER BY plt_tokens.token_id ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "lock_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "account_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "token_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "token_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "amount",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 5,
+        "name": "decimal",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2ad6a1a0e83c4bce5aae90756dc8a555e44ddfc0c50587c5b0ba12f44c24e353"
+}

--- a/backend/.sqlx/query-30750d6fdbc34dd1e37bbf0d310b536e354b009eda4a1a6beac875ada5280680.json
+++ b/backend/.sqlx/query-30750d6fdbc34dd1e37bbf0d310b536e354b009eda4a1a6beac875ada5280680.json
@@ -1,0 +1,88 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT *\n            FROM (\n                SELECT\n                    lock_id,\n                    creator_account_index,\n                    created_transaction_index,\n                    created_at,\n                    expiry,\n                    canceled_transaction_index,\n                    canceled_at,\n                    config as \"config: sqlx::types::Json<LockCreateConfig>\",\n                    raw_config,\n                    metadata_name,\n                    metadata_description\n                FROM plt_locks\n                WHERE starts_with(lock_id, $5)\n                    AND (\n                        COALESCE(created_transaction_index, 0) < $1\n                        OR (\n                            COALESCE(created_transaction_index, 0) = $1\n                            AND lock_id > $2\n                        )\n                    )\n                    AND (\n                        COALESCE(created_transaction_index, 0) > $3\n                        OR (\n                            COALESCE(created_transaction_index, 0) = $3\n                            AND lock_id < $4\n                        )\n                    )\n                ORDER BY\n                    CASE WHEN $7 THEN COALESCE(created_transaction_index, 0) END ASC,\n                    CASE WHEN $7 THEN lock_id END DESC,\n                    CASE WHEN NOT $7 THEN COALESCE(created_transaction_index, 0) END DESC,\n                    CASE WHEN NOT $7 THEN lock_id END ASC\n                LIMIT $6\n            ) locks\n            ORDER BY COALESCE(created_transaction_index, 0) DESC, lock_id ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "lock_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "creator_account_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_transaction_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "expiry",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "canceled_transaction_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "canceled_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "config: sqlx::types::Json<LockCreateConfig>",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 8,
+        "name": "raw_config",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "metadata_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "metadata_description",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Int8",
+        "Text",
+        "Text",
+        "Int8",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "30750d6fdbc34dd1e37bbf0d310b536e354b009eda4a1a6beac875ada5280680"
+}

--- a/backend/.sqlx/query-32528bf3f5683f658a5cb123cf4ff6ddb70e720bd2485e341ae2343b2847283d.json
+++ b/backend/.sqlx/query-32528bf3f5683f658a5cb123cf4ff6ddb70e720bd2485e341ae2343b2847283d.json
@@ -83,7 +83,8 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenUpdate"
+                "TokenUpdate",
+                "MetaUpdate"
               ]
             }
           }
@@ -136,7 +137,8 @@
                 "BlockEnergyLimitUpdate",
                 "FinalizationCommitteeParametersUpdate",
                 "ValidatorScoreParametersUpdate",
-                "CreatePltUpdate"
+                "CreatePltUpdate",
+                "MaxLockDurationUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-37ba226ca571e84f5719cede1990dd9f76655a40b3a806aa5f08b070e8101ca3.json
+++ b/backend/.sqlx/query-37ba226ca571e84f5719cede1990dd9f76655a40b3a806aa5f08b070e8101ca3.json
@@ -83,7 +83,8 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenUpdate"
+                "TokenUpdate",
+                "MetaUpdate"
               ]
             }
           }
@@ -136,7 +137,8 @@
                 "BlockEnergyLimitUpdate",
                 "FinalizationCommitteeParametersUpdate",
                 "ValidatorScoreParametersUpdate",
-                "CreatePltUpdate"
+                "CreatePltUpdate",
+                "MaxLockDurationUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-41e982c228f5fd4f95b7cd74f7e90c5712bfa70eb5584a7a868eb937b1469d98.json
+++ b/backend/.sqlx/query-41e982c228f5fd4f95b7cd74f7e90c5712bfa70eb5584a7a868eb937b1469d98.json
@@ -48,7 +48,10 @@
                 "AddDenyList",
                 "RemoveDenyList",
                 "Pause",
-                "Unpause"
+                "Unpause",
+                "AssignAdminRoles",
+                "RevokeAdminRoles",
+                "UpdateMetadata"
               ]
             }
           }

--- a/backend/.sqlx/query-423f208f0b81fc7d96656b005c2ef937c4ace01978997cd958ac7a7487b455ff.json
+++ b/backend/.sqlx/query-423f208f0b81fc7d96656b005c2ef937c4ace01978997cd958ac7a7487b455ff.json
@@ -47,7 +47,8 @@
                       "RegisterData",
                       "ConfigureBaker",
                       "ConfigureDelegation",
-                      "TokenUpdate"
+                      "TokenUpdate",
+                      "MetaUpdate"
                     ]
                   }
                 }

--- a/backend/.sqlx/query-438a90fd5c06d77b564cb83787064775e4e565fe241b8f7b2dda1f11389c7b39.json
+++ b/backend/.sqlx/query-438a90fd5c06d77b564cb83787064775e4e565fe241b8f7b2dda1f11389c7b39.json
@@ -48,7 +48,10 @@
                 "AddDenyList",
                 "RemoveDenyList",
                 "Pause",
-                "Unpause"
+                "Unpause",
+                "AssignAdminRoles",
+                "RevokeAdminRoles",
+                "UpdateMetadata"
               ]
             }
           }

--- a/backend/.sqlx/query-488e6beda97909a82e542c10706c1143752e0abfed1b58905ca758a913494f34.json
+++ b/backend/.sqlx/query-488e6beda97909a82e542c10706c1143752e0abfed1b58905ca758a913494f34.json
@@ -1,0 +1,98 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                lock_id,\n                creator_account_index,\n                created_transaction_index,\n                created_at,\n                expiry,\n                canceled_transaction_index,\n                canceled_at,\n                config as \"config: Json<LockCreateConfig>\",\n                raw_config,\n                metadata_name,\n                metadata_description,\n                account_index as \"account_index!\",\n                cursor_index as \"cursor_index!\"\n            FROM (\n                SELECT\n                    locks.lock_id,\n                    locks.creator_account_index,\n                    locks.created_transaction_index,\n                    locks.created_at,\n                    locks.expiry,\n                    locks.canceled_transaction_index,\n                    locks.canceled_at,\n                    locks.config,\n                    locks.raw_config,\n                    locks.metadata_name,\n                    locks.metadata_description,\n                    $5::BIGINT AS account_index,\n                    COALESCE(locks.created_transaction_index, 0) AS cursor_index\n                FROM plt_locks locks\n                WHERE EXISTS (\n                    SELECT 1\n                    FROM plt_lock_accounts accounts\n                    WHERE accounts.lock_id = locks.lock_id\n                        AND accounts.account_index = $5\n                )\n                    AND $2 < COALESCE(locks.created_transaction_index, 0)\n                    AND COALESCE(locks.created_transaction_index, 0) < $1\n                ORDER BY\n                    CASE WHEN $4 THEN COALESCE(locks.created_transaction_index, 0) END ASC,\n                    CASE WHEN NOT $4 THEN COALESCE(locks.created_transaction_index, 0) END DESC,\n                    locks.lock_id ASC\n                LIMIT $3\n            ) locks\n            ORDER BY cursor_index DESC, lock_id ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "lock_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "creator_account_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_transaction_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "expiry",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "canceled_transaction_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "canceled_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "config: Json<LockCreateConfig>",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 8,
+        "name": "raw_config",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "metadata_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "metadata_description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "account_index!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 12,
+        "name": "cursor_index!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8",
+        "Int8",
+        "Bool",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      null,
+      null
+    ]
+  },
+  "hash": "488e6beda97909a82e542c10706c1143752e0abfed1b58905ca758a913494f34"
+}

--- a/backend/.sqlx/query-48b398793199197edfc359135e17cc5e0f044d30ab95fff0731424c792abbe8c.json
+++ b/backend/.sqlx/query-48b398793199197edfc359135e17cc5e0f044d30ab95fff0731424c792abbe8c.json
@@ -56,7 +56,8 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenUpdate"
+                "TokenUpdate",
+                "MetaUpdate"
               ]
             }
           }
@@ -101,7 +102,8 @@
                 "BlockEnergyLimitUpdate",
                 "FinalizationCommitteeParametersUpdate",
                 "ValidatorScoreParametersUpdate",
-                "CreatePltUpdate"
+                "CreatePltUpdate",
+                "MaxLockDurationUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-5f3b5db8484b7b9a0ad1ab5435fc18aedfb15cfc72a3d6026c63acb5b57f9aa4.json
+++ b/backend/.sqlx/query-5f3b5db8484b7b9a0ad1ab5435fc18aedfb15cfc72a3d6026c63acb5b57f9aa4.json
@@ -83,7 +83,8 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenUpdate"
+                "TokenUpdate",
+                "MetaUpdate"
               ]
             }
           }
@@ -136,7 +137,8 @@
                 "BlockEnergyLimitUpdate",
                 "FinalizationCommitteeParametersUpdate",
                 "ValidatorScoreParametersUpdate",
-                "CreatePltUpdate"
+                "CreatePltUpdate",
+                "MaxLockDurationUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-6643ca4c708a09557b1f551f8bab5dccf5f44a3a7fada16509d9c44eee0c4523.json
+++ b/backend/.sqlx/query-6643ca4c708a09557b1f551f8bab5dccf5f44a3a7fada16509d9c44eee0c4523.json
@@ -29,7 +29,10 @@
                 "AddDenyList",
                 "RemoveDenyList",
                 "Pause",
-                "Unpause"
+                "Unpause",
+                "AssignAdminRoles",
+                "RevokeAdminRoles",
+                "UpdateMetadata"
               ]
             }
           }

--- a/backend/.sqlx/query-6b6d66c88b1f86ef8c5d3e437acefb1002c9cda785391bef489ec9fc30efdc03.json
+++ b/backend/.sqlx/query-6b6d66c88b1f86ef8c5d3e437acefb1002c9cda785391bef489ec9fc30efdc03.json
@@ -1,0 +1,116 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT *\n            FROM (\n                SELECT\n                    plt_lock_events.id,\n                    plt_lock_events.transaction_index,\n                    plt_lock_events.block_height,\n                    plt_lock_events.slot_time,\n                    plt_lock_events.operation_order,\n                    plt_lock_events.event_type,\n                    plt_lock_events.lock_id,\n                    plt_lock_events.token_index,\n                    plt_tokens.token_id as \"token_id?: TokenId\",\n                    plt_lock_events.account_index,\n                    plt_lock_events.source_account_index,\n                    plt_lock_events.recipient_account_index,\n                    plt_lock_events.amount,\n                    plt_lock_events.decimals,\n                    plt_lock_events.memo as \"memo: Json<serde_json::Value>\",\n                    plt_lock_events.event as \"event: Json<serde_json::Value>\"\n                FROM plt_lock_events\n                LEFT JOIN plt_tokens ON plt_tokens.index = plt_lock_events.token_index\n                WHERE plt_lock_events.lock_id = $5\n                    AND $2 < plt_lock_events.id\n                    AND plt_lock_events.id < $1\n                ORDER BY\n                    CASE WHEN $4 THEN plt_lock_events.id END ASC,\n                    CASE WHEN NOT $4 THEN plt_lock_events.id END DESC\n                LIMIT $3\n            ) events\n            ORDER BY id DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "transaction_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "block_height",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "slot_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "operation_order",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "event_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "lock_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "token_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 8,
+        "name": "token_id?: TokenId",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "account_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 10,
+        "name": "source_account_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "recipient_account_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 12,
+        "name": "amount",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 13,
+        "name": "decimals",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "memo: Json<serde_json::Value>",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 15,
+        "name": "event: Json<serde_json::Value>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8",
+        "Int8",
+        "Bool",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "6b6d66c88b1f86ef8c5d3e437acefb1002c9cda785391bef489ec9fc30efdc03"
+}

--- a/backend/.sqlx/query-7951a69fca704906fa019aad5090028310a08ff665d4f4a87237694a3a7ea434.json
+++ b/backend/.sqlx/query-7951a69fca704906fa019aad5090028310a08ff665d4f4a87237694a3a7ea434.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                    MIN(COALESCE(locks.created_transaction_index, 0)) AS min_index,\n                    MAX(COALESCE(locks.created_transaction_index, 0)) AS max_index\n                FROM plt_locks locks\n                WHERE EXISTS (\n                    SELECT 1\n                    FROM plt_lock_accounts accounts\n                    WHERE accounts.lock_id = locks.lock_id\n                        AND accounts.account_index = $1\n                )\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "min_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "max_index",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "7951a69fca704906fa019aad5090028310a08ff665d4f4a87237694a3a7ea434"
+}

--- a/backend/.sqlx/query-7b80925e24833be8d444055c1b3966224c16b877986e1bc6c4fe7e0a6e9795da.json
+++ b/backend/.sqlx/query-7b80925e24833be8d444055c1b3966224c16b877986e1bc6c4fe7e0a6e9795da.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT MIN(id) AS min_id, MAX(id) AS max_id\n                FROM plt_lock_events\n                WHERE lock_id = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "min_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "max_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "7b80925e24833be8d444055c1b3966224c16b877986e1bc6c4fe7e0a6e9795da"
+}

--- a/backend/.sqlx/query-b73da89223162e98e88e57309c7c68d75ca54ece9c9989a69221cb05a9701edb.json
+++ b/backend/.sqlx/query-b73da89223162e98e88e57309c7c68d75ca54ece9c9989a69221cb05a9701edb.json
@@ -48,7 +48,10 @@
                 "AddDenyList",
                 "RemoveDenyList",
                 "Pause",
-                "Unpause"
+                "Unpause",
+                "AssignAdminRoles",
+                "RevokeAdminRoles",
+                "UpdateMetadata"
               ]
             }
           }

--- a/backend/.sqlx/query-c4a840b9d7451d2e3a0748dba9cb7fbb7568eaac5a3c4cb9be564989ac60d13f.json
+++ b/backend/.sqlx/query-c4a840b9d7451d2e3a0748dba9cb7fbb7568eaac5a3c4cb9be564989ac60d13f.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH\n                starting_lock AS (\n                    SELECT\n                        COALESCE(created_transaction_index, 0) AS created_transaction_index,\n                        lock_id\n                    FROM plt_locks\n                    WHERE starts_with(lock_id, $1)\n                    ORDER BY COALESCE(created_transaction_index, 0) DESC, lock_id ASC\n                    LIMIT 1\n                ),\n                ending_lock AS (\n                    SELECT\n                        COALESCE(created_transaction_index, 0) AS created_transaction_index,\n                        lock_id\n                    FROM plt_locks\n                    WHERE starts_with(lock_id, $1)\n                    ORDER BY COALESCE(created_transaction_index, 0) ASC, lock_id DESC\n                    LIMIT 1\n                )\n            SELECT\n                starting_lock.created_transaction_index AS \"start_created_transaction_index!\",\n                starting_lock.lock_id AS \"start_lock_id!\",\n                ending_lock.created_transaction_index AS \"end_created_transaction_index!\",\n                ending_lock.lock_id AS \"end_lock_id!\"\n            FROM starting_lock, ending_lock\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "start_created_transaction_index!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "start_lock_id!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "end_created_transaction_index!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "end_lock_id!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "c4a840b9d7451d2e3a0748dba9cb7fbb7568eaac5a3c4cb9be564989ac60d13f"
+}

--- a/backend/.sqlx/query-e875e6f3724d3826805db8d7386363c52d888be3f5248e11bd3e33c015fd8538.json
+++ b/backend/.sqlx/query-e875e6f3724d3826805db8d7386363c52d888be3f5248e11bd3e33c015fd8538.json
@@ -83,7 +83,8 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenUpdate"
+                "TokenUpdate",
+                "MetaUpdate"
               ]
             }
           }
@@ -136,7 +137,8 @@
                 "BlockEnergyLimitUpdate",
                 "FinalizationCommitteeParametersUpdate",
                 "ValidatorScoreParametersUpdate",
-                "CreatePltUpdate"
+                "CreatePltUpdate",
+                "MaxLockDurationUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-f1a9e2a6899898f25bab3661b3daec6280ba2d52848c07f79e7be8457fe2a7d6.json
+++ b/backend/.sqlx/query-f1a9e2a6899898f25bab3661b3daec6280ba2d52848c07f79e7be8457fe2a7d6.json
@@ -83,7 +83,8 @@
                 "RegisterData",
                 "ConfigureBaker",
                 "ConfigureDelegation",
-                "TokenUpdate"
+                "TokenUpdate",
+                "MetaUpdate"
               ]
             }
           }
@@ -136,7 +137,8 @@
                 "BlockEnergyLimitUpdate",
                 "FinalizationCommitteeParametersUpdate",
                 "ValidatorScoreParametersUpdate",
-                "CreatePltUpdate"
+                "CreatePltUpdate",
+                "MaxLockDurationUpdate"
               ]
             }
           }

--- a/backend/.sqlx/query-f33b052d2890c72a7d64c8615a2bd08cd72f333b17f34174c8268bcfa6c35e2d.json
+++ b/backend/.sqlx/query-f33b052d2890c72a7d64c8615a2bd08cd72f333b17f34174c8268bcfa6c35e2d.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                plt_lock_balances.lock_id,\n                plt_lock_balances.account_index,\n                plt_lock_balances.token_index,\n                plt_tokens.token_id,\n                plt_lock_balances.amount,\n                plt_lock_balances.decimal\n            FROM plt_lock_balances\n            JOIN plt_tokens ON plt_tokens.index = plt_lock_balances.token_index\n            WHERE plt_lock_balances.lock_id = $1\n                AND plt_lock_balances.amount <> 0\n            ORDER BY plt_lock_balances.account_index ASC, plt_tokens.token_id ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "lock_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "account_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "token_index",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "token_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "amount",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 5,
+        "name": "decimal",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f33b052d2890c72a7d64c8615a2bd08cd72f333b17f34174c8268bcfa6c35e2d"
+}

--- a/backend/.sqlx/query-f36f9e8c6bfce75714103909dd2b0c9bd52036c1b8dc1927b5717698a06db4ec.json
+++ b/backend/.sqlx/query-f36f9e8c6bfce75714103909dd2b0c9bd52036c1b8dc1927b5717698a06db4ec.json
@@ -48,7 +48,10 @@
                 "AddDenyList",
                 "RemoveDenyList",
                 "Pause",
-                "Unpause"
+                "Unpause",
+                "AssignAdminRoles",
+                "RevokeAdminRoles",
+                "UpdateMetadata"
               ]
             }
           }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-Database schema version: 50
-
-Database schema version: 51
-
 Database schema version: 52
 
 ### Added

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+Database schema version: 50
+
+Database schema version: 51
+
+Database schema version: 52
+
+### Added
+
+- Added support for Locks/P11 `MetaUpdate` transaction types, reject reasons, and lock-aware PLT transfers.
+- Added lock event indexing, GraphQL lock details, account related locks, roles, and lock search.
+- Added support for `MaxLockDurationUpdate` chain update payloads.
+
 ## [2.0.29] - 2026-05-05
 
 ### Added

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -1605,6 +1605,15 @@ type LockCanceled {
 	destroyed: Boolean!
 }
 
+type LockConnection {
+	"Information to aid in pagination."
+	pageInfo: PageInfo!
+	"A list of edges."
+	edges: [LockEdge!]!
+	"A list of nodes."
+	nodes: [Lock!]!
+}
+
 type LockControllerConfig {
 	controllerType: String!
 	simpleV0: LockControllerSimpleV0Config
@@ -1639,6 +1648,14 @@ type LockCreated {
 
 type LockDestroyed {
 	lockId: String!
+}
+
+"An edge in a connection."
+type LockEdge {
+	"The item at the end of the edge"
+	node: Lock!
+	"A cursor for use in pagination"
+	cursor: String!
 }
 
 type LockExpired {
@@ -2693,6 +2710,16 @@ type SearchResult {
 		"Returns the elements in the list that come before the specified cursor."
 		before: String
 	): PltTokenConnection!
+	locks(
+		"Returns the first _n_ elements from the list."
+		first: Int,
+		"Returns the elements in the list that come after the specified cursor."
+		after: String,
+		"Returns the last _n_ elements from the list."
+		last: Int,
+		"Returns the elements in the list that come before the specified cursor."
+		before: String
+	): LockConnection!
 	accounts(
 		"Returns the first _n_ elements from the list."
 		first: Int,

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -353,6 +353,7 @@ enum AccountTransactionType {
 	CONFIGURE_BAKER
 	CONFIGURE_DELEGATION
 	TOKEN_UPDATE
+	META_UPDATE
 }
 
 "A segment of a collection."
@@ -894,7 +895,7 @@ type ChainUpdateEnqueued {
 	payload: ChainUpdatePayload!
 }
 
-union ChainUpdatePayload = ProtocolChainUpdatePayload | MinBlockTimeUpdate | TimeoutParametersUpdate | FinalizationCommitteeParametersUpdate | BlockEnergyLimitUpdate | GasRewardsCpv2Update | ElectionDifficultyChainUpdatePayload | EuroPerEnergyChainUpdatePayload | MicroCcdPerEuroChainUpdatePayload | FoundationAccountChainUpdatePayload | MintDistributionChainUpdatePayload | MintDistributionV1ChainUpdatePayload | TransactionFeeDistributionChainUpdatePayload | GasRewardsChainUpdatePayload | BakerStakeThresholdChainUpdatePayload | RootKeysChainUpdatePayload | Level1KeysChainUpdatePayload | AddAnonymityRevokerChainUpdatePayload | AddIdentityProviderChainUpdatePayload | CooldownParametersChainUpdatePayload | PoolParametersChainUpdatePayload | TimeParametersChainUpdatePayload | ValidatorScoreParametersUpdate | CreatePltUpdate
+union ChainUpdatePayload = ProtocolChainUpdatePayload | MinBlockTimeUpdate | MaxLockDurationUpdate | TimeoutParametersUpdate | FinalizationCommitteeParametersUpdate | BlockEnergyLimitUpdate | GasRewardsCpv2Update | ElectionDifficultyChainUpdatePayload | EuroPerEnergyChainUpdatePayload | MicroCcdPerEuroChainUpdatePayload | FoundationAccountChainUpdatePayload | MintDistributionChainUpdatePayload | MintDistributionV1ChainUpdatePayload | TransactionFeeDistributionChainUpdatePayload | GasRewardsChainUpdatePayload | BakerStakeThresholdChainUpdatePayload | RootKeysChainUpdatePayload | Level1KeysChainUpdatePayload | AddAnonymityRevokerChainUpdatePayload | AddIdentityProviderChainUpdatePayload | CooldownParametersChainUpdatePayload | PoolParametersChainUpdatePayload | TimeParametersChainUpdatePayload | ValidatorScoreParametersUpdate | CreatePltUpdate
 
 type Cis2Event {
 	tokenId: String!
@@ -1525,7 +1526,39 @@ type LinkedContractsCollectionSegment {
 	totalCount: Int!
 }
 
+type LockCancelNotAuthorized {
+	details: JSON!
+}
+
+type LockExpired {
+	lockId: String!
+}
+
+type LockFundNotAuthorized {
+	details: JSON!
+}
+
+type LockRecipientNotPermitted {
+	details: JSON!
+}
+
+type LockReturnNotAuthorized {
+	details: JSON!
+}
+
+type LockSendNotAuthorized {
+	details: JSON!
+}
+
+type LockTokenNotPermitted {
+	details: JSON!
+}
+
 scalar Long
+
+type MaxLockDurationUpdate {
+	durationSeconds: UnsignedLong!
+}
 
 type Memo {
 	bytes: String!
@@ -1753,6 +1786,10 @@ type NonExistentCredIds {
 
 type NonExistentCredentialId {
 	_: Boolean! @deprecated(reason: "Don't use! This field is only in the schema to make this a valid GraphQL type (which does not allow types without any fields)")
+}
+
+type NonExistentLockId {
+	lockId: String!
 }
 
 type NonExistentRewardAccount {
@@ -2715,6 +2752,8 @@ type TokenModuleReject {
 type TokenTransferEvent {
 	from: TokenHolder!
 	to: TokenHolder!
+	fromLock: String
+	toLock: String
 	amount: TokenAmount!
 	memo: Memo
 }
@@ -2816,7 +2855,7 @@ type TransactionMetricsBuckets {
 	y_TransactionCount: [Int!]!
 }
 
-union TransactionRejectReason = ModuleNotWf | ModuleHashAlreadyExists | InvalidAccountReference | InvalidInitMethod | InvalidReceiveMethod | InvalidModuleReference | InvalidContractAddress | RuntimeFailure | AmountTooLarge | SerializationFailure | OutOfEnergy | RejectedInit | RejectedReceive | NonExistentRewardAccount | InvalidProof | AlreadyABaker | NotABaker | InsufficientBalanceForBakerStake | StakeUnderMinimumThresholdForBaking | BakerInCooldown | DuplicateAggregationKey | NonExistentCredentialId | KeyIndexAlreadyInUse | InvalidAccountThreshold | InvalidCredentialKeySignThreshold | InvalidEncryptedAmountTransferProof | InvalidTransferToPublicProof | EncryptedAmountSelfTransfer | InvalidIndexOnEncryptedTransfer | ZeroScheduledAmount | NonIncreasingSchedule | FirstScheduledReleaseExpired | ScheduledSelfTransfer | InvalidCredentials | DuplicateCredIds | NonExistentCredIds | RemoveFirstCredential | CredentialHolderDidNotSign | NotAllowedMultipleCredentials | NotAllowedToReceiveEncrypted | NotAllowedToHandleEncrypted | MissingBakerAddParameters | FinalizationRewardCommissionNotInRange | BakingRewardCommissionNotInRange | TransactionFeeCommissionNotInRange | AlreadyADelegator | InsufficientBalanceForDelegationStake | MissingDelegationAddParameters | InsufficientDelegationStake | DelegatorInCooldown | NotADelegator | DelegationTargetNotABaker | StakeOverMaximumThresholdForPool | PoolWouldBecomeOverDelegated | PoolClosed | NonExistentTokenId | TokenModuleReject | UnauthorizedTokenGovernance
+union TransactionRejectReason = ModuleNotWf | ModuleHashAlreadyExists | InvalidAccountReference | InvalidInitMethod | InvalidReceiveMethod | InvalidModuleReference | InvalidContractAddress | RuntimeFailure | AmountTooLarge | SerializationFailure | OutOfEnergy | RejectedInit | RejectedReceive | NonExistentRewardAccount | InvalidProof | AlreadyABaker | NotABaker | InsufficientBalanceForBakerStake | StakeUnderMinimumThresholdForBaking | BakerInCooldown | DuplicateAggregationKey | NonExistentCredentialId | KeyIndexAlreadyInUse | InvalidAccountThreshold | InvalidCredentialKeySignThreshold | InvalidEncryptedAmountTransferProof | InvalidTransferToPublicProof | EncryptedAmountSelfTransfer | InvalidIndexOnEncryptedTransfer | ZeroScheduledAmount | NonIncreasingSchedule | FirstScheduledReleaseExpired | ScheduledSelfTransfer | InvalidCredentials | DuplicateCredIds | NonExistentCredIds | RemoveFirstCredential | CredentialHolderDidNotSign | NotAllowedMultipleCredentials | NotAllowedToReceiveEncrypted | NotAllowedToHandleEncrypted | MissingBakerAddParameters | FinalizationRewardCommissionNotInRange | BakingRewardCommissionNotInRange | TransactionFeeCommissionNotInRange | AlreadyADelegator | InsufficientBalanceForDelegationStake | MissingDelegationAddParameters | InsufficientDelegationStake | DelegatorInCooldown | NotADelegator | DelegationTargetNotABaker | StakeOverMaximumThresholdForPool | PoolWouldBecomeOverDelegated | PoolClosed | NonExistentTokenId | TokenModuleReject | UnauthorizedTokenGovernance | NonExistentLockId | LockExpired | LockFundNotAuthorized | LockSendNotAuthorized | LockReturnNotAuthorized | LockCancelNotAuthorized | LockTokenNotPermitted | LockRecipientNotPermitted
 
 union TransactionResult = Success | Rejected
 
@@ -2884,6 +2923,7 @@ enum UpdateTransactionType {
 	GAS_REWARDS_CPV_2_UPDATE
 	TIMEOUT_PARAMETERS_UPDATE
 	MIN_BLOCK_TIME_UPDATE
+	MAX_LOCK_DURATION_UPDATE
 	BLOCK_ENERGY_LIMIT_UPDATE
 	FINALIZATION_COMMITTEE_PARAMETERS_UPDATE
 	VALIDATOR_SCORE_PARAMETERS_UPDATE

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -1294,7 +1294,7 @@ type EuroPerEnergyChainUpdatePayload {
 	exchangeRate: Ratio!
 }
 
-union Event = Transferred | TransferMemo | TransferredWithSchedule | EncryptedAmountsRemoved | AmountAddedByDecryption | EncryptedSelfAmountAdded | NewEncryptedAmount | AccountCreated | CredentialDeployed | CredentialKeysUpdated | CredentialsUpdated | BakerAdded | BakerKeysUpdated | BakerRemoved | BakerSetRestakeEarnings | BakerStakeDecreased | BakerStakeIncreased | BakerSetOpenStatus | BakerSetMetadataURL | BakerSetTransactionFeeCommission | BakerSetBakingRewardCommission | BakerSetFinalizationRewardCommission | BakerDelegationRemoved | BakerSuspended | BakerResumed | ContractInitialized | ContractModuleDeployed | ContractUpdated | ContractCall | ContractInterrupted | ContractResumed | ContractUpgraded | DelegationAdded | DelegationRemoved | DelegationStakeIncreased | DelegationStakeDecreased | DelegationSetRestakeEarnings | DelegationSetDelegationTarget | DataRegistered | ChainUpdateEnqueued | TokenUpdate | TokenCreationDetails
+union Event = Transferred | TransferMemo | TransferredWithSchedule | EncryptedAmountsRemoved | AmountAddedByDecryption | EncryptedSelfAmountAdded | NewEncryptedAmount | AccountCreated | CredentialDeployed | CredentialKeysUpdated | CredentialsUpdated | BakerAdded | BakerKeysUpdated | BakerRemoved | BakerSetRestakeEarnings | BakerStakeDecreased | BakerStakeIncreased | BakerSetOpenStatus | BakerSetMetadataURL | BakerSetTransactionFeeCommission | BakerSetBakingRewardCommission | BakerSetFinalizationRewardCommission | BakerDelegationRemoved | BakerSuspended | BakerResumed | ContractInitialized | ContractModuleDeployed | ContractUpdated | ContractCall | ContractInterrupted | ContractResumed | ContractUpgraded | DelegationAdded | DelegationRemoved | DelegationStakeIncreased | DelegationStakeDecreased | DelegationSetRestakeEarnings | DelegationSetDelegationTarget | DataRegistered | ChainUpdateEnqueued | TokenUpdate | TokenCreationDetails | LockCreated | LockFunded | LockSent | LockReturned | LockCanceled | LockDestroyed
 
 type EventConnection {
 	"Information to aid in pagination."
@@ -1530,6 +1530,48 @@ type LockCancelNotAuthorized {
 	details: JSON!
 }
 
+type LockCanceled {
+	lockId: String!
+	memo: Memo
+	destroyed: Boolean!
+}
+
+type LockControllerConfig {
+	controllerType: String!
+	simpleV0: LockControllerSimpleV0Config
+}
+
+type LockControllerGrant {
+	account: CborHolderAccount!
+	roles: [String!]!
+}
+
+type LockControllerSimpleV0Config {
+	grants: [LockControllerGrant!]!
+	tokenIds: [String!]!
+	keepAlive: Boolean!
+	memo: Memo
+}
+
+type LockCreateConfig {
+	expiry: DateTime!
+	recipients: LockRecipientsConfig!
+	controller: LockControllerConfig!
+	metadata: LockMetadataConfig
+}
+
+type LockCreated {
+	lockId: String
+	config: LockCreateConfig
+	rawConfigPresent: Boolean!
+	configUnavailable: Boolean!
+	rawConfig: String
+}
+
+type LockDestroyed {
+	lockId: String!
+}
+
 type LockExpired {
 	lockId: String!
 }
@@ -1538,16 +1580,50 @@ type LockFundNotAuthorized {
 	details: JSON!
 }
 
+type LockFunded {
+	lockId: String!
+	tokenId: String!
+	amount: TokenAmount!
+	memo: Memo
+}
+
+type LockMetadataConfig {
+	name: String
+	description: String
+}
+
 type LockRecipientNotPermitted {
 	details: JSON!
+}
+
+type LockRecipientsConfig {
+	recipientType: String!
+	accounts: [CborHolderAccount!]!
 }
 
 type LockReturnNotAuthorized {
 	details: JSON!
 }
 
+type LockReturned {
+	lockId: String!
+	tokenId: String!
+	source: CborHolderAccount!
+	amount: TokenAmount!
+	memo: Memo
+}
+
 type LockSendNotAuthorized {
 	details: JSON!
+}
+
+type LockSent {
+	lockId: String!
+	tokenId: String!
+	source: CborHolderAccount!
+	recipient: CborHolderAccount!
+	amount: TokenAmount!
+	memo: Memo
 }
 
 type LockTokenNotPermitted {

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -30,6 +30,16 @@ type Account {
 		"Returns the elements in the list that come before the specified cursor."
 		before: String
 	): AccountTokenConnection!
+	relatedLocks(
+		"Returns the first _n_ elements from the list."
+		first: Int,
+		"Returns the elements in the list that come after the specified cursor."
+		after: String,
+		"Returns the last _n_ elements from the list."
+		last: Int,
+		"Returns the elements in the list that come before the specified cursor."
+		before: String
+	): AccountRelatedLockConnection!
 	transactions(
 		"Returns the first _n_ elements from the list."
 		first: Int,
@@ -161,6 +171,28 @@ type AccountProtocolTokenConnection {
 type AccountProtocolTokenEdge {
 	"The item at the end of the edge"
 	node: AccountProtocolToken!
+	"A cursor for use in pagination"
+	cursor: String!
+}
+
+type AccountRelatedLock {
+	lock: Lock!
+	accountBalances: [LockBalance!]!
+}
+
+type AccountRelatedLockConnection {
+	"Information to aid in pagination."
+	pageInfo: PageInfo!
+	"A list of edges."
+	edges: [AccountRelatedLockEdge!]!
+	"A list of nodes."
+	nodes: [AccountRelatedLock!]!
+}
+
+"An edge in a connection."
+type AccountRelatedLockEdge {
+	"The item at the end of the edge"
+	node: AccountRelatedLock!
 	"A cursor for use in pagination"
 	cursor: String!
 }
@@ -1526,6 +1558,42 @@ type LinkedContractsCollectionSegment {
 	totalCount: Int!
 }
 
+type Lock {
+	id: ID!
+	lockId: String!
+	creator: Account
+	createdTransaction: Transaction
+	createdAt: DateTime
+	expiry: DateTime
+	canceledTransaction: Transaction
+	canceledAt: DateTime
+	status: LockStatus!
+	config: LockCreateConfig
+	rawConfig: String
+	metadataName: String
+	metadataDescription: String
+	balances: [LockBalance!]!
+	history(
+		"Returns the first _n_ elements from the list."
+		first: Int,
+		"Returns the elements in the list that come after the specified cursor."
+		after: String,
+		"Returns the last _n_ elements from the list."
+		last: Int,
+		"Returns the elements in the list that come before the specified cursor."
+		before: String
+	): LockHistoryEventConnection!
+}
+
+type LockBalance {
+	lockId: String!
+	account: Account!
+	accountAddress: AccountAddress!
+	tokenIndex: Int!
+	tokenId: String!
+	amount: TokenAmount!
+}
+
 type LockCancelNotAuthorized {
 	details: JSON!
 }
@@ -1587,6 +1655,42 @@ type LockFunded {
 	memo: Memo
 }
 
+type LockHistoryEvent {
+	id: ID!
+	transaction: Transaction!
+	transactionIndex: Int!
+	blockHeight: Int!
+	slotTime: DateTime!
+	operationOrder: Int!
+	eventType: String!
+	lockId: String!
+	tokenIndex: Int
+	tokenId: String
+	account: Account
+	source: Account
+	recipient: Account
+	amount: TokenAmount
+	memo: JSON
+	event: JSON!
+}
+
+type LockHistoryEventConnection {
+	"Information to aid in pagination."
+	pageInfo: PageInfo!
+	"A list of edges."
+	edges: [LockHistoryEventEdge!]!
+	"A list of nodes."
+	nodes: [LockHistoryEvent!]!
+}
+
+"An edge in a connection."
+type LockHistoryEventEdge {
+	"The item at the end of the edge"
+	node: LockHistoryEvent!
+	"A cursor for use in pagination"
+	cursor: String!
+}
+
 type LockMetadataConfig {
 	name: String
 	description: String
@@ -1624,6 +1728,12 @@ type LockSent {
 	recipient: CborHolderAccount!
 	amount: TokenAmount!
 	memo: Memo
+}
+
+enum LockStatus {
+	ACTIVE
+	EXPIRED
+	CANCELED
 }
 
 type LockTokenNotPermitted {
@@ -2423,6 +2533,7 @@ type Query {
 		before: String
 	): PltAccountAmountConnection!
 	pltUniqueAccounts: Int!
+	lock(lockId: String!): Lock!
 }
 
 """

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -178,6 +178,7 @@ type AccountProtocolTokenEdge {
 type AccountRelatedLock {
 	lock: Lock!
 	accountBalances: [LockBalance!]!
+	roles: [String!]!
 }
 
 type AccountRelatedLockConnection {

--- a/backend/src/graphql_api.rs
+++ b/backend/src/graphql_api.rs
@@ -10,6 +10,7 @@ mod block;
 mod block_metrics;
 mod contract;
 mod db;
+mod lock;
 mod module_reference_event;
 pub mod node_status;
 mod passive_delegation;
@@ -243,6 +244,18 @@ pub struct ApiServiceConfig {
         default_value = "10"
     )]
     plt_by_account_address_connection_limit: u64,
+    #[arg(
+        long,
+        env = "CCDSCAN_API_CONFIG_LOCK_HISTORY_CONNECTION_LIMIT",
+        default_value = "100"
+    )]
+    lock_history_connection_limit: u64,
+    #[arg(
+        long,
+        env = "CCDSCAN_API_CONFIG_ACCOUNT_RELATED_LOCKS_CONNECTION_LIMIT",
+        default_value = "100"
+    )]
+    account_related_locks_connection_limit: u64,
 }
 
 #[derive(MergedObject, Default)]
@@ -268,6 +281,7 @@ pub struct Query(
     plt::QueryPltEvent,
     plt::QueryPlt,
     plt::QueryPltAccountAmount,
+    lock::QueryLock,
 );
 
 pub struct Service {

--- a/backend/src/graphql_api/account.rs
+++ b/backend/src/graphql_api/account.rs
@@ -5,7 +5,9 @@ use super::{
 use crate::{
     address::AccountAddress,
     connection::{ConnectionBounds, DescendingI64, Reversed},
-    graphql_api::{block::Block, token::AccountTokenInterim, Transaction},
+    graphql_api::{
+        block::Block, lock::AccountRelatedLock, token::AccountTokenInterim, Transaction,
+    },
     scalar_types::{AccountIndex, Amount, BlockHeight, DateTime, Long, TransactionIndex},
     transaction_event::{
         delegation::{BakerDelegationTarget, DelegationTarget, PassiveDelegationTarget},
@@ -991,6 +993,21 @@ impl Account {
                 .is_some_and(|db_last| Cursor::from(db_last) > last.cursor);
         }
         Ok(connection)
+    }
+
+    async fn related_locks(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "Returns the first _n_ elements from the list.")] first: Option<u64>,
+        #[graphql(desc = "Returns the elements in the list that come after the specified cursor.")]
+        after: Option<String>,
+        #[graphql(desc = "Returns the last _n_ elements from the list.")] last: Option<u64>,
+        #[graphql(
+            desc = "Returns the elements in the list that come before the specified cursor."
+        )]
+        before: Option<String>,
+    ) -> ApiResult<connection::Connection<String, AccountRelatedLock>> {
+        AccountRelatedLock::connection(ctx, self.index, first, after, last, before).await
     }
 
     async fn transactions(

--- a/backend/src/graphql_api/lock.rs
+++ b/backend/src/graphql_api/lock.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use async_graphql::{connection, types, Context, Enum, Object};
 use bigdecimal::BigDecimal;
 use chrono::Utc;
@@ -593,6 +595,35 @@ impl AccountRelatedLock {
         .await?;
         Ok(balances)
     }
+
+    async fn query_account_address(&self, pool: &PgPool) -> ApiResult<AccountAddress> {
+        let row: AccountAddressRow =
+            sqlx::query_as("SELECT address FROM accounts WHERE index = $1")
+                .bind(self.account_index)
+                .fetch_one(pool)
+                .await?;
+        Ok(row.address.into())
+    }
+
+    async fn query_roles(&self, pool: &PgPool) -> ApiResult<Vec<String>> {
+        let Some(simple_v0) = self
+            .config
+            .as_ref()
+            .and_then(|config| config.0.controller.simple_v0.as_ref())
+        else {
+            return Ok(Vec::new());
+        };
+        let account_address = self.query_account_address(pool).await?.to_string();
+
+        Ok(simple_v0
+            .grants
+            .iter()
+            .filter(|grant| grant.account.address.to_string() == account_address)
+            .flat_map(|grant| grant.roles.iter().cloned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect())
+    }
 }
 
 #[Object]
@@ -603,6 +634,10 @@ impl AccountRelatedLock {
 
     async fn account_balances(&self, ctx: &Context<'_>) -> ApiResult<Vec<LockBalance>> {
         self.query_account_balances(get_pool(ctx)?).await
+    }
+
+    async fn roles(&self, ctx: &Context<'_>) -> ApiResult<Vec<String>> {
+        self.query_roles(get_pool(ctx)?).await
     }
 }
 

--- a/backend/src/graphql_api/lock.rs
+++ b/backend/src/graphql_api/lock.rs
@@ -4,7 +4,7 @@ use async_graphql::{connection, types, Context, Enum, Object};
 use bigdecimal::BigDecimal;
 use chrono::Utc;
 use futures::TryStreamExt;
-use sqlx::{types::Json, FromRow, PgPool};
+use sqlx::{types::Json, PgPool};
 
 use crate::{
     address::AccountAddress,
@@ -38,7 +38,7 @@ pub enum LockStatus {
     Canceled,
 }
 
-#[derive(Debug, Clone, FromRow)]
+#[derive(Debug, Clone)]
 pub struct Lock {
     pub lock_id: String,
     pub creator_account_index: Option<i64>,
@@ -55,7 +55,8 @@ pub struct Lock {
 
 impl Lock {
     pub async fn query_by_id(pool: &PgPool, lock_id: &str) -> ApiResult<Option<Self>> {
-        let lock = sqlx::query_as::<_, Lock>(
+        let lock = sqlx::query_as!(
+            Lock,
             r#"
             SELECT
                 lock_id,
@@ -65,15 +66,15 @@ impl Lock {
                 expiry,
                 canceled_transaction_index,
                 canceled_at,
-                config,
+                config as "config: Json<LockCreateConfig>",
                 raw_config,
                 metadata_name,
                 metadata_description
             FROM plt_locks
             WHERE lock_id = $1
             "#,
+            lock_id
         )
-        .bind(lock_id)
         .fetch_optional(pool)
         .await?;
         Ok(lock)
@@ -90,7 +91,8 @@ impl Lock {
     }
 
     async fn query_balances(&self, pool: &PgPool) -> ApiResult<Vec<LockBalance>> {
-        let balances = sqlx::query_as::<_, LockBalance>(
+        let balances = sqlx::query_as!(
+            LockBalance,
             r#"
             SELECT
                 plt_lock_balances.lock_id,
@@ -105,8 +107,8 @@ impl Lock {
                 AND plt_lock_balances.amount <> 0
             ORDER BY plt_lock_balances.account_index ASC, plt_tokens.token_id ASC
             "#,
+            &self.lock_id
         )
-        .bind(&self.lock_id)
         .fetch_all(pool)
         .await?;
         Ok(balances)
@@ -130,7 +132,8 @@ impl Lock {
             config.lock_history_connection_limit,
         )?;
 
-        let mut row_stream = sqlx::query_as::<_, LockHistoryEvent>(
+        let mut row_stream = sqlx::query_as!(
+            LockHistoryEvent,
             r#"
             SELECT *
             FROM (
@@ -143,14 +146,14 @@ impl Lock {
                     plt_lock_events.event_type,
                     plt_lock_events.lock_id,
                     plt_lock_events.token_index,
-                    plt_tokens.token_id,
+                    plt_tokens.token_id as "token_id?: TokenId",
                     plt_lock_events.account_index,
                     plt_lock_events.source_account_index,
                     plt_lock_events.recipient_account_index,
                     plt_lock_events.amount,
                     plt_lock_events.decimals,
-                    plt_lock_events.memo,
-                    plt_lock_events.event
+                    plt_lock_events.memo as "memo: Json<serde_json::Value>",
+                    plt_lock_events.event as "event: Json<serde_json::Value>"
                 FROM plt_lock_events
                 LEFT JOIN plt_tokens ON plt_tokens.index = plt_lock_events.token_index
                 WHERE plt_lock_events.lock_id = $5
@@ -163,12 +166,12 @@ impl Lock {
             ) events
             ORDER BY id DESC
             "#,
+            i64::from(query.from),
+            i64::from(query.to),
+            query.limit,
+            query.is_last,
+            &self.lock_id
         )
-        .bind(i64::from(query.from))
-        .bind(i64::from(query.to))
-        .bind(query.limit)
-        .bind(query.is_last)
-        .bind(&self.lock_id)
         .fetch(pool);
 
         let mut connection = connection::Connection::new(false, false);
@@ -183,14 +186,14 @@ impl Lock {
         }
 
         if let (Some(page_min_id), Some(page_max_id)) = (min_id, max_id) {
-            let bounds: LockHistoryBounds = sqlx::query_as(
+            let bounds = sqlx::query!(
                 r#"
                 SELECT MIN(id) AS min_id, MAX(id) AS max_id
                 FROM plt_lock_events
                 WHERE lock_id = $1
                 "#,
+                &self.lock_id
             )
-            .bind(&self.lock_id)
             .fetch_one(pool)
             .await?;
             connection.has_previous_page = bounds.max_id.is_some_and(|db_max| db_max > page_max_id);
@@ -284,7 +287,7 @@ impl Lock {
     }
 }
 
-#[derive(Debug, Clone, FromRow)]
+#[derive(Debug, Clone)]
 pub struct LockBalance {
     lock_id: String,
     account_index: i64,
@@ -307,11 +310,12 @@ impl LockBalance {
     }
 
     async fn account_address(&self, ctx: &Context<'_>) -> ApiResult<AccountAddress> {
-        let row: AccountAddressRow =
-            sqlx::query_as("SELECT address FROM accounts WHERE index = $1")
-                .bind(self.account_index)
-                .fetch_one(get_pool(ctx)?)
-                .await?;
+        let row = sqlx::query!(
+            "SELECT address FROM accounts WHERE index = $1",
+            self.account_index
+        )
+        .fetch_one(get_pool(ctx)?)
+        .await?;
         Ok(row.address.into())
     }
 
@@ -331,7 +335,7 @@ impl LockBalance {
     }
 }
 
-#[derive(Debug, Clone, FromRow)]
+#[derive(Debug, Clone)]
 pub struct LockHistoryEvent {
     id: i64,
     transaction_index: TransactionIndex,
@@ -434,7 +438,7 @@ impl LockHistoryEvent {
     }
 }
 
-#[derive(Debug, Clone, FromRow)]
+#[derive(Debug, Clone)]
 pub struct AccountRelatedLock {
     lock_id: String,
     creator_account_index: Option<i64>,
@@ -470,9 +474,23 @@ impl AccountRelatedLock {
             config.account_related_locks_connection_limit,
         )?;
 
-        let mut row_stream = sqlx::query_as::<_, AccountRelatedLock>(
+        let mut row_stream = sqlx::query_as!(
+            AccountRelatedLock,
             r#"
-            SELECT *
+            SELECT
+                lock_id,
+                creator_account_index,
+                created_transaction_index,
+                created_at,
+                expiry,
+                canceled_transaction_index,
+                canceled_at,
+                config as "config: Json<LockCreateConfig>",
+                raw_config,
+                metadata_name,
+                metadata_description,
+                account_index as "account_index!",
+                cursor_index as "cursor_index!"
             FROM (
                 SELECT
                     locks.lock_id,
@@ -505,12 +523,12 @@ impl AccountRelatedLock {
             ) locks
             ORDER BY cursor_index DESC, lock_id ASC
             "#,
+            i64::from(query.from),
+            i64::from(query.to),
+            query.limit,
+            query.is_last,
+            account_index
         )
-        .bind(i64::from(query.from))
-        .bind(i64::from(query.to))
-        .bind(query.limit)
-        .bind(query.is_last)
-        .bind(account_index)
         .fetch(pool);
 
         let mut connection = connection::Connection::new(false, false);
@@ -527,7 +545,7 @@ impl AccountRelatedLock {
         }
 
         if let (Some(page_min_index), Some(page_max_index)) = (min_index, max_index) {
-            let bounds: AccountRelatedLocksBounds = sqlx::query_as(
+            let bounds = sqlx::query!(
                 r#"
                 SELECT
                     MIN(COALESCE(locks.created_transaction_index, 0)) AS min_index,
@@ -540,8 +558,8 @@ impl AccountRelatedLock {
                         AND accounts.account_index = $1
                 )
                 "#,
+                account_index
             )
-            .bind(account_index)
             .fetch_one(pool)
             .await?;
             connection.has_previous_page = bounds
@@ -572,7 +590,8 @@ impl AccountRelatedLock {
     }
 
     async fn query_account_balances(&self, pool: &PgPool) -> ApiResult<Vec<LockBalance>> {
-        let balances = sqlx::query_as::<_, LockBalance>(
+        let balances = sqlx::query_as!(
+            LockBalance,
             r#"
             SELECT
                 plt_lock_balances.lock_id,
@@ -588,20 +607,21 @@ impl AccountRelatedLock {
                 AND plt_lock_balances.amount <> 0
             ORDER BY plt_tokens.token_id ASC
             "#,
+            &self.lock_id,
+            self.account_index
         )
-        .bind(&self.lock_id)
-        .bind(self.account_index)
         .fetch_all(pool)
         .await?;
         Ok(balances)
     }
 
     async fn query_account_address(&self, pool: &PgPool) -> ApiResult<AccountAddress> {
-        let row: AccountAddressRow =
-            sqlx::query_as("SELECT address FROM accounts WHERE index = $1")
-                .bind(self.account_index)
-                .fetch_one(pool)
-                .await?;
+        let row = sqlx::query!(
+            "SELECT address FROM accounts WHERE index = $1",
+            self.account_index
+        )
+        .fetch_one(pool)
+        .await?;
         Ok(row.address.into())
     }
 
@@ -639,21 +659,4 @@ impl AccountRelatedLock {
     async fn roles(&self, ctx: &Context<'_>) -> ApiResult<Vec<String>> {
         self.query_roles(get_pool(ctx)?).await
     }
-}
-
-#[derive(Debug, FromRow)]
-struct LockHistoryBounds {
-    min_id: Option<i64>,
-    max_id: Option<i64>,
-}
-
-#[derive(Debug, FromRow)]
-struct AccountRelatedLocksBounds {
-    min_index: Option<i64>,
-    max_index: Option<i64>,
-}
-
-#[derive(Debug, FromRow)]
-struct AccountAddressRow {
-    address: String,
 }

--- a/backend/src/graphql_api/lock.rs
+++ b/backend/src/graphql_api/lock.rs
@@ -1,0 +1,624 @@
+use async_graphql::{connection, types, Context, Enum, Object};
+use bigdecimal::BigDecimal;
+use chrono::Utc;
+use futures::TryStreamExt;
+use sqlx::{types::Json, FromRow, PgPool};
+
+use crate::{
+    address::AccountAddress,
+    connection::DescendingI64,
+    graphql_api::{
+        account::Account, get_config, get_pool, transaction::Transaction, ApiError, ApiResult,
+        ConnectionQuery,
+    },
+    scalar_types::{DateTime, TokenId, TokenIndex, TransactionIndex},
+    transaction_event::{
+        protocol_level_locks::LockCreateConfig, protocol_level_tokens::TokenAmount,
+    },
+};
+
+#[derive(Default)]
+pub struct QueryLock;
+
+#[Object]
+impl QueryLock {
+    async fn lock(&self, ctx: &Context<'_>, lock_id: String) -> ApiResult<Lock> {
+        Lock::query_by_id(get_pool(ctx)?, &lock_id)
+            .await?
+            .ok_or(ApiError::NotFound)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Enum, Eq, PartialEq)]
+pub enum LockStatus {
+    Active,
+    Expired,
+    Canceled,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct Lock {
+    pub lock_id: String,
+    pub creator_account_index: Option<i64>,
+    pub created_transaction_index: Option<i64>,
+    pub created_at: Option<DateTime>,
+    pub expiry: Option<DateTime>,
+    pub canceled_transaction_index: Option<i64>,
+    pub canceled_at: Option<DateTime>,
+    pub config: Option<Json<LockCreateConfig>>,
+    pub raw_config: Option<String>,
+    pub metadata_name: Option<String>,
+    pub metadata_description: Option<String>,
+}
+
+impl Lock {
+    pub async fn query_by_id(pool: &PgPool, lock_id: &str) -> ApiResult<Option<Self>> {
+        let lock = sqlx::query_as::<_, Lock>(
+            r#"
+            SELECT
+                lock_id,
+                creator_account_index,
+                created_transaction_index,
+                created_at,
+                expiry,
+                canceled_transaction_index,
+                canceled_at,
+                config,
+                raw_config,
+                metadata_name,
+                metadata_description
+            FROM plt_locks
+            WHERE lock_id = $1
+            "#,
+        )
+        .bind(lock_id)
+        .fetch_optional(pool)
+        .await?;
+        Ok(lock)
+    }
+
+    fn compute_status(&self) -> LockStatus {
+        if self.canceled_at.is_some() {
+            LockStatus::Canceled
+        } else if self.expiry.is_some_and(|expiry| expiry < Utc::now()) {
+            LockStatus::Expired
+        } else {
+            LockStatus::Active
+        }
+    }
+
+    async fn query_balances(&self, pool: &PgPool) -> ApiResult<Vec<LockBalance>> {
+        let balances = sqlx::query_as::<_, LockBalance>(
+            r#"
+            SELECT
+                plt_lock_balances.lock_id,
+                plt_lock_balances.account_index,
+                plt_lock_balances.token_index,
+                plt_tokens.token_id,
+                plt_lock_balances.amount,
+                plt_lock_balances.decimal
+            FROM plt_lock_balances
+            JOIN plt_tokens ON plt_tokens.index = plt_lock_balances.token_index
+            WHERE plt_lock_balances.lock_id = $1
+                AND plt_lock_balances.amount <> 0
+            ORDER BY plt_lock_balances.account_index ASC, plt_tokens.token_id ASC
+            "#,
+        )
+        .bind(&self.lock_id)
+        .fetch_all(pool)
+        .await?;
+        Ok(balances)
+    }
+
+    async fn query_history(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> ApiResult<connection::Connection<String, LockHistoryEvent>> {
+        let config = get_config(ctx)?;
+        let pool = get_pool(ctx)?;
+        let query = ConnectionQuery::<DescendingI64>::new(
+            first,
+            after,
+            last,
+            before,
+            config.lock_history_connection_limit,
+        )?;
+
+        let mut row_stream = sqlx::query_as::<_, LockHistoryEvent>(
+            r#"
+            SELECT *
+            FROM (
+                SELECT
+                    plt_lock_events.id,
+                    plt_lock_events.transaction_index,
+                    plt_lock_events.block_height,
+                    plt_lock_events.slot_time,
+                    plt_lock_events.operation_order,
+                    plt_lock_events.event_type,
+                    plt_lock_events.lock_id,
+                    plt_lock_events.token_index,
+                    plt_tokens.token_id,
+                    plt_lock_events.account_index,
+                    plt_lock_events.source_account_index,
+                    plt_lock_events.recipient_account_index,
+                    plt_lock_events.amount,
+                    plt_lock_events.decimals,
+                    plt_lock_events.memo,
+                    plt_lock_events.event
+                FROM plt_lock_events
+                LEFT JOIN plt_tokens ON plt_tokens.index = plt_lock_events.token_index
+                WHERE plt_lock_events.lock_id = $5
+                    AND $2 < plt_lock_events.id
+                    AND plt_lock_events.id < $1
+                ORDER BY
+                    CASE WHEN $4 THEN plt_lock_events.id END ASC,
+                    CASE WHEN NOT $4 THEN plt_lock_events.id END DESC
+                LIMIT $3
+            ) events
+            ORDER BY id DESC
+            "#,
+        )
+        .bind(i64::from(query.from))
+        .bind(i64::from(query.to))
+        .bind(query.limit)
+        .bind(query.is_last)
+        .bind(&self.lock_id)
+        .fetch(pool);
+
+        let mut connection = connection::Connection::new(false, false);
+        let mut min_id: Option<i64> = None;
+        let mut max_id: Option<i64> = None;
+        while let Some(event) = row_stream.try_next().await? {
+            min_id = Some(min_id.map_or(event.id, |current| current.min(event.id)));
+            max_id = Some(max_id.map_or(event.id, |current| current.max(event.id)));
+            connection
+                .edges
+                .push(connection::Edge::new(event.id.to_string(), event));
+        }
+
+        if let (Some(page_min_id), Some(page_max_id)) = (min_id, max_id) {
+            let bounds: LockHistoryBounds = sqlx::query_as(
+                r#"
+                SELECT MIN(id) AS min_id, MAX(id) AS max_id
+                FROM plt_lock_events
+                WHERE lock_id = $1
+                "#,
+            )
+            .bind(&self.lock_id)
+            .fetch_one(pool)
+            .await?;
+            connection.has_previous_page = bounds.max_id.is_some_and(|db_max| db_max > page_max_id);
+            connection.has_next_page = bounds.min_id.is_some_and(|db_min| db_min < page_min_id);
+        }
+
+        Ok(connection)
+    }
+}
+
+#[Object]
+impl Lock {
+    async fn id(&self) -> types::ID {
+        types::ID::from(self.lock_id.clone())
+    }
+
+    async fn lock_id(&self) -> &str {
+        &self.lock_id
+    }
+
+    async fn creator(&self, ctx: &Context<'_>) -> ApiResult<Option<Account>> {
+        match self.creator_account_index {
+            Some(index) => Account::query_by_index(get_pool(ctx)?, index).await,
+            None => Ok(None),
+        }
+    }
+
+    async fn created_transaction(&self, ctx: &Context<'_>) -> ApiResult<Option<Transaction>> {
+        match self.created_transaction_index {
+            Some(index) => Transaction::query_by_index(get_pool(ctx)?, index).await,
+            None => Ok(None),
+        }
+    }
+
+    async fn created_at(&self) -> Option<DateTime> {
+        self.created_at
+    }
+
+    async fn expiry(&self) -> Option<DateTime> {
+        self.expiry
+    }
+
+    async fn canceled_transaction(&self, ctx: &Context<'_>) -> ApiResult<Option<Transaction>> {
+        match self.canceled_transaction_index {
+            Some(index) => Transaction::query_by_index(get_pool(ctx)?, index).await,
+            None => Ok(None),
+        }
+    }
+
+    async fn canceled_at(&self) -> Option<DateTime> {
+        self.canceled_at
+    }
+
+    async fn status(&self) -> LockStatus {
+        self.compute_status()
+    }
+
+    async fn config(&self) -> Option<LockCreateConfig> {
+        self.config.as_ref().map(|config| config.0.clone())
+    }
+
+    async fn raw_config(&self) -> Option<&str> {
+        self.raw_config.as_deref()
+    }
+
+    async fn metadata_name(&self) -> Option<&str> {
+        self.metadata_name.as_deref()
+    }
+
+    async fn metadata_description(&self) -> Option<&str> {
+        self.metadata_description.as_deref()
+    }
+
+    async fn balances(&self, ctx: &Context<'_>) -> ApiResult<Vec<LockBalance>> {
+        self.query_balances(get_pool(ctx)?).await
+    }
+
+    async fn history(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "Returns the first _n_ elements from the list.")] first: Option<u64>,
+        #[graphql(desc = "Returns the elements in the list that come after the specified cursor.")]
+        after: Option<String>,
+        #[graphql(desc = "Returns the last _n_ elements from the list.")] last: Option<u64>,
+        #[graphql(
+            desc = "Returns the elements in the list that come before the specified cursor."
+        )]
+        before: Option<String>,
+    ) -> ApiResult<connection::Connection<String, LockHistoryEvent>> {
+        self.query_history(ctx, first, after, last, before).await
+    }
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct LockBalance {
+    lock_id: String,
+    account_index: i64,
+    token_index: TokenIndex,
+    token_id: TokenId,
+    amount: BigDecimal,
+    decimal: i32,
+}
+
+#[Object]
+impl LockBalance {
+    async fn lock_id(&self) -> &str {
+        &self.lock_id
+    }
+
+    async fn account(&self, ctx: &Context<'_>) -> ApiResult<Account> {
+        Account::query_by_index(get_pool(ctx)?, self.account_index)
+            .await?
+            .ok_or(ApiError::NotFound)
+    }
+
+    async fn account_address(&self, ctx: &Context<'_>) -> ApiResult<AccountAddress> {
+        let row: AccountAddressRow =
+            sqlx::query_as("SELECT address FROM accounts WHERE index = $1")
+                .bind(self.account_index)
+                .fetch_one(get_pool(ctx)?)
+                .await?;
+        Ok(row.address.into())
+    }
+
+    async fn token_index(&self) -> TokenIndex {
+        self.token_index
+    }
+
+    async fn token_id(&self) -> &str {
+        &self.token_id
+    }
+
+    async fn amount(&self) -> TokenAmount {
+        TokenAmount {
+            value: self.amount.to_string(),
+            decimals: self.decimal.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct LockHistoryEvent {
+    id: i64,
+    transaction_index: TransactionIndex,
+    block_height: i64,
+    slot_time: DateTime,
+    operation_order: i32,
+    event_type: String,
+    lock_id: String,
+    token_index: Option<TokenIndex>,
+    token_id: Option<TokenId>,
+    account_index: Option<i64>,
+    source_account_index: Option<i64>,
+    recipient_account_index: Option<i64>,
+    amount: Option<BigDecimal>,
+    decimals: Option<i32>,
+    memo: Option<Json<serde_json::Value>>,
+    event: Json<serde_json::Value>,
+}
+
+#[Object]
+impl LockHistoryEvent {
+    async fn id(&self) -> types::ID {
+        types::ID::from(self.id)
+    }
+
+    async fn transaction(&self, ctx: &Context<'_>) -> ApiResult<Transaction> {
+        Transaction::query_by_index(get_pool(ctx)?, self.transaction_index)
+            .await?
+            .ok_or(ApiError::NotFound)
+    }
+
+    async fn transaction_index(&self) -> TransactionIndex {
+        self.transaction_index
+    }
+
+    async fn block_height(&self) -> i64 {
+        self.block_height
+    }
+
+    async fn slot_time(&self) -> DateTime {
+        self.slot_time
+    }
+
+    async fn operation_order(&self) -> i32 {
+        self.operation_order
+    }
+
+    async fn event_type(&self) -> &str {
+        &self.event_type
+    }
+
+    async fn lock_id(&self) -> &str {
+        &self.lock_id
+    }
+
+    async fn token_index(&self) -> Option<TokenIndex> {
+        self.token_index
+    }
+
+    async fn token_id(&self) -> Option<&str> {
+        self.token_id.as_deref()
+    }
+
+    async fn account(&self, ctx: &Context<'_>) -> ApiResult<Option<Account>> {
+        match self.account_index {
+            Some(index) => Account::query_by_index(get_pool(ctx)?, index).await,
+            None => Ok(None),
+        }
+    }
+
+    async fn source(&self, ctx: &Context<'_>) -> ApiResult<Option<Account>> {
+        match self.source_account_index {
+            Some(index) => Account::query_by_index(get_pool(ctx)?, index).await,
+            None => Ok(None),
+        }
+    }
+
+    async fn recipient(&self, ctx: &Context<'_>) -> ApiResult<Option<Account>> {
+        match self.recipient_account_index {
+            Some(index) => Account::query_by_index(get_pool(ctx)?, index).await,
+            None => Ok(None),
+        }
+    }
+
+    async fn amount(&self) -> Option<TokenAmount> {
+        self.amount.as_ref().map(|amount| TokenAmount {
+            value: amount.to_string(),
+            decimals: self.decimals.unwrap_or_default().to_string(),
+        })
+    }
+
+    async fn memo(&self) -> Option<async_graphql::Json<serde_json::Value>> {
+        self.memo
+            .as_ref()
+            .map(|memo| async_graphql::Json(memo.0.clone()))
+    }
+
+    async fn event(&self) -> async_graphql::Json<serde_json::Value> {
+        async_graphql::Json(self.event.0.clone())
+    }
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct AccountRelatedLock {
+    lock_id: String,
+    creator_account_index: Option<i64>,
+    created_transaction_index: Option<i64>,
+    created_at: Option<DateTime>,
+    expiry: Option<DateTime>,
+    canceled_transaction_index: Option<i64>,
+    canceled_at: Option<DateTime>,
+    config: Option<Json<LockCreateConfig>>,
+    raw_config: Option<String>,
+    metadata_name: Option<String>,
+    metadata_description: Option<String>,
+    account_index: i64,
+    cursor_index: i64,
+}
+
+impl AccountRelatedLock {
+    pub async fn connection(
+        ctx: &Context<'_>,
+        account_index: i64,
+        first: Option<u64>,
+        after: Option<String>,
+        last: Option<u64>,
+        before: Option<String>,
+    ) -> ApiResult<connection::Connection<String, AccountRelatedLock>> {
+        let config = get_config(ctx)?;
+        let pool = get_pool(ctx)?;
+        let query = ConnectionQuery::<DescendingI64>::new(
+            first,
+            after,
+            last,
+            before,
+            config.account_related_locks_connection_limit,
+        )?;
+
+        let mut row_stream = sqlx::query_as::<_, AccountRelatedLock>(
+            r#"
+            SELECT *
+            FROM (
+                SELECT
+                    locks.lock_id,
+                    locks.creator_account_index,
+                    locks.created_transaction_index,
+                    locks.created_at,
+                    locks.expiry,
+                    locks.canceled_transaction_index,
+                    locks.canceled_at,
+                    locks.config,
+                    locks.raw_config,
+                    locks.metadata_name,
+                    locks.metadata_description,
+                    $5::BIGINT AS account_index,
+                    COALESCE(locks.created_transaction_index, 0) AS cursor_index
+                FROM plt_locks locks
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM plt_lock_accounts accounts
+                    WHERE accounts.lock_id = locks.lock_id
+                        AND accounts.account_index = $5
+                )
+                    AND $2 < COALESCE(locks.created_transaction_index, 0)
+                    AND COALESCE(locks.created_transaction_index, 0) < $1
+                ORDER BY
+                    CASE WHEN $4 THEN COALESCE(locks.created_transaction_index, 0) END ASC,
+                    CASE WHEN NOT $4 THEN COALESCE(locks.created_transaction_index, 0) END DESC,
+                    locks.lock_id ASC
+                LIMIT $3
+            ) locks
+            ORDER BY cursor_index DESC, lock_id ASC
+            "#,
+        )
+        .bind(i64::from(query.from))
+        .bind(i64::from(query.to))
+        .bind(query.limit)
+        .bind(query.is_last)
+        .bind(account_index)
+        .fetch(pool);
+
+        let mut connection = connection::Connection::new(false, false);
+        let mut min_index: Option<i64> = None;
+        let mut max_index: Option<i64> = None;
+        while let Some(lock) = row_stream.try_next().await? {
+            min_index =
+                Some(min_index.map_or(lock.cursor_index, |current| current.min(lock.cursor_index)));
+            max_index =
+                Some(max_index.map_or(lock.cursor_index, |current| current.max(lock.cursor_index)));
+            connection
+                .edges
+                .push(connection::Edge::new(lock.cursor_index.to_string(), lock));
+        }
+
+        if let (Some(page_min_index), Some(page_max_index)) = (min_index, max_index) {
+            let bounds: AccountRelatedLocksBounds = sqlx::query_as(
+                r#"
+                SELECT
+                    MIN(COALESCE(locks.created_transaction_index, 0)) AS min_index,
+                    MAX(COALESCE(locks.created_transaction_index, 0)) AS max_index
+                FROM plt_locks locks
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM plt_lock_accounts accounts
+                    WHERE accounts.lock_id = locks.lock_id
+                        AND accounts.account_index = $1
+                )
+                "#,
+            )
+            .bind(account_index)
+            .fetch_one(pool)
+            .await?;
+            connection.has_previous_page = bounds
+                .max_index
+                .is_some_and(|db_max| db_max > page_max_index);
+            connection.has_next_page = bounds
+                .min_index
+                .is_some_and(|db_min| db_min < page_min_index);
+        }
+
+        Ok(connection)
+    }
+
+    fn as_lock(&self) -> Lock {
+        Lock {
+            lock_id: self.lock_id.clone(),
+            creator_account_index: self.creator_account_index,
+            created_transaction_index: self.created_transaction_index,
+            created_at: self.created_at,
+            expiry: self.expiry,
+            canceled_transaction_index: self.canceled_transaction_index,
+            canceled_at: self.canceled_at,
+            config: self.config.clone(),
+            raw_config: self.raw_config.clone(),
+            metadata_name: self.metadata_name.clone(),
+            metadata_description: self.metadata_description.clone(),
+        }
+    }
+
+    async fn query_account_balances(&self, pool: &PgPool) -> ApiResult<Vec<LockBalance>> {
+        let balances = sqlx::query_as::<_, LockBalance>(
+            r#"
+            SELECT
+                plt_lock_balances.lock_id,
+                plt_lock_balances.account_index,
+                plt_lock_balances.token_index,
+                plt_tokens.token_id,
+                plt_lock_balances.amount,
+                plt_lock_balances.decimal
+            FROM plt_lock_balances
+            JOIN plt_tokens ON plt_tokens.index = plt_lock_balances.token_index
+            WHERE plt_lock_balances.lock_id = $1
+                AND plt_lock_balances.account_index = $2
+                AND plt_lock_balances.amount <> 0
+            ORDER BY plt_tokens.token_id ASC
+            "#,
+        )
+        .bind(&self.lock_id)
+        .bind(self.account_index)
+        .fetch_all(pool)
+        .await?;
+        Ok(balances)
+    }
+}
+
+#[Object]
+impl AccountRelatedLock {
+    async fn lock(&self) -> Lock {
+        self.as_lock()
+    }
+
+    async fn account_balances(&self, ctx: &Context<'_>) -> ApiResult<Vec<LockBalance>> {
+        self.query_account_balances(get_pool(ctx)?).await
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct LockHistoryBounds {
+    min_id: Option<i64>,
+    max_id: Option<i64>,
+}
+
+#[derive(Debug, FromRow)]
+struct AccountRelatedLocksBounds {
+    min_index: Option<i64>,
+    max_index: Option<i64>,
+}
+
+#[derive(Debug, FromRow)]
+struct AccountAddressRow {
+    address: String,
+}

--- a/backend/src/graphql_api/search_result.rs
+++ b/backend/src/graphql_api/search_result.rs
@@ -3,10 +3,11 @@ use super::{
     block::Block,
     contract::{self, Contract, ContractSnapshot},
     db, get_config, get_pool,
+    lock::Lock,
     module_reference_event::ModuleReferenceEvent,
     node_status::NodeInfoReceiver,
     token::Token,
-    ApiResult, ConnectionQuery, InternalError,
+    ApiError, ApiResult, ConnectionQuery, InternalError,
 };
 use crate::{
     connection::{connection_from_slice, DescendingI64, NestedCursor},
@@ -54,6 +55,88 @@ const HASH_DUMMY_QUERY: &str = "$";
 /// Regular expression matching 256-bit hash in hexadecimal representation.
 static HASH_256_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-fA-F0-9]{1,64}$").expect("invalid regex"));
+
+static LOCK_ID_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9._:-]{1,128}$").expect("invalid regex"));
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SearchLockCursor {
+    created_transaction_index: DescendingI64,
+    lock_id: String,
+}
+
+impl crate::connection::ConnectionBounds for SearchLockCursor {
+    const END_BOUND: Self = Self {
+        created_transaction_index: DescendingI64::new(i64::MIN),
+        lock_id: String::new(),
+    };
+    const START_BOUND: Self = Self {
+        created_transaction_index: DescendingI64::new(i64::MAX),
+        lock_id: String::new(),
+    };
+}
+
+impl CursorType for SearchLockCursor {
+    type Error = SearchLockCursorDecodeError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        let (created_transaction_index, lock_id) = s
+            .split_once('|')
+            .ok_or(SearchLockCursorDecodeError::MissingSeparator)?;
+        let created_transaction_index = created_transaction_index
+            .parse::<i64>()
+            .map_err(SearchLockCursorDecodeError::InvalidTransactionIndex)?;
+        if !LOCK_ID_REGEX.is_match(lock_id) {
+            return Err(SearchLockCursorDecodeError::InvalidLockId);
+        }
+        Ok(Self {
+            created_transaction_index: DescendingI64::new(created_transaction_index),
+            lock_id: lock_id.to_string(),
+        })
+    }
+
+    fn encode_cursor(&self) -> String {
+        format!("{}|{}", self.created_transaction_index.cursor, self.lock_id)
+    }
+}
+
+impl PartialOrd for SearchLockCursor {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SearchLockCursor {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.created_transaction_index
+            .cmp(&other.created_transaction_index)
+            .then_with(|| self.lock_id.cmp(&other.lock_id))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SearchLockCursorDecodeError {
+    #[error("Missing separator")]
+    MissingSeparator,
+    #[error("Invalid transaction index: {0}")]
+    InvalidTransactionIndex(std::num::ParseIntError),
+    #[error("Invalid lock ID")]
+    InvalidLockId,
+}
+
+impl From<SearchLockCursorDecodeError> for ApiError {
+    fn from(err: SearchLockCursorDecodeError) -> Self {
+        ApiError::InvalidCursorFormat(err.to_string())
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct SearchLockCollectionEnds {
+    start_created_transaction_index: i64,
+    start_lock_id: String,
+    end_created_transaction_index: i64,
+    end_lock_id: String,
+}
 
 #[Object]
 impl SearchResult {
@@ -828,6 +911,177 @@ impl SearchResult {
             connection.has_next_page = result.min_index.is_some_and(|db_min| db_min < last_idx);
             connection.has_previous_page =
                 result.max_index.is_some_and(|db_max| db_max > first_idx);
+        }
+
+        Ok(connection)
+    }
+
+    async fn locks(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "Returns the first _n_ elements from the list.")] first: Option<u64>,
+        #[graphql(desc = "Returns the elements in the list that come after the specified cursor.")]
+        after: Option<String>,
+        #[graphql(desc = "Returns the last _n_ elements from the list.")] last: Option<u64>,
+        #[graphql(
+            desc = "Returns the elements in the list that come before the specified cursor."
+        )]
+        before: Option<String>,
+    ) -> ApiResult<connection::Connection<String, Lock>> {
+        let mut connection = connection::Connection::new(false, false);
+        let query_text = self.query.trim();
+        if query_text.is_empty() || !LOCK_ID_REGEX.is_match(query_text) {
+            return Ok(connection);
+        }
+
+        let pool = get_pool(ctx)?;
+        let config = get_config(ctx)?;
+        let query = ConnectionQuery::<SearchLockCursor>::new(
+            first,
+            after,
+            last,
+            before,
+            config.account_related_locks_connection_limit,
+        )?;
+
+        let from_created_transaction_index = query.from.created_transaction_index.cursor;
+        let from_lock_id = query.from.lock_id;
+        let to_created_transaction_index = query.to.created_transaction_index.cursor;
+        let to_lock_id = query.to.lock_id;
+
+        let mut row_stream = sqlx::query_as::<_, Lock>(
+            r#"
+            SELECT *
+            FROM (
+                SELECT
+                    lock_id,
+                    creator_account_index,
+                    created_transaction_index,
+                    created_at,
+                    expiry,
+                    canceled_transaction_index,
+                    canceled_at,
+                    config,
+                    raw_config,
+                    metadata_name,
+                    metadata_description
+                FROM plt_locks
+                WHERE starts_with(lock_id, $5)
+                    AND (
+                        COALESCE(created_transaction_index, 0) < $1
+                        OR (
+                            COALESCE(created_transaction_index, 0) = $1
+                            AND lock_id > $2
+                        )
+                    )
+                    AND (
+                        COALESCE(created_transaction_index, 0) > $3
+                        OR (
+                            COALESCE(created_transaction_index, 0) = $3
+                            AND lock_id < $4
+                        )
+                    )
+                ORDER BY
+                    CASE WHEN $7 THEN COALESCE(created_transaction_index, 0) END ASC,
+                    CASE WHEN $7 THEN lock_id END DESC,
+                    CASE WHEN NOT $7 THEN COALESCE(created_transaction_index, 0) END DESC,
+                    CASE WHEN NOT $7 THEN lock_id END ASC
+                LIMIT $6
+            ) locks
+            ORDER BY COALESCE(created_transaction_index, 0) DESC, lock_id ASC
+            "#,
+        )
+        .bind(from_created_transaction_index)
+        .bind(&from_lock_id)
+        .bind(to_created_transaction_index)
+        .bind(&to_lock_id)
+        .bind(query_text)
+        .bind(query.limit)
+        .bind(query.is_last)
+        .fetch(pool);
+
+        while let Some(lock) = row_stream.try_next().await? {
+            let cursor = SearchLockCursor {
+                created_transaction_index: DescendingI64::new(
+                    lock.created_transaction_index.unwrap_or_default(),
+                ),
+                lock_id: lock.lock_id.clone(),
+            };
+            connection
+                .edges
+                .push(connection::Edge::new(cursor.encode_cursor(), lock));
+        }
+
+        let (Some(first_item), Some(last_item)) =
+            (connection.edges.first(), connection.edges.last())
+        else {
+            return Ok(connection);
+        };
+
+        let collection_ends = sqlx::query_as::<_, SearchLockCollectionEnds>(
+            r#"
+            WITH
+                starting_lock AS (
+                    SELECT
+                        COALESCE(created_transaction_index, 0) AS created_transaction_index,
+                        lock_id
+                    FROM plt_locks
+                    WHERE starts_with(lock_id, $1)
+                    ORDER BY COALESCE(created_transaction_index, 0) DESC, lock_id ASC
+                    LIMIT 1
+                ),
+                ending_lock AS (
+                    SELECT
+                        COALESCE(created_transaction_index, 0) AS created_transaction_index,
+                        lock_id
+                    FROM plt_locks
+                    WHERE starts_with(lock_id, $1)
+                    ORDER BY COALESCE(created_transaction_index, 0) ASC, lock_id DESC
+                    LIMIT 1
+                )
+            SELECT
+                starting_lock.created_transaction_index AS start_created_transaction_index,
+                starting_lock.lock_id AS start_lock_id,
+                ending_lock.created_transaction_index AS end_created_transaction_index,
+                ending_lock.lock_id AS end_lock_id
+            FROM starting_lock, ending_lock
+            "#,
+        )
+        .bind(query_text)
+        .fetch_optional(pool)
+        .await?;
+
+        if let Some(collection_ends) = collection_ends {
+            let collection_start_cursor = SearchLockCursor {
+                created_transaction_index: DescendingI64::new(
+                    collection_ends.start_created_transaction_index,
+                ),
+                lock_id: collection_ends.start_lock_id,
+            };
+            let page_start_cursor = SearchLockCursor {
+                created_transaction_index: DescendingI64::new(
+                    first_item
+                        .node
+                        .created_transaction_index
+                        .unwrap_or_default(),
+                ),
+                lock_id: first_item.node.lock_id.clone(),
+            };
+            connection.has_previous_page = collection_start_cursor < page_start_cursor;
+
+            let collection_end_cursor = SearchLockCursor {
+                created_transaction_index: DescendingI64::new(
+                    collection_ends.end_created_transaction_index,
+                ),
+                lock_id: collection_ends.end_lock_id,
+            };
+            let page_end_cursor = SearchLockCursor {
+                created_transaction_index: DescendingI64::new(
+                    last_item.node.created_transaction_index.unwrap_or_default(),
+                ),
+                lock_id: last_item.node.lock_id.clone(),
+            };
+            connection.has_next_page = collection_end_cursor > page_end_cursor;
         }
 
         Ok(connection)

--- a/backend/src/graphql_api/search_result.rs
+++ b/backend/src/graphql_api/search_result.rs
@@ -16,7 +16,7 @@ use crate::{
         transaction::Transaction,
     },
     scalar_types::TokenId,
-    transaction_event::Event,
+    transaction_event::{protocol_level_locks::LockCreateConfig, Event},
     transaction_reject::TransactionRejectReason,
     transaction_type::{
         AccountTransactionType, CredentialDeploymentTransactionType, DbTransactionType,
@@ -130,7 +130,6 @@ impl From<SearchLockCursorDecodeError> for ApiError {
     }
 }
 
-#[derive(sqlx::FromRow)]
 struct SearchLockCollectionEnds {
     start_created_transaction_index: i64,
     start_lock_id: String,
@@ -949,7 +948,8 @@ impl SearchResult {
         let to_created_transaction_index = query.to.created_transaction_index.cursor;
         let to_lock_id = query.to.lock_id;
 
-        let mut row_stream = sqlx::query_as::<_, Lock>(
+        let mut row_stream = sqlx::query_as!(
+            Lock,
             r#"
             SELECT *
             FROM (
@@ -961,7 +961,7 @@ impl SearchResult {
                     expiry,
                     canceled_transaction_index,
                     canceled_at,
-                    config,
+                    config as "config: sqlx::types::Json<LockCreateConfig>",
                     raw_config,
                     metadata_name,
                     metadata_description
@@ -990,14 +990,14 @@ impl SearchResult {
             ) locks
             ORDER BY COALESCE(created_transaction_index, 0) DESC, lock_id ASC
             "#,
+            from_created_transaction_index,
+            &from_lock_id,
+            to_created_transaction_index,
+            &to_lock_id,
+            query_text,
+            query.limit,
+            query.is_last
         )
-        .bind(from_created_transaction_index)
-        .bind(&from_lock_id)
-        .bind(to_created_transaction_index)
-        .bind(&to_lock_id)
-        .bind(query_text)
-        .bind(query.limit)
-        .bind(query.is_last)
         .fetch(pool);
 
         while let Some(lock) = row_stream.try_next().await? {
@@ -1018,7 +1018,8 @@ impl SearchResult {
             return Ok(connection);
         };
 
-        let collection_ends = sqlx::query_as::<_, SearchLockCollectionEnds>(
+        let collection_ends = sqlx::query_as!(
+            SearchLockCollectionEnds,
             r#"
             WITH
                 starting_lock AS (
@@ -1040,14 +1041,14 @@ impl SearchResult {
                     LIMIT 1
                 )
             SELECT
-                starting_lock.created_transaction_index AS start_created_transaction_index,
-                starting_lock.lock_id AS start_lock_id,
-                ending_lock.created_transaction_index AS end_created_transaction_index,
-                ending_lock.lock_id AS end_lock_id
+                starting_lock.created_transaction_index AS "start_created_transaction_index!",
+                starting_lock.lock_id AS "start_lock_id!",
+                ending_lock.created_transaction_index AS "end_created_transaction_index!",
+                ending_lock.lock_id AS "end_lock_id!"
             FROM starting_lock, ending_lock
             "#,
+            query_text
         )
-        .bind(query_text)
         .fetch_optional(pool)
         .await?;
 

--- a/backend/src/indexer/block/block_item.rs
+++ b/backend/src/indexer/block/block_item.rs
@@ -170,9 +170,10 @@ impl PreparedBlockItem {
         let success = item_summary.is_success().known_or_err()?;
         let (events, reject) = if success {
             let events: serde_json::Value =
-                serde_json::to_value(transaction_event::events_from_summary(
+                serde_json::to_value(transaction_event::events_from_summary_with_item(
                     item_summary.details.as_ref().known_or_err()?.clone(),
                     data.block_info.block_slot_time,
+                    Some(item),
                 )?)?;
             (Some(events), None)
         } else {

--- a/backend/src/indexer/block/block_item/account_transaction.rs
+++ b/backend/src/indexer/block/block_item/account_transaction.rs
@@ -344,7 +344,8 @@ impl PreparedEvent {
             ),
             AccountTransactionEffects::CredentialKeysUpdated { .. }
             | AccountTransactionEffects::CredentialsUpdated { .. }
-            | AccountTransactionEffects::DataRegistered { .. } => PreparedEvent::NoOperation,
+            | AccountTransactionEffects::DataRegistered { .. }
+            | AccountTransactionEffects::MetaUpdate { .. } => PreparedEvent::NoOperation,
             AccountTransactionEffects::DelegationConfigured { data: events } => {
                 PreparedEvent::AccountDelegationEvents(
                     delegation_events::PreparedAccountDelegationEvents {

--- a/backend/src/indexer/block/block_item/account_transaction.rs
+++ b/backend/src/indexer/block/block_item/account_transaction.rs
@@ -9,6 +9,7 @@
 use crate::{
     graphql_api::AccountStatementEntryType,
     indexer::{
+        block::block_item::account_transaction::lock_events::PreparedLockEvents,
         block::block_item::account_transaction::plt_events::{
             PreparedTokenEvent, PreparedTokenEvents,
         },
@@ -16,12 +17,14 @@ use crate::{
         db::update_account_balance::PreparedUpdateAccountBalance,
         statistics::Statistics,
     },
+    transaction_event::protocol_level_locks,
 };
 use anyhow::{Context, Ok};
 use chrono::{DateTime, Utc};
 use concordium_rust_sdk::{
-    base::transactions::{BlockItem, EncodedPayload},
+    base::transactions::{BlockItem, EncodedPayload, Payload},
     id::types::AccountAddress,
+    protocol_level_tokens::meta_operations::MetaUpdatePayload,
     types::{queries::ProtocolVersionInt, AccountTransactionDetails, AccountTransactionEffects},
     v2::{self},
 };
@@ -29,6 +32,7 @@ use concordium_rust_sdk::{
 mod baker_events;
 mod contract_events;
 mod delegation_events;
+mod lock_events;
 mod module_events;
 mod plt_events;
 mod rejected_events;
@@ -172,6 +176,8 @@ enum PreparedEvent {
 
     /// Events related to token update AccountTransactionEffects.
     TokenUpdateEvents(plt_events::PreparedTokenEvents),
+    /// Events related to meta update AccountTransactionEffects.
+    MetaUpdateEvents(PreparedMetaUpdateEvents),
 }
 impl PreparedEvent {
     async fn prepare(
@@ -344,8 +350,15 @@ impl PreparedEvent {
             ),
             AccountTransactionEffects::CredentialKeysUpdated { .. }
             | AccountTransactionEffects::CredentialsUpdated { .. }
-            | AccountTransactionEffects::DataRegistered { .. }
-            | AccountTransactionEffects::MetaUpdate { .. } => PreparedEvent::NoOperation,
+            | AccountTransactionEffects::DataRegistered { .. } => PreparedEvent::NoOperation,
+            AccountTransactionEffects::MetaUpdate { events } => {
+                let payload = meta_update_payload_from_item(item)?;
+                PreparedEvent::MetaUpdateEvents(PreparedMetaUpdateEvents::prepare(
+                    events,
+                    payload.as_ref(),
+                    sender,
+                )?)
+            }
             AccountTransactionEffects::DelegationConfigured { data: events } => {
                 PreparedEvent::AccountDelegationEvents(
                     delegation_events::PreparedAccountDelegationEvents {
@@ -421,7 +434,75 @@ impl PreparedEvent {
                 .save(tx, tx_idx, slot_time)
                 .await
                 .context("Failed processing block item event with token update events"),
+            PreparedEvent::MetaUpdateEvents(event) => event
+                .save(tx, tx_idx, slot_time)
+                .await
+                .context("Failed processing block item event with meta update events"),
             PreparedEvent::NoOperation => Ok(()),
         }
+    }
+}
+
+#[derive(Debug)]
+struct PreparedMetaUpdateEvents {
+    token_events: PreparedTokenEvents,
+    lock_events: PreparedLockEvents,
+}
+
+impl PreparedMetaUpdateEvents {
+    fn prepare(
+        events: &[concordium_rust_sdk::protocol_level_tokens::MetaEvent],
+        payload: Option<&MetaUpdatePayload>,
+        sender: &AccountAddress,
+    ) -> anyhow::Result<Self> {
+        let token_events = PreparedTokenEvents {
+            events: events
+                .iter()
+                .filter_map(|event| match event {
+                    concordium_rust_sdk::protocol_level_tokens::MetaEvent::Token(event) => {
+                        Some(PreparedTokenEvent::prepare(event))
+                    }
+                    _ => None,
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?,
+        };
+        let lock_events = protocol_level_locks::events_from_meta_update(events, payload)
+            .and_then(|events| PreparedLockEvents::prepare(events, sender.to_string()))?;
+        Ok(Self {
+            token_events,
+            lock_events,
+        })
+    }
+
+    async fn save(
+        &self,
+        tx: &mut sqlx::PgTransaction<'_>,
+        transaction_index: i64,
+        slot_time: DateTime<Utc>,
+    ) -> anyhow::Result<()> {
+        self.token_events
+            .save(tx, transaction_index, slot_time)
+            .await?;
+        self.lock_events
+            .save(tx, transaction_index, slot_time)
+            .await?;
+        Ok(())
+    }
+}
+
+fn meta_update_payload_from_item(
+    item: &BlockItem<EncodedPayload>,
+) -> anyhow::Result<Option<MetaUpdatePayload>> {
+    let encoded_payload = match item {
+        BlockItem::AccountTransaction(account_transaction) => &account_transaction.payload,
+        BlockItem::AccountTransactionV1(account_transaction) => &account_transaction.payload,
+        _ => return Ok(None),
+    };
+    let payload = encoded_payload
+        .decode()
+        .context("Failed decoding account transaction payload")?;
+    match payload {
+        Payload::MetaUpdate { payload } => Ok(Some(payload)),
+        _ => Ok(None),
     }
 }

--- a/backend/src/indexer/block/block_item/account_transaction/lock_events.rs
+++ b/backend/src/indexer/block/block_item/account_transaction/lock_events.rs
@@ -1,0 +1,662 @@
+use crate::transaction_event::{
+    protocol_level_locks::{
+        LockCanceled, LockCreateConfig, LockCreated, LockDestroyed, LockFunded, LockReturned,
+        LockSent,
+    },
+    protocol_level_tokens::TokenAmount,
+    Event,
+};
+use anyhow::Context;
+use bigdecimal::BigDecimal;
+use chrono::{DateTime, Utc};
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub struct PreparedLockEvents {
+    events: Vec<PreparedLockEvent>,
+}
+
+impl PreparedLockEvents {
+    pub fn prepare(events: Vec<Event>, sender: String) -> anyhow::Result<Self> {
+        let events = events
+            .into_iter()
+            .filter_map(|event| PreparedLockEvent::prepare(event, &sender).transpose())
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(Self { events })
+    }
+
+    pub async fn save(
+        &self,
+        tx: &mut sqlx::PgTransaction<'_>,
+        transaction_index: i64,
+        slot_time: DateTime<Utc>,
+    ) -> anyhow::Result<()> {
+        for (operation_order, event) in self.events.iter().enumerate() {
+            event
+                .save(tx, transaction_index, slot_time, operation_order as i32)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+enum PreparedLockEvent {
+    Created {
+        event: LockCreated,
+        creator: String,
+    },
+    Funded {
+        event: LockFunded,
+        account: String,
+    },
+    Sent {
+        event: LockSent,
+        sender: String,
+    },
+    Returned {
+        event: LockReturned,
+        sender: String,
+    },
+    Canceled {
+        event: LockCanceled,
+        sender: String,
+    },
+    Destroyed {
+        event: LockDestroyed,
+        sender: String,
+    },
+}
+
+impl PreparedLockEvent {
+    fn prepare(event: Event, sender: &str) -> anyhow::Result<Option<Self>> {
+        Ok(match event {
+            Event::LockCreated(event) => Some(Self::Created {
+                event,
+                creator: sender.to_string(),
+            }),
+            Event::LockFunded(event) => Some(Self::Funded {
+                event,
+                account: sender.to_string(),
+            }),
+            Event::LockSent(event) => Some(Self::Sent {
+                event,
+                sender: sender.to_string(),
+            }),
+            Event::LockReturned(event) => Some(Self::Returned {
+                event,
+                sender: sender.to_string(),
+            }),
+            Event::LockCanceled(event) => Some(Self::Canceled {
+                event,
+                sender: sender.to_string(),
+            }),
+            Event::LockDestroyed(event) => Some(Self::Destroyed {
+                event,
+                sender: sender.to_string(),
+            }),
+            _ => None,
+        })
+    }
+
+    async fn save(
+        &self,
+        tx: &mut sqlx::PgTransaction<'_>,
+        transaction_index: i64,
+        slot_time: DateTime<Utc>,
+        operation_order: i32,
+    ) -> anyhow::Result<()> {
+        match self {
+            PreparedLockEvent::Created { event, creator } => {
+                if let Some(lock_id) = &event.lock_id {
+                    upsert_created_lock(tx, transaction_index, slot_time, lock_id, creator, event)
+                        .await?;
+                    insert_lock_event(
+                        tx,
+                        InsertLockEvent {
+                            transaction_index,
+                            slot_time,
+                            operation_order,
+                            event_type: "LockCreate",
+                            lock_id,
+                            token_id: None,
+                            account: Some(creator),
+                            source: None,
+                            recipient: None,
+                            amount: None,
+                            memo: None,
+                            event,
+                        },
+                    )
+                    .await?;
+                    upsert_relationship(tx, lock_id, creator, "Creator", transaction_index).await?;
+                    upsert_relationship(tx, lock_id, creator, "Touched", transaction_index).await?;
+                    if let Some(config) = &event.config {
+                        save_config_relationships(tx, lock_id, config, transaction_index).await?;
+                    }
+                }
+            }
+            PreparedLockEvent::Funded { event, account } => {
+                ensure_lock_exists(tx, &event.lock_id).await?;
+                insert_lock_event(
+                    tx,
+                    InsertLockEvent {
+                        transaction_index,
+                        slot_time,
+                        operation_order,
+                        event_type: "LockFund",
+                        lock_id: &event.lock_id,
+                        token_id: Some(&event.token_id),
+                        account: Some(account),
+                        source: None,
+                        recipient: None,
+                        amount: Some(&event.amount),
+                        memo: event.memo.as_ref(),
+                        event,
+                    },
+                )
+                .await?;
+                update_balance(
+                    tx,
+                    &event.lock_id,
+                    account,
+                    &event.token_id,
+                    &event.amount,
+                    1,
+                )
+                .await?;
+                upsert_relationship(
+                    tx,
+                    &event.lock_id,
+                    account,
+                    "BalanceHolder",
+                    transaction_index,
+                )
+                .await?;
+                upsert_relationship(tx, &event.lock_id, account, "Touched", transaction_index)
+                    .await?;
+            }
+            PreparedLockEvent::Sent { event, sender } => {
+                ensure_lock_exists(tx, &event.lock_id).await?;
+                let source = event.source.address.to_string();
+                let recipient = event.recipient.address.to_string();
+                insert_lock_event(
+                    tx,
+                    InsertLockEvent {
+                        transaction_index,
+                        slot_time,
+                        operation_order,
+                        event_type: "LockSend",
+                        lock_id: &event.lock_id,
+                        token_id: Some(&event.token_id),
+                        account: None,
+                        source: Some(&source),
+                        recipient: Some(&recipient),
+                        amount: Some(&event.amount),
+                        memo: event.memo.as_ref(),
+                        event,
+                    },
+                )
+                .await?;
+                update_balance(
+                    tx,
+                    &event.lock_id,
+                    &source,
+                    &event.token_id,
+                    &event.amount,
+                    -1,
+                )
+                .await?;
+                update_balance(
+                    tx,
+                    &event.lock_id,
+                    &recipient,
+                    &event.token_id,
+                    &event.amount,
+                    1,
+                )
+                .await?;
+                upsert_relationship(
+                    tx,
+                    &event.lock_id,
+                    &source,
+                    "BalanceHolder",
+                    transaction_index,
+                )
+                .await?;
+                upsert_relationship(
+                    tx,
+                    &event.lock_id,
+                    &recipient,
+                    "BalanceHolder",
+                    transaction_index,
+                )
+                .await?;
+                upsert_relationship(tx, &event.lock_id, &source, "Touched", transaction_index)
+                    .await?;
+                upsert_relationship(tx, &event.lock_id, &recipient, "Touched", transaction_index)
+                    .await?;
+                upsert_relationship(tx, &event.lock_id, sender, "Touched", transaction_index)
+                    .await?;
+            }
+            PreparedLockEvent::Returned { event, sender } => {
+                ensure_lock_exists(tx, &event.lock_id).await?;
+                let source = event.source.address.to_string();
+                insert_lock_event(
+                    tx,
+                    InsertLockEvent {
+                        transaction_index,
+                        slot_time,
+                        operation_order,
+                        event_type: "LockReturn",
+                        lock_id: &event.lock_id,
+                        token_id: Some(&event.token_id),
+                        account: None,
+                        source: Some(&source),
+                        recipient: None,
+                        amount: Some(&event.amount),
+                        memo: event.memo.as_ref(),
+                        event,
+                    },
+                )
+                .await?;
+                update_balance(
+                    tx,
+                    &event.lock_id,
+                    &source,
+                    &event.token_id,
+                    &event.amount,
+                    -1,
+                )
+                .await?;
+                upsert_relationship(
+                    tx,
+                    &event.lock_id,
+                    &source,
+                    "BalanceHolder",
+                    transaction_index,
+                )
+                .await?;
+                upsert_relationship(tx, &event.lock_id, &source, "Touched", transaction_index)
+                    .await?;
+                upsert_relationship(tx, &event.lock_id, sender, "Touched", transaction_index)
+                    .await?;
+            }
+            PreparedLockEvent::Canceled { event, sender } => {
+                ensure_lock_exists(tx, &event.lock_id).await?;
+                mark_lock_canceled(tx, transaction_index, slot_time, &event.lock_id).await?;
+                insert_lock_event(
+                    tx,
+                    InsertLockEvent {
+                        transaction_index,
+                        slot_time,
+                        operation_order,
+                        event_type: "LockCancel",
+                        lock_id: &event.lock_id,
+                        token_id: None,
+                        account: Some(sender),
+                        source: None,
+                        recipient: None,
+                        amount: None,
+                        memo: event.memo.as_ref(),
+                        event,
+                    },
+                )
+                .await?;
+                clear_balances(tx, &event.lock_id).await?;
+                upsert_relationship(tx, &event.lock_id, sender, "Touched", transaction_index)
+                    .await?;
+            }
+            PreparedLockEvent::Destroyed { event, sender } => {
+                ensure_lock_exists(tx, &event.lock_id).await?;
+                mark_lock_canceled(tx, transaction_index, slot_time, &event.lock_id).await?;
+                insert_lock_event(
+                    tx,
+                    InsertLockEvent {
+                        transaction_index,
+                        slot_time,
+                        operation_order,
+                        event_type: "LockDestroy",
+                        lock_id: &event.lock_id,
+                        token_id: None,
+                        account: None,
+                        source: None,
+                        recipient: None,
+                        amount: None,
+                        memo: None,
+                        event,
+                    },
+                )
+                .await?;
+                clear_balances(tx, &event.lock_id).await?;
+                upsert_relationship(tx, &event.lock_id, sender, "Touched", transaction_index)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+struct InsertLockEvent<'a, T> {
+    transaction_index: i64,
+    slot_time: DateTime<Utc>,
+    operation_order: i32,
+    event_type: &'a str,
+    lock_id: &'a str,
+    token_id: Option<&'a str>,
+    account: Option<&'a str>,
+    source: Option<&'a str>,
+    recipient: Option<&'a str>,
+    amount: Option<&'a TokenAmount>,
+    memo: Option<&'a crate::transaction_event::protocol_level_tokens::Memo>,
+    event: &'a T,
+}
+
+async fn insert_lock_event<T: serde::Serialize>(
+    tx: &mut sqlx::PgTransaction<'_>,
+    params: InsertLockEvent<'_, T>,
+) -> anyhow::Result<()> {
+    let amount = params.amount.map(amount_value).transpose()?;
+    let decimals = params.amount.map(amount_decimals).transpose()?;
+    let memo = params.memo.map(serde_json::to_value).transpose()?;
+    let event = serde_json::to_value(params.event)?;
+    let account = params.account.map(canonical_address).transpose()?;
+    let source = params.source.map(canonical_address).transpose()?;
+    let recipient = params.recipient.map(canonical_address).transpose()?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO plt_lock_events (
+            transaction_index,
+            block_height,
+            slot_time,
+            operation_order,
+            event_type,
+            lock_id,
+            token_index,
+            account_index,
+            source_account_index,
+            recipient_account_index,
+            amount,
+            decimals,
+            memo,
+            event
+        )
+        VALUES (
+            $1,
+            (SELECT block_height FROM transactions WHERE index = $1),
+            $2,
+            $3,
+            $4,
+            $5,
+            (SELECT index FROM plt_tokens WHERE token_id = $6),
+            (SELECT index FROM accounts WHERE canonical_address = $7::bytea),
+            (SELECT index FROM accounts WHERE canonical_address = $8::bytea),
+            (SELECT index FROM accounts WHERE canonical_address = $9::bytea),
+            $10,
+            $11,
+            $12,
+            $13
+        )
+        "#,
+    )
+    .bind(params.transaction_index)
+    .bind(params.slot_time)
+    .bind(params.operation_order)
+    .bind(params.event_type)
+    .bind(params.lock_id)
+    .bind(params.token_id)
+    .bind(account)
+    .bind(source)
+    .bind(recipient)
+    .bind(amount)
+    .bind(decimals)
+    .bind(memo)
+    .bind(event)
+    .execute(tx.as_mut())
+    .await?;
+
+    Ok(())
+}
+
+async fn upsert_created_lock(
+    tx: &mut sqlx::PgTransaction<'_>,
+    transaction_index: i64,
+    slot_time: DateTime<Utc>,
+    lock_id: &str,
+    creator: &str,
+    event: &LockCreated,
+) -> anyhow::Result<()> {
+    let creator = canonical_address(creator)?;
+    let config = event
+        .config
+        .as_ref()
+        .map(serde_json::to_value)
+        .transpose()?;
+    let expiry = event.config.as_ref().map(|config| config.expiry);
+    let metadata_name = event
+        .config
+        .as_ref()
+        .and_then(|config| config.metadata.as_ref())
+        .and_then(|metadata| metadata.name.clone());
+    let metadata_description = event
+        .config
+        .as_ref()
+        .and_then(|config| config.metadata.as_ref())
+        .and_then(|metadata| metadata.description.clone());
+
+    sqlx::query(
+        r#"
+        INSERT INTO plt_locks (
+            lock_id,
+            creator_account_index,
+            created_transaction_index,
+            created_block_height,
+            created_at,
+            expiry,
+            config,
+            raw_config,
+            metadata_name,
+            metadata_description
+        )
+        VALUES (
+            $1,
+            (SELECT index FROM accounts WHERE canonical_address = $2::bytea),
+            $3,
+            (SELECT block_height FROM transactions WHERE index = $3),
+            $4,
+            $5,
+            $6,
+            $7,
+            $8,
+            $9
+        )
+        ON CONFLICT (lock_id) DO UPDATE SET
+            creator_account_index = COALESCE(plt_locks.creator_account_index, EXCLUDED.creator_account_index),
+            created_transaction_index = COALESCE(plt_locks.created_transaction_index, EXCLUDED.created_transaction_index),
+            created_block_height = COALESCE(plt_locks.created_block_height, EXCLUDED.created_block_height),
+            created_at = COALESCE(plt_locks.created_at, EXCLUDED.created_at),
+            expiry = COALESCE(plt_locks.expiry, EXCLUDED.expiry),
+            config = COALESCE(plt_locks.config, EXCLUDED.config),
+            raw_config = COALESCE(plt_locks.raw_config, EXCLUDED.raw_config),
+            metadata_name = COALESCE(plt_locks.metadata_name, EXCLUDED.metadata_name),
+            metadata_description = COALESCE(plt_locks.metadata_description, EXCLUDED.metadata_description)
+        "#,
+    )
+    .bind(lock_id)
+    .bind(creator)
+    .bind(transaction_index)
+    .bind(slot_time)
+    .bind(expiry)
+    .bind(config)
+    .bind(&event.raw_config)
+    .bind(metadata_name)
+    .bind(metadata_description)
+    .execute(tx.as_mut())
+    .await?;
+
+    Ok(())
+}
+
+async fn ensure_lock_exists(tx: &mut sqlx::PgTransaction<'_>, lock_id: &str) -> anyhow::Result<()> {
+    sqlx::query("INSERT INTO plt_locks (lock_id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind(lock_id)
+        .execute(tx.as_mut())
+        .await?;
+    Ok(())
+}
+
+async fn mark_lock_canceled(
+    tx: &mut sqlx::PgTransaction<'_>,
+    transaction_index: i64,
+    slot_time: DateTime<Utc>,
+    lock_id: &str,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        UPDATE plt_locks
+        SET
+            canceled_transaction_index = COALESCE(canceled_transaction_index, $1),
+            canceled_block_height = COALESCE(canceled_block_height, (SELECT block_height FROM transactions WHERE index = $1)),
+            canceled_at = COALESCE(canceled_at, $2)
+        WHERE lock_id = $3
+        "#,
+    )
+    .bind(transaction_index)
+    .bind(slot_time)
+    .bind(lock_id)
+    .execute(tx.as_mut())
+    .await?;
+    Ok(())
+}
+
+async fn save_config_relationships(
+    tx: &mut sqlx::PgTransaction<'_>,
+    lock_id: &str,
+    config: &LockCreateConfig,
+    transaction_index: i64,
+) -> anyhow::Result<()> {
+    for recipient in &config.recipients.accounts {
+        upsert_relationship(
+            tx,
+            lock_id,
+            &recipient.address.to_string(),
+            "Recipient",
+            transaction_index,
+        )
+        .await?;
+    }
+
+    if let Some(simple_v0) = &config.controller.simple_v0 {
+        for grant in &simple_v0.grants {
+            upsert_relationship(
+                tx,
+                lock_id,
+                &grant.account.address.to_string(),
+                "Controller",
+                transaction_index,
+            )
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn upsert_relationship(
+    tx: &mut sqlx::PgTransaction<'_>,
+    lock_id: &str,
+    account: &str,
+    relationship_type: &str,
+    transaction_index: i64,
+) -> anyhow::Result<()> {
+    let account = canonical_address(account)?;
+    sqlx::query(
+        r#"
+        INSERT INTO plt_lock_accounts (
+            lock_id,
+            account_index,
+            relationship_type,
+            first_transaction_index,
+            last_transaction_index
+        )
+        SELECT $1, accounts.index, $3, $4, $4
+        FROM accounts
+        WHERE accounts.canonical_address = $2::bytea
+        ON CONFLICT (lock_id, account_index, relationship_type) DO UPDATE SET
+            last_transaction_index = EXCLUDED.last_transaction_index
+        "#,
+    )
+    .bind(lock_id)
+    .bind(account)
+    .bind(relationship_type)
+    .bind(transaction_index)
+    .execute(tx.as_mut())
+    .await?;
+    Ok(())
+}
+
+async fn update_balance(
+    tx: &mut sqlx::PgTransaction<'_>,
+    lock_id: &str,
+    account: &str,
+    token_id: &str,
+    amount: &TokenAmount,
+    sign: i32,
+) -> anyhow::Result<()> {
+    let account = canonical_address(account)?;
+    let amount_value = amount_value(amount)?;
+    let amount_value = if sign < 0 {
+        -amount_value
+    } else {
+        amount_value
+    };
+    let decimals = amount_decimals(amount)?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO plt_lock_balances (lock_id, account_index, token_index, amount, decimal)
+        SELECT $1, accounts.index, plt_tokens.index, $4, $5
+        FROM accounts, plt_tokens
+        WHERE accounts.canonical_address = $2::bytea
+          AND plt_tokens.token_id = $3
+        ON CONFLICT (lock_id, account_index, token_index) DO UPDATE SET
+            amount = plt_lock_balances.amount + EXCLUDED.amount,
+            decimal = EXCLUDED.decimal
+        "#,
+    )
+    .bind(lock_id)
+    .bind(account)
+    .bind(token_id)
+    .bind(amount_value)
+    .bind(decimals)
+    .execute(tx.as_mut())
+    .await?;
+
+    Ok(())
+}
+
+async fn clear_balances(tx: &mut sqlx::PgTransaction<'_>, lock_id: &str) -> anyhow::Result<()> {
+    sqlx::query("UPDATE plt_lock_balances SET amount = 0 WHERE lock_id = $1")
+        .bind(lock_id)
+        .execute(tx.as_mut())
+        .await?;
+    Ok(())
+}
+
+fn amount_value(amount: &TokenAmount) -> anyhow::Result<BigDecimal> {
+    BigDecimal::from_str(&amount.value).context("Failed to parse lock token amount")
+}
+
+fn amount_decimals(amount: &TokenAmount) -> anyhow::Result<i32> {
+    amount
+        .decimals
+        .parse()
+        .context("Failed to parse lock token decimals")
+}
+
+fn canonical_address(account: &str) -> anyhow::Result<Vec<u8>> {
+    let account = concordium_rust_sdk::base::contracts_common::AccountAddress::from_str(account)
+        .map_err(|_| anyhow::anyhow!("Failed to parse account address: {}", account))?;
+    Ok(account.get_canonical_address().0.to_vec())
+}

--- a/backend/src/migrations.rs
+++ b/backend/src/migrations.rs
@@ -302,6 +302,8 @@ pub enum SchemaVersion {
     AddMetaUpdateAccountTransactionType,
     #[display("0051: Add MaxLockDuration update transaction type")]
     AddMaxLockDurationUpdateTransactionType,
+    #[display("0052: Add PLT lock state tables")]
+    AddPltLockStateTables,
 }
 impl SchemaVersion {
     /// The minimum supported database schema version for the API.
@@ -309,7 +311,7 @@ impl SchemaVersion {
     /// have been introduced since this version.
     pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion = SchemaVersion::IndexPltHolderNonZero;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::AddMaxLockDurationUpdateTransactionType;
+    const LATEST: SchemaVersion = SchemaVersion::AddPltLockStateTables;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.
@@ -382,6 +384,7 @@ impl SchemaVersion {
             SchemaVersion::AlterPltTokenModuleEventTypes => false,
             SchemaVersion::AddMetaUpdateAccountTransactionType => false,
             SchemaVersion::AddMaxLockDurationUpdateTransactionType => false,
+            SchemaVersion::AddPltLockStateTables => false,
         }
     }
 
@@ -443,6 +446,7 @@ impl SchemaVersion {
             SchemaVersion::AlterPltTokenModuleEventTypes => false,
             SchemaVersion::AddMetaUpdateAccountTransactionType => false,
             SchemaVersion::AddMaxLockDurationUpdateTransactionType => false,
+            SchemaVersion::AddPltLockStateTables => false,
         }
     }
 
@@ -809,7 +813,16 @@ impl SchemaVersion {
                 SchemaVersion::AddMaxLockDurationUpdateTransactionType
             }
 
-            SchemaVersion::AddMaxLockDurationUpdateTransactionType => unimplemented!(
+            SchemaVersion::AddMaxLockDurationUpdateTransactionType => {
+                tx.as_mut()
+                    .execute(sqlx::raw_sql(include_str!(
+                        "./migrations/m0052_plt_locks.sql"
+                    )))
+                    .await?;
+                SchemaVersion::AddPltLockStateTables
+            }
+
+            SchemaVersion::AddPltLockStateTables => unimplemented!(
                 "No migration implemented for database schema version {}",
                 self.as_i64()
             ),

--- a/backend/src/migrations.rs
+++ b/backend/src/migrations.rs
@@ -298,6 +298,10 @@ pub enum SchemaVersion {
     IndexPltHolderNonZero,
     #[display("0049: Alter plt token modules events to add new event types")]
     AlterPltTokenModuleEventTypes,
+    #[display("0050: Add MetaUpdate account transaction type")]
+    AddMetaUpdateAccountTransactionType,
+    #[display("0051: Add MaxLockDuration update transaction type")]
+    AddMaxLockDurationUpdateTransactionType,
 }
 impl SchemaVersion {
     /// The minimum supported database schema version for the API.
@@ -305,7 +309,7 @@ impl SchemaVersion {
     /// have been introduced since this version.
     pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion = SchemaVersion::IndexPltHolderNonZero;
     /// The latest known version of the schema.
-    const LATEST: SchemaVersion = SchemaVersion::AlterPltTokenModuleEventTypes;
+    const LATEST: SchemaVersion = SchemaVersion::AddMaxLockDurationUpdateTransactionType;
 
     /// Parse version number into a database schema version.
     /// None if the version is unknown.
@@ -376,6 +380,8 @@ impl SchemaVersion {
             SchemaVersion::AlterTxnAddSponsoredTxn => false,
             SchemaVersion::IndexPltHolderNonZero => false,
             SchemaVersion::AlterPltTokenModuleEventTypes => false,
+            SchemaVersion::AddMetaUpdateAccountTransactionType => false,
+            SchemaVersion::AddMaxLockDurationUpdateTransactionType => false,
         }
     }
 
@@ -435,6 +441,8 @@ impl SchemaVersion {
             SchemaVersion::AlterTxnAddSponsoredTxn => false,
             SchemaVersion::IndexPltHolderNonZero => false,
             SchemaVersion::AlterPltTokenModuleEventTypes => false,
+            SchemaVersion::AddMetaUpdateAccountTransactionType => false,
+            SchemaVersion::AddMaxLockDurationUpdateTransactionType => false,
         }
     }
 
@@ -783,7 +791,25 @@ impl SchemaVersion {
                 SchemaVersion::AlterPltTokenModuleEventTypes
             }
 
-            SchemaVersion::AlterPltTokenModuleEventTypes => unimplemented!(
+            SchemaVersion::AlterPltTokenModuleEventTypes => {
+                tx.as_mut()
+                    .execute(sqlx::raw_sql(include_str!(
+                        "./migrations/m0050_add_meta_update_account_transaction_type.sql"
+                    )))
+                    .await?;
+                SchemaVersion::AddMetaUpdateAccountTransactionType
+            }
+
+            SchemaVersion::AddMetaUpdateAccountTransactionType => {
+                tx.as_mut()
+                    .execute(sqlx::raw_sql(include_str!(
+                        "./migrations/m0051_add_max_lock_duration_update_transaction_type.sql"
+                    )))
+                    .await?;
+                SchemaVersion::AddMaxLockDurationUpdateTransactionType
+            }
+
+            SchemaVersion::AddMaxLockDurationUpdateTransactionType => unimplemented!(
                 "No migration implemented for database schema version {}",
                 self.as_i64()
             ),

--- a/backend/src/migrations.rs
+++ b/backend/src/migrations.rs
@@ -309,7 +309,7 @@ impl SchemaVersion {
     /// The minimum supported database schema version for the API.
     /// Fails at startup if any breaking (destructive) database schema versions
     /// have been introduced since this version.
-    pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion = SchemaVersion::IndexPltHolderNonZero;
+    pub const API_SUPPORTED_SCHEMA_VERSION: SchemaVersion = SchemaVersion::AddPltLockStateTables;
     /// The latest known version of the schema.
     const LATEST: SchemaVersion = SchemaVersion::AddPltLockStateTables;
 

--- a/backend/src/migrations/m0050_add_meta_update_account_transaction_type.sql
+++ b/backend/src/migrations/m0050_add_meta_update_account_transaction_type.sql
@@ -1,0 +1,2 @@
+ALTER TYPE account_transaction_type
+    ADD VALUE IF NOT EXISTS 'MetaUpdate';

--- a/backend/src/migrations/m0051_add_max_lock_duration_update_transaction_type.sql
+++ b/backend/src/migrations/m0051_add_max_lock_duration_update_transaction_type.sql
@@ -1,0 +1,2 @@
+ALTER TYPE update_transaction_type
+    ADD VALUE IF NOT EXISTS 'MaxLockDurationUpdate';

--- a/backend/src/migrations/m0052_plt_locks.sql
+++ b/backend/src/migrations/m0052_plt_locks.sql
@@ -1,0 +1,88 @@
+CREATE TABLE plt_locks (
+    lock_id TEXT PRIMARY KEY,
+    creator_account_index BIGINT REFERENCES accounts(index),
+    created_transaction_index BIGINT REFERENCES transactions(index),
+    created_block_height BIGINT,
+    created_at TIMESTAMPTZ,
+    expiry TIMESTAMPTZ,
+    canceled_transaction_index BIGINT REFERENCES transactions(index),
+    canceled_block_height BIGINT,
+    canceled_at TIMESTAMPTZ,
+    config JSONB,
+    raw_config TEXT,
+    metadata_name TEXT,
+    metadata_description TEXT
+);
+
+CREATE INDEX plt_locks_created_at_idx
+ON plt_locks(created_at DESC, lock_id);
+
+CREATE INDEX plt_locks_canceled_at_idx
+ON plt_locks(canceled_at)
+WHERE canceled_at IS NOT NULL;
+
+CREATE TABLE plt_lock_events (
+    id BIGSERIAL PRIMARY KEY,
+    transaction_index BIGINT NOT NULL REFERENCES transactions(index),
+    block_height BIGINT NOT NULL,
+    slot_time TIMESTAMPTZ NOT NULL,
+    operation_order INT NOT NULL,
+    event_type TEXT NOT NULL CHECK (
+        event_type IN (
+            'LockCreate',
+            'LockFund',
+            'LockSend',
+            'LockReturn',
+            'LockCancel',
+            'LockDestroy'
+        )
+    ),
+    lock_id TEXT NOT NULL REFERENCES plt_locks(lock_id),
+    token_index BIGINT REFERENCES plt_tokens(index),
+    account_index BIGINT REFERENCES accounts(index),
+    source_account_index BIGINT REFERENCES accounts(index),
+    recipient_account_index BIGINT REFERENCES accounts(index),
+    amount NUMERIC,
+    decimals INT,
+    memo JSONB,
+    event JSONB NOT NULL
+);
+
+CREATE INDEX plt_lock_events_lock_time_idx
+ON plt_lock_events(lock_id, slot_time DESC, operation_order DESC);
+
+CREATE INDEX plt_lock_events_transaction_idx
+ON plt_lock_events(transaction_index, operation_order);
+
+CREATE TABLE plt_lock_balances (
+    lock_id TEXT NOT NULL REFERENCES plt_locks(lock_id),
+    account_index BIGINT NOT NULL REFERENCES accounts(index),
+    token_index BIGINT NOT NULL REFERENCES plt_tokens(index),
+    amount NUMERIC NOT NULL DEFAULT 0,
+    decimal INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (lock_id, account_index, token_index)
+);
+
+CREATE INDEX plt_lock_balances_account_idx
+ON plt_lock_balances(account_index, token_index)
+WHERE amount <> 0;
+
+CREATE TABLE plt_lock_accounts (
+    lock_id TEXT NOT NULL REFERENCES plt_locks(lock_id),
+    account_index BIGINT NOT NULL REFERENCES accounts(index),
+    relationship_type TEXT NOT NULL CHECK (
+        relationship_type IN (
+            'Creator',
+            'BalanceHolder',
+            'Recipient',
+            'Controller',
+            'Touched'
+        )
+    ),
+    first_transaction_index BIGINT NOT NULL REFERENCES transactions(index),
+    last_transaction_index BIGINT NOT NULL REFERENCES transactions(index),
+    PRIMARY KEY (lock_id, account_index, relationship_type)
+);
+
+CREATE INDEX plt_lock_accounts_account_idx
+ON plt_lock_accounts(account_index, lock_id);

--- a/backend/src/transaction_event/chain_update.rs
+++ b/backend/src/transaction_event/chain_update.rs
@@ -39,6 +39,7 @@ pub struct ChainUpdateEnqueued {
 pub enum ChainUpdatePayload {
     Protocol(ProtocolChainUpdatePayload),
     MinBlockTime(MinBlockTimeUpdate),
+    MaxLockDuration(MaxLockDurationUpdate),
     TimeoutParameters(TimeoutParametersUpdate),
     FinalizationCommitteeParameters(FinalizationCommitteeParametersUpdate),
     BlockEnergyLimit(BlockEnergyLimitUpdate),
@@ -65,6 +66,11 @@ pub enum ChainUpdatePayload {
 
 #[derive(SimpleObject, Serialize, Deserialize)]
 pub struct MinBlockTimeUpdate {
+    pub duration_seconds: UnsignedLong,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize)]
+pub struct MaxLockDurationUpdate {
     pub duration_seconds: UnsignedLong,
 }
 

--- a/backend/src/transaction_event/mod.rs
+++ b/backend/src/transaction_event/mod.rs
@@ -546,6 +546,7 @@ pub fn events_from_summary(
                     }))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?,
+            AccountTransactionEffects::MetaUpdate { .. } => Vec::new(),
         },
         BlockItemSummaryDetails::AccountCreation(details) => {
             vec![
@@ -617,6 +618,14 @@ pub fn events_from_summary(
                             protocol_level_tokens::TokenTransferEvent {
                                 from: token_transfer_event.from.clone().into(),
                                 to: token_transfer_event.to.clone().into(),
+                                from_lock: token_transfer_event
+                                    .from_lock
+                                    .as_ref()
+                                    .map(|lock| lock.to_string()),
+                                to_lock: token_transfer_event
+                                    .to_lock
+                                    .as_ref()
+                                    .map(|lock| lock.to_string()),
                                 amount: token_transfer_event.amount.into(),
                                 memo: token_transfer_event.memo.clone().map(Into::into),
                             },

--- a/backend/src/transaction_event/mod.rs
+++ b/backend/src/transaction_event/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 use anyhow::Context;
 use async_graphql::{ComplexObject, Object, SimpleObject, Union};
 use bigdecimal::BigDecimal;
+use concordium_rust_sdk::base::transactions::{BlockItem, EncodedPayload, Payload};
 use concordium_rust_sdk::smart_contracts::types::WasmVersion;
 use concordium_rust_sdk::{
     cis2, common::cbor, protocol_level_tokens::TokenModuleInitializationParameters, types::Address,
@@ -18,6 +19,7 @@ pub mod baker;
 pub mod chain_update;
 pub mod credentials;
 pub mod delegation;
+pub mod protocol_level_locks;
 pub mod protocol_level_tokens;
 pub mod smart_contracts;
 pub mod transfers;
@@ -75,6 +77,12 @@ pub enum Event {
     // Plt
     TokenUpdate(protocol_level_tokens::TokenUpdate),
     TokenCreationDetails(protocol_level_tokens::TokenCreationDetails),
+    LockCreated(protocol_level_locks::LockCreated),
+    LockFunded(protocol_level_locks::LockFunded),
+    LockSent(protocol_level_locks::LockSent),
+    LockReturned(protocol_level_locks::LockReturned),
+    LockCanceled(protocol_level_locks::LockCanceled),
+    LockDestroyed(protocol_level_locks::LockDestroyed),
 }
 
 #[derive(SimpleObject, serde::Serialize, serde::Deserialize)]
@@ -98,6 +106,14 @@ impl DataRegistered {
 pub fn events_from_summary(
     value: concordium_rust_sdk::types::BlockItemSummaryDetails,
     block_time: DateTime,
+) -> anyhow::Result<Vec<Event>> {
+    events_from_summary_with_item(value, block_time, None)
+}
+
+pub fn events_from_summary_with_item(
+    value: concordium_rust_sdk::types::BlockItemSummaryDetails,
+    block_time: DateTime,
+    item: Option<&BlockItem<EncodedPayload>>,
 ) -> anyhow::Result<Vec<Event>> {
     use concordium_rust_sdk::types::{AccountTransactionEffects, BlockItemSummaryDetails};
     let events = match value {
@@ -546,7 +562,13 @@ pub fn events_from_summary(
                     }))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?,
-            AccountTransactionEffects::MetaUpdate { .. } => Vec::new(),
+            AccountTransactionEffects::MetaUpdate { events } => {
+                let payload = item
+                    .map(meta_update_payload_from_item)
+                    .transpose()?
+                    .flatten();
+                protocol_level_locks::events_from_meta_update(&events, payload.as_ref())?
+            }
         },
         BlockItemSummaryDetails::AccountCreation(details) => {
             vec![
@@ -652,6 +674,25 @@ pub fn events_from_summary(
         }
     };
     Ok(events)
+}
+
+fn meta_update_payload_from_item(
+    item: &BlockItem<EncodedPayload>,
+) -> anyhow::Result<
+    Option<concordium_rust_sdk::protocol_level_tokens::meta_operations::MetaUpdatePayload>,
+> {
+    let encoded_payload = match item {
+        BlockItem::AccountTransaction(account_transaction) => &account_transaction.payload,
+        BlockItem::AccountTransactionV1(account_transaction) => &account_transaction.payload,
+        _ => return Ok(None),
+    };
+    let payload = encoded_payload
+        .decode()
+        .context("Failed decoding account transaction payload")?;
+    match payload {
+        Payload::MetaUpdate { payload } => Ok(Some(payload)),
+        _ => Ok(None),
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/backend/src/transaction_event/protocol_level_locks.rs
+++ b/backend/src/transaction_event/protocol_level_locks.rs
@@ -1,0 +1,372 @@
+use crate::{
+    scalar_types::DateTime,
+    transaction_event::protocol_level_tokens::{CborHolderAccount, Memo, TokenAmount},
+};
+use anyhow::Context;
+use async_graphql::SimpleObject;
+use concordium_rust_sdk::{
+    common::cbor,
+    protocol_level_tokens::{
+        meta_operations::{
+            MetaLockCancelDetails, MetaLockCreateDetails, MetaLockFundDetails,
+            MetaLockReturnDetails, MetaLockSendDetails, MetaUpdateOperation, MetaUpdatePayload,
+        },
+        CborMemo, LockConfig as SdkLockConfig, LockController, LockControllerSimpleV0,
+        LockControllerSimpleV0Capability, LockControllerSimpleV0Grant, LockMetadata,
+        LockRecipients, MetaEvent, RawCbor,
+    },
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockCreated {
+    pub lock_id: Option<String>,
+    pub config: Option<LockCreateConfig>,
+    pub raw_config_present: bool,
+    pub config_unavailable: bool,
+    pub raw_config: Option<String>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockFunded {
+    pub lock_id: String,
+    pub token_id: String,
+    pub amount: TokenAmount,
+    pub memo: Option<Memo>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockSent {
+    pub lock_id: String,
+    pub token_id: String,
+    pub source: CborHolderAccount,
+    pub recipient: CborHolderAccount,
+    pub amount: TokenAmount,
+    pub memo: Option<Memo>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockReturned {
+    pub lock_id: String,
+    pub token_id: String,
+    pub source: CborHolderAccount,
+    pub amount: TokenAmount,
+    pub memo: Option<Memo>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockCanceled {
+    pub lock_id: String,
+    pub memo: Option<Memo>,
+    pub destroyed: bool,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockDestroyed {
+    pub lock_id: String,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockCreateConfig {
+    pub expiry: DateTime,
+    pub recipients: LockRecipientsConfig,
+    pub controller: LockControllerConfig,
+    pub metadata: Option<LockMetadataConfig>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockRecipientsConfig {
+    pub recipient_type: String,
+    pub accounts: Vec<CborHolderAccount>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockControllerConfig {
+    pub controller_type: String,
+    pub simple_v0: Option<LockControllerSimpleV0Config>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockControllerSimpleV0Config {
+    pub grants: Vec<LockControllerGrant>,
+    pub token_ids: Vec<String>,
+    pub keep_alive: bool,
+    pub memo: Option<Memo>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockControllerGrant {
+    pub account: CborHolderAccount,
+    pub roles: Vec<String>,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize, Clone, Debug)]
+pub struct LockMetadataConfig {
+    pub name: Option<String>,
+    pub description: Option<String>,
+}
+
+pub fn events_from_meta_update(
+    events: &[MetaEvent],
+    payload: Option<&MetaUpdatePayload>,
+) -> anyhow::Result<Vec<super::Event>> {
+    let operations = payload
+        .map(MetaUpdatePayload::decode_operations)
+        .transpose()
+        .context("Failed decoding MetaUpdate operations")?;
+
+    let mut lock_create_events = events.iter().filter_map(|event| match event {
+        MetaEvent::LockCreate(event) => Some(event),
+        _ => None,
+    });
+    let destroyed_lock_ids = events
+        .iter()
+        .filter_map(|event| match event {
+            MetaEvent::LockDestroy(event) => Some(event.lock_id.to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    let mut output = Vec::new();
+    let mut canceled_lock_ids = Vec::new();
+
+    if let Some(operations) = operations {
+        for operation in operations.operations {
+            match operation {
+                MetaUpdateOperation::LockCreate(details) => {
+                    let emitted = lock_create_events.next();
+                    output.push(super::Event::LockCreated(LockCreated::from_operation(
+                        details, emitted,
+                    )?));
+                }
+                MetaUpdateOperation::LockFund(details) => {
+                    output.push(super::Event::LockFunded(details.into()));
+                }
+                MetaUpdateOperation::LockSend(details) => {
+                    output.push(super::Event::LockSent(details.into()));
+                }
+                MetaUpdateOperation::LockReturn(details) => {
+                    output.push(super::Event::LockReturned(details.into()));
+                }
+                MetaUpdateOperation::LockCancel(details) => {
+                    let lock_id = details.lock.to_string();
+                    let destroyed = destroyed_lock_ids.contains(&lock_id);
+                    canceled_lock_ids.push(lock_id);
+                    output.push(super::Event::LockCanceled(LockCanceled::from_operation(
+                        details, destroyed,
+                    )));
+                }
+                MetaUpdateOperation::Transfer(_)
+                | MetaUpdateOperation::Mint(_)
+                | MetaUpdateOperation::Burn(_)
+                | MetaUpdateOperation::AddAllowList(_)
+                | MetaUpdateOperation::RemoveAllowList(_)
+                | MetaUpdateOperation::AddDenyList(_)
+                | MetaUpdateOperation::RemoveDenyList(_)
+                | MetaUpdateOperation::Pause(_)
+                | MetaUpdateOperation::Unpause(_)
+                | MetaUpdateOperation::AssignAdminRoles(_)
+                | MetaUpdateOperation::RevokeAdminRoles(_)
+                | MetaUpdateOperation::UpdateMetadata(_) => {}
+            }
+        }
+    }
+
+    for event in events {
+        match event {
+            MetaEvent::Token(token_event) => {
+                output.push(super::Event::TokenUpdate(
+                    super::protocol_level_tokens::TokenUpdate {
+                        token_id: token_event.token_id.clone().into(),
+                        event: token_event.event.clone().into(),
+                    },
+                ));
+            }
+            MetaEvent::LockCreate(event) => {
+                if payload.is_none() {
+                    output.push(super::Event::LockCreated(LockCreated::from_emitted_event(
+                        event,
+                    )));
+                }
+            }
+            MetaEvent::LockDestroy(event) => {
+                let lock_id = event.lock_id.to_string();
+                if !canceled_lock_ids.contains(&lock_id) {
+                    output.push(super::Event::LockDestroyed(LockDestroyed { lock_id }));
+                }
+            }
+        }
+    }
+
+    Ok(output)
+}
+
+impl LockCreated {
+    fn from_operation(
+        details: MetaLockCreateDetails,
+        event: Option<&concordium_rust_sdk::protocol_level_tokens::LockCreateEvent>,
+    ) -> anyhow::Result<Self> {
+        let raw_config = event.map(|event| event.lock_config.to_string());
+        Ok(Self {
+            lock_id: event.map(|event| event.lock_id.to_string()),
+            config: Some(details.config.try_into()?),
+            raw_config_present: event.is_some(),
+            config_unavailable: false,
+            raw_config,
+        })
+    }
+
+    fn from_emitted_event(
+        event: &concordium_rust_sdk::protocol_level_tokens::LockCreateEvent,
+    ) -> Self {
+        let config = decode_lock_config(&event.lock_config)
+            .ok()
+            .and_then(|config| config.try_into().ok());
+        Self {
+            lock_id: Some(event.lock_id.to_string()),
+            config_unavailable: config.is_none(),
+            config,
+            raw_config_present: true,
+            raw_config: Some(event.lock_config.to_string()),
+        }
+    }
+}
+
+impl From<MetaLockFundDetails> for LockFunded {
+    fn from(details: MetaLockFundDetails) -> Self {
+        Self {
+            lock_id: details.lock.to_string(),
+            token_id: details.token.into(),
+            amount: details.amount.into(),
+            memo: details.memo.map(memo_from_cbor_memo),
+        }
+    }
+}
+
+impl From<MetaLockSendDetails> for LockSent {
+    fn from(details: MetaLockSendDetails) -> Self {
+        Self {
+            lock_id: details.lock.to_string(),
+            token_id: details.token.into(),
+            source: details.source.into(),
+            recipient: details.recipient.into(),
+            amount: details.amount.into(),
+            memo: details.memo.map(memo_from_cbor_memo),
+        }
+    }
+}
+
+impl From<MetaLockReturnDetails> for LockReturned {
+    fn from(details: MetaLockReturnDetails) -> Self {
+        Self {
+            lock_id: details.lock.to_string(),
+            token_id: details.token.into(),
+            source: details.source.into(),
+            amount: details.amount.into(),
+            memo: details.memo.map(memo_from_cbor_memo),
+        }
+    }
+}
+
+impl LockCanceled {
+    fn from_operation(details: MetaLockCancelDetails, destroyed: bool) -> Self {
+        Self {
+            lock_id: details.lock.to_string(),
+            memo: details.memo.map(memo_from_cbor_memo),
+            destroyed,
+        }
+    }
+}
+
+impl TryFrom<SdkLockConfig> for LockCreateConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(config: SdkLockConfig) -> anyhow::Result<Self> {
+        let expiry = DateTime::from_timestamp(config.expiry.seconds.try_into()?, 0)
+            .context("Failed to parse lock expiry")?;
+        Ok(Self {
+            expiry,
+            recipients: config.recipients.into(),
+            controller: config.controller.into(),
+            metadata: config
+                .metadata
+                .as_ref()
+                .and_then(|metadata| LockMetadata::decode_raw_cbor(metadata).ok())
+                .map(Into::into),
+        })
+    }
+}
+
+impl From<LockRecipients> for LockRecipientsConfig {
+    fn from(recipients: LockRecipients) -> Self {
+        match recipients {
+            LockRecipients::Any => Self {
+                recipient_type: "Any".to_string(),
+                accounts: Vec::new(),
+            },
+            LockRecipients::Limited(accounts) => Self {
+                recipient_type: "Limited".to_string(),
+                accounts: accounts.into_iter().map(Into::into).collect(),
+            },
+        }
+    }
+}
+
+impl From<LockController> for LockControllerConfig {
+    fn from(controller: LockController) -> Self {
+        match controller {
+            LockController::SimpleV0(simple_v0) => Self {
+                controller_type: "SimpleV0".to_string(),
+                simple_v0: Some(simple_v0.into()),
+            },
+        }
+    }
+}
+
+impl From<LockControllerSimpleV0> for LockControllerSimpleV0Config {
+    fn from(config: LockControllerSimpleV0) -> Self {
+        Self {
+            grants: config.grants.into_iter().map(Into::into).collect(),
+            token_ids: config.tokens.into_iter().map(Into::into).collect(),
+            keep_alive: config.keep_alive,
+            memo: config.memo.map(memo_from_cbor_memo),
+        }
+    }
+}
+
+impl From<LockControllerSimpleV0Grant> for LockControllerGrant {
+    fn from(grant: LockControllerSimpleV0Grant) -> Self {
+        Self {
+            account: grant.account.into(),
+            roles: grant.roles.into_iter().map(role_to_string).collect(),
+        }
+    }
+}
+
+impl From<LockMetadata> for LockMetadataConfig {
+    fn from(metadata: LockMetadata) -> Self {
+        Self {
+            name: metadata.name,
+            description: metadata.description,
+        }
+    }
+}
+
+fn decode_lock_config(raw_config: &RawCbor) -> anyhow::Result<SdkLockConfig> {
+    cbor::cbor_decode(raw_config.as_ref()).context("Failed decoding lock config")
+}
+
+fn memo_from_cbor_memo(memo: CborMemo) -> Memo {
+    let memo: concordium_rust_sdk::types::Memo = memo.into();
+    memo.into()
+}
+
+fn role_to_string(role: LockControllerSimpleV0Capability) -> String {
+    match role {
+        LockControllerSimpleV0Capability::Fund => "fund",
+        LockControllerSimpleV0Capability::Return => "return",
+        LockControllerSimpleV0Capability::Send => "send",
+        LockControllerSimpleV0Capability::Cancel => "cancel",
+    }
+    .to_string()
+}

--- a/backend/src/transaction_event/protocol_level_tokens.rs
+++ b/backend/src/transaction_event/protocol_level_tokens.rs
@@ -437,6 +437,8 @@ impl Memo {
 pub struct TokenTransferEvent {
     pub from: TokenHolder,
     pub to: TokenHolder,
+    pub from_lock: Option<String>,
+    pub to_lock: Option<String>,
     pub amount: TokenAmount,
     pub memo: Option<Memo>,
 }
@@ -498,6 +500,8 @@ impl From<concordium_rust_sdk::protocol_level_tokens::TokenEventDetails> for Tok
             TokenEventDetailsType::Transfer(e) => TokenEventDetails::Transfer(TokenTransferEvent {
                 from: e.from.into(),
                 to: e.to.into(),
+                from_lock: e.from_lock.map(|lock| lock.to_string()),
+                to_lock: e.to_lock.map(|lock| lock.to_string()),
                 amount: e.amount.into(),
                 memo: e.memo.map(Into::into),
             }),

--- a/backend/src/transaction_reject.rs
+++ b/backend/src/transaction_reject.rs
@@ -70,6 +70,14 @@ pub enum TransactionRejectReason {
     NonExistentTokenId(NonExistentTokenId),
     TokenUpdateTransactionFailed(TokenModuleReject),
     UnauthorizedTokenGovernance(UnauthorizedTokenGovernance),
+    NonExistentLockId(NonExistentLockId),
+    LockExpired(LockExpired),
+    LockFundNotAuthorized(LockFundNotAuthorized),
+    LockSendNotAuthorized(LockSendNotAuthorized),
+    LockReturnNotAuthorized(LockReturnNotAuthorized),
+    LockCancelNotAuthorized(LockCancelNotAuthorized),
+    LockTokenNotPermitted(LockTokenNotPermitted),
+    LockRecipientNotPermitted(LockRecipientNotPermitted),
 }
 
 #[derive(SimpleObject, serde::Serialize, serde::Deserialize, Clone, Copy)]
@@ -591,6 +599,46 @@ pub struct UnauthorizedTokenGovernance {
     pub token_id: String,
 }
 
+#[derive(SimpleObject, serde::Serialize, serde::Deserialize, Clone)]
+pub struct NonExistentLockId {
+    lock_id: String,
+}
+
+#[derive(SimpleObject, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LockExpired {
+    lock_id: String,
+}
+
+#[derive(SimpleObject, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LockFundNotAuthorized {
+    details: serde_json::Value,
+}
+
+#[derive(SimpleObject, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LockSendNotAuthorized {
+    details: serde_json::Value,
+}
+
+#[derive(SimpleObject, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LockReturnNotAuthorized {
+    details: serde_json::Value,
+}
+
+#[derive(SimpleObject, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LockCancelNotAuthorized {
+    details: serde_json::Value,
+}
+
+#[derive(SimpleObject, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LockTokenNotPermitted {
+    details: serde_json::Value,
+}
+
+#[derive(SimpleObject, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LockRecipientNotPermitted {
+    details: serde_json::Value,
+}
+
 /// TransactionRejectReason being prepared for indexing.
 /// Most reject reasons can just be inserted, but a few require some processing
 /// before inserting.
@@ -890,6 +938,46 @@ impl PreparedTransactionRejectReason {
                     .context(
                         "Failed to serialize token module transaction failure details to JSON",
                     )?,
+                })
+            }
+            RejectReason::NonExistentLockId { lock_id } => {
+                TransactionRejectReason::NonExistentLockId(NonExistentLockId {
+                    lock_id: lock_id.to_string(),
+                })
+            }
+            RejectReason::LockExpired { lock_id } => {
+                TransactionRejectReason::LockExpired(LockExpired {
+                    lock_id: lock_id.to_string(),
+                })
+            }
+            RejectReason::LockFundNotAuthorized { details } => {
+                TransactionRejectReason::LockFundNotAuthorized(LockFundNotAuthorized {
+                    details: serde_json::to_value(details)?,
+                })
+            }
+            RejectReason::LockSendNotAuthorized { details } => {
+                TransactionRejectReason::LockSendNotAuthorized(LockSendNotAuthorized {
+                    details: serde_json::to_value(details)?,
+                })
+            }
+            RejectReason::LockReturnNotAuthorized { details } => {
+                TransactionRejectReason::LockReturnNotAuthorized(LockReturnNotAuthorized {
+                    details: serde_json::to_value(details)?,
+                })
+            }
+            RejectReason::LockCancelNotAuthorized { details } => {
+                TransactionRejectReason::LockCancelNotAuthorized(LockCancelNotAuthorized {
+                    details: serde_json::to_value(details)?,
+                })
+            }
+            RejectReason::LockTokenNotPermitted { details } => {
+                TransactionRejectReason::LockTokenNotPermitted(LockTokenNotPermitted {
+                    details: serde_json::to_value(details)?,
+                })
+            }
+            RejectReason::LockRecipientNotPermitted { details } => {
+                TransactionRejectReason::LockRecipientNotPermitted(LockRecipientNotPermitted {
+                    details: serde_json::to_value(details)?,
                 })
             }
         };

--- a/backend/src/transaction_type.rs
+++ b/backend/src/transaction_type.rs
@@ -48,6 +48,7 @@ pub enum AccountTransactionType {
     ConfigureBaker,
     ConfigureDelegation,
     TokenUpdate,
+    MetaUpdate,
 }
 
 impl From<concordium_rust_sdk::types::TransactionType> for AccountTransactionType {
@@ -78,6 +79,7 @@ impl From<concordium_rust_sdk::types::TransactionType> for AccountTransactionTyp
             TT::ConfigureBaker => ATT::ConfigureBaker,
             TT::ConfigureDelegation => ATT::ConfigureDelegation,
             TT::TokenUpdate => ATT::TokenUpdate,
+            TT::MetaUpdate => ATT::MetaUpdate,
         }
     }
 }
@@ -133,6 +135,7 @@ pub enum UpdateTransactionType {
     GasRewardsCpv2Update,
     TimeoutParametersUpdate,
     MinBlockTimeUpdate,
+    MaxLockDurationUpdate,
     BlockEnergyLimitUpdate,
     FinalizationCommitteeParametersUpdate,
     ValidatorScoreParametersUpdate,

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Added display support for lock-aware PLT transfers and lock lifecycle events.
+- Added account related lock roles and header search results for locks.
+- Added labels for Locks/P11 reject reasons, `MetaUpdate`, and `MaxLockDurationUpdate`.
+
 ## [1.7.33] - 2026-05-05
 
 ### Added

--- a/frontend/src/components/Accounts/AccountDetailsContainer.vue
+++ b/frontend/src/components/Accounts/AccountDetailsContainer.vue
@@ -12,6 +12,7 @@
 		:go-to-page-account-rewards="goToPageAccountRewards"
 		:go-to-page-account-tokens="goToPageAccountTokens"
 		:go-to-page-plt="goToPagePlt"
+		:go-to-page-related-locks="goToPageRelatedLocks"
 	/>
 </template>
 
@@ -55,6 +56,14 @@ const {
 	after: afterPlt,
 	before: beforePlt,
 	goToPage: goToPagePlt,
+} = usePagination({ pageSize: PAGE_SIZE_SMALL })
+
+const {
+	first: firstRelatedLocks,
+	last: lastRelatedLocks,
+	after: afterRelatedLocks,
+	before: beforeRelatedLocks,
+	goToPage: goToPageRelatedLocks,
 } = usePagination({ pageSize: PAGE_SIZE_SMALL })
 
 const {
@@ -106,6 +115,10 @@ const transactionVariables = {
 	lastPlt,
 	afterPlt,
 	beforePlt,
+	firstRelatedLocks,
+	lastRelatedLocks,
+	afterRelatedLocks,
+	beforeRelatedLocks,
 }
 
 const { data, error, componentState, executeQuery } = useAccountQuery({

--- a/frontend/src/components/Accounts/AccountDetailsContent.vue
+++ b/frontend/src/components/Accounts/AccountDetailsContent.vue
@@ -52,6 +52,16 @@
 				</template>
 			</Accordion>
 			<Accordion>
+				Locks
+				<template #content>
+					<AccountDetailsLocks
+						:related-locks="account.relatedLocks.nodes || []"
+						:page-info="account.relatedLocks.pageInfo"
+						:go-to-page="goToPageRelatedLocks"
+					/>
+				</template>
+			</Accordion>
+			<Accordion>
 				Account statement
 				<template #content>
 					<AccountDetailsAccountStatement
@@ -133,6 +143,7 @@ import AccountDetailsAmounts from './AccountDetailsAmounts.vue'
 import AccountDetailsTransactions from './AccountDetailsTransactions.vue'
 import AccountDetailsToken from './AccountDetailsToken.vue'
 import AccountDetailsPlts from './AccountDetailsPlts.vue'
+import AccountDetailsLocks from './AccountDetailsLocks.vue'
 import AccountDetailsReleaseScheduleTransactions from './AccountDetailsReleaseScheduleTransactions.vue'
 import AccountDetailsAccountStatement from './AccountDetailsAccountStatement.vue'
 import DrawerContent from '~/components/Drawer/DrawerContent.vue'
@@ -162,6 +173,7 @@ type Props = {
 	goToPageAccountRewards: (page: PageInfo) => (target: PaginationTarget) => void
 	goToPageAccountTokens: (page: PageInfo) => (target: PaginationTarget) => void
 	goToPagePlt: (page: PageInfo) => (target: PaginationTarget) => void
+	goToPageRelatedLocks: (page: PageInfo) => (target: PaginationTarget) => void
 }
 
 defineProps<Props>()

--- a/frontend/src/components/Accounts/AccountDetailsLocks.vue
+++ b/frontend/src/components/Accounts/AccountDetailsLocks.vue
@@ -5,6 +5,7 @@
 				<TableRow>
 					<TableTh>Lock ID</TableTh>
 					<TableTh>Balance</TableTh>
+					<TableTh v-if="breakpoint >= Breakpoint.LG">Roles</TableTh>
 					<TableTh v-if="breakpoint >= Breakpoint.LG">Created</TableTh>
 					<TableTh v-if="breakpoint >= Breakpoint.MD">Expiry</TableTh>
 					<TableTh>Status</TableTh>
@@ -38,6 +39,12 @@
 							</div>
 						</div>
 						<span v-else class="text-theme-faded">No current balance</span>
+					</TableTd>
+					<TableTd v-if="breakpoint >= Breakpoint.LG">
+						<span v-if="relatedLock.roles.length" class="whitespace-normal">
+							{{ relatedLock.roles.join(', ') }}
+						</span>
+						<span v-else class="text-theme-faded">-</span>
 					</TableTd>
 					<TableTd v-if="breakpoint >= Breakpoint.LG">
 						{{ formatOptionalTimestamp(relatedLock.lock.createdAt) }}

--- a/frontend/src/components/Accounts/AccountDetailsLocks.vue
+++ b/frontend/src/components/Accounts/AccountDetailsLocks.vue
@@ -1,0 +1,98 @@
+<template>
+	<div>
+		<Table v-if="relatedLocks.length">
+			<TableHead>
+				<TableRow>
+					<TableTh>Lock ID</TableTh>
+					<TableTh>Balance</TableTh>
+					<TableTh v-if="breakpoint >= Breakpoint.LG">Created</TableTh>
+					<TableTh v-if="breakpoint >= Breakpoint.MD">Expiry</TableTh>
+					<TableTh>Status</TableTh>
+				</TableRow>
+			</TableHead>
+			<TableBody>
+				<TableRow
+					v-for="relatedLock in relatedLocks"
+					:key="relatedLock.lock.lockId"
+				>
+					<TableTd>
+						<LockLink :lock-id="relatedLock.lock.lockId" />
+					</TableTd>
+					<TableTd>
+						<div
+							v-if="relatedLock.accountBalances.length"
+							class="space-y-1"
+						>
+							<div
+								v-for="balance in relatedLock.accountBalances"
+								:key="`${relatedLock.lock.lockId}-${balance.tokenId}`"
+								class="whitespace-nowrap"
+							>
+								<PltAmount
+									:value="balance.amount.value"
+									:decimals="Number(balance.amount.decimals)"
+								/>
+								<span class="numerical text-theme-faded ml-1">
+									{{ balance.tokenId }}
+								</span>
+							</div>
+						</div>
+						<span v-else class="text-theme-faded">No current balance</span>
+					</TableTd>
+					<TableTd v-if="breakpoint >= Breakpoint.LG">
+						{{ formatOptionalTimestamp(relatedLock.lock.createdAt) }}
+					</TableTd>
+					<TableTd v-if="breakpoint >= Breakpoint.MD">
+						{{ formatOptionalTimestamp(relatedLock.lock.expiry) }}
+					</TableTd>
+					<TableTd>
+						<Badge :type="getStatusBadgeType(relatedLock.lock.status)">
+							{{ relatedLock.lock.status.toLowerCase() }}
+						</Badge>
+					</TableTd>
+				</TableRow>
+			</TableBody>
+		</Table>
+		<div v-else class="p-4">No locks</div>
+		<div class="mt-8">
+			<Pagination
+				v-if="pageInfo"
+				:page-info="pageInfo"
+				:go-to-page="goToPage"
+			/>
+		</div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import LockLink from '~/components/molecules/LockLink.vue'
+import PltAmount from '~/components/atoms/PltAmount.vue'
+import Badge from '~/components/Badge.vue'
+import { Breakpoint, useBreakpoint } from '~/composables/useBreakpoint'
+import type {
+	AccountRelatedLock,
+	PageInfo,
+} from '~/types/generated'
+import { LockStatus } from '~/types/generated'
+import { formatTimestamp } from '~/utils/format'
+import type { PaginationTarget } from '~/composables/usePagination'
+
+type Props = {
+	relatedLocks: AccountRelatedLock[]
+	pageInfo: PageInfo
+	goToPage: (page: PageInfo) => (target: PaginationTarget) => void
+}
+
+defineProps<Props>()
+
+const { breakpoint } = useBreakpoint()
+
+const formatOptionalTimestamp = (timestamp?: string | null) =>
+	timestamp ? formatTimestamp(timestamp) : '-'
+
+const getStatusBadgeType = (status: LockStatus) => {
+	if (status === LockStatus.Active) return 'success'
+	if (status === LockStatus.Expired) return 'info'
+	return 'failure'
+}
+</script>

--- a/frontend/src/components/Drawer/DrawerContainer.vue
+++ b/frontend/src/components/Drawer/DrawerContainer.vue
@@ -76,6 +76,10 @@
 							:contract-address-index="drawerItem.contractAddressIndex"
 							:contract-address-sub-index="drawerItem.contractAddressSubIndex"
 						/>
+						<LockDetailsContainer
+							v-else-if="drawerItem && drawerItem.entityTypeName === 'lock'"
+							:lock-id="drawerItem.lockId"
+						/>
 					</template>
 				</Drawer>
 			</div>
@@ -96,6 +100,7 @@ import NodeDetailsContainer from '~/components/NodeDetails/NodeDetailsContainer.
 import ContractDetailsContainer from '~/components/Contracts/ContractDetailsContainer.vue'
 import ModuleDetailsContainer from '~/components/Module/ModuleDetailsContainer.vue'
 import TokenDetailsContainer from '~/components/Tokens/TokenDetailsContainer.vue'
+import LockDetailsContainer from '~/components/Locks/LockDetailsContainer.vue'
 
 const { softReset, getDisplayItems, currentDrawerCount, currentTopItem } =
 	useDrawer()

--- a/frontend/src/components/Locks/LockDetailsContainer.vue
+++ b/frontend/src/components/Locks/LockDetailsContainer.vue
@@ -1,0 +1,29 @@
+<template>
+	<Loader v-if="componentState === 'loading'" />
+	<NotFound v-else-if="componentState === 'empty'" class="pt-20" />
+	<Error v-else-if="componentState === 'error'" :error="error" class="pt-20" />
+	<LockDetailsContent
+		v-else-if="componentState === 'success' && data?.lock"
+		:lock="data.lock"
+		:fetching="fetching"
+	/>
+</template>
+
+<script lang="ts" setup>
+import LockDetailsContent from './LockDetailsContent.vue'
+import Error from '~/components/molecules/Error.vue'
+import Loader from '~/components/molecules/Loader.vue'
+import NotFound from '~/components/molecules/NotFound.vue'
+import { useLockQuery } from '~/queries/useLockQuery'
+
+type Props = {
+	lockId: string
+}
+
+const props = defineProps<Props>()
+const lockId = toRef(props, 'lockId')
+
+const { data, error, componentState, fetching } = useLockQuery({
+	lockId,
+})
+</script>

--- a/frontend/src/components/Locks/LockDetailsContent.vue
+++ b/frontend/src/components/Locks/LockDetailsContent.vue
@@ -1,0 +1,238 @@
+<template>
+	<LockDetailsHeader :lock="lock" />
+	<DrawerContent>
+		<div class="grid gap-8 md:grid-cols-3 mb-12">
+			<DetailsCard v-if="lock.createdAt">
+				<template #title>Created</template>
+				<template #default>
+					{{ formatTimestamp(lock.createdAt) }}
+				</template>
+				<template v-if="lock.createdTransaction" #secondary>
+					<TransactionLink :hash="lock.createdTransaction.transactionHash" />
+				</template>
+			</DetailsCard>
+			<DetailsCard v-if="lock.expiry">
+				<template #title>Expiry</template>
+				<template #default>
+					{{ formatTimestamp(lock.expiry) }}
+				</template>
+			</DetailsCard>
+			<DetailsCard v-if="lock.canceledAt">
+				<template #title>Canceled</template>
+				<template #default>
+					{{ formatTimestamp(lock.canceledAt) }}
+				</template>
+				<template v-if="lock.canceledTransaction" #secondary>
+					<TransactionLink :hash="lock.canceledTransaction.transactionHash" />
+				</template>
+			</DetailsCard>
+			<DetailsCard v-if="lock.creator?.address.asString">
+				<template #title>Creator</template>
+				<template #default>
+					<AccountLink
+						icon-size="big"
+						:address="lock.creator.address.asString"
+					/>
+				</template>
+			</DetailsCard>
+			<DetailsCard v-if="metadataName">
+				<template #title>Name</template>
+				<template #default>{{ metadataName }}</template>
+			</DetailsCard>
+			<DetailsCard v-if="metadataDescription" class="md:col-span-2">
+				<template #title>Description</template>
+				<template #default>{{ metadataDescription }}</template>
+			</DetailsCard>
+		</div>
+	</DrawerContent>
+
+	<DrawerContent>
+		<section class="mb-12">
+			<h2 class="text-xl mb-4">Current balances</h2>
+			<Table v-if="lock.balances.length" :class="{ fetching }">
+				<TableHead>
+					<TableRow>
+						<TableTh>Account</TableTh>
+						<TableTh>Token</TableTh>
+						<TableTh align="right">Amount</TableTh>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					<TableRow
+						v-for="balance in lock.balances"
+						:key="`${balance.accountAddress.asString}-${balance.tokenId}`"
+					>
+						<TableTd>
+							<AccountLink :address="balance.accountAddress.asString" />
+						</TableTd>
+						<TableTd>
+							<span class="numerical">{{ balance.tokenId }}</span>
+						</TableTd>
+						<TableTd align="right">
+							<PltAmount
+								:value="balance.amount.value"
+								:decimals="Number(balance.amount.decimals)"
+							/>
+						</TableTd>
+					</TableRow>
+				</TableBody>
+			</Table>
+			<p v-else class="text-theme-faded">No current locked balances.</p>
+		</section>
+	</DrawerContent>
+
+	<DrawerContent>
+		<section class="mb-12">
+			<h2 class="text-xl mb-4">Configuration</h2>
+			<div v-if="lock.config" class="grid gap-8 md:grid-cols-2">
+				<div>
+					<h3 class="text-sm text-theme-faded mb-2">Recipients</h3>
+					<p v-if="lock.config.recipients.recipientType === 'Any'">
+						Any eligible recipient
+					</p>
+					<ul v-else class="space-y-2">
+						<li
+							v-for="account in lock.config.recipients.accounts"
+							:key="account.address.asString"
+						>
+							<AccountLink :address="account.address.asString" />
+						</li>
+					</ul>
+				</div>
+				<div v-if="simpleController">
+					<h3 class="text-sm text-theme-faded mb-2">Controller</h3>
+					<p>
+						SimpleV0
+						<span v-if="simpleController.keepAlive" class="text-theme-faded">
+							keep alive
+						</span>
+					</p>
+					<p v-if="simpleController.tokenIds.length" class="mt-2">
+						Tokens:
+						<span class="numerical">{{ simpleController.tokenIds.join(', ') }}</span>
+					</p>
+				</div>
+				<div v-if="simpleController?.grants.length" class="md:col-span-2">
+					<h3 class="text-sm text-theme-faded mb-2">Controller grants</h3>
+					<Table>
+						<TableHead>
+							<TableRow>
+								<TableTh>Account</TableTh>
+								<TableTh>Roles</TableTh>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							<TableRow
+								v-for="grant in simpleController.grants"
+								:key="grant.account.address.asString"
+							>
+								<TableTd>
+									<AccountLink :address="grant.account.address.asString" />
+								</TableTd>
+								<TableTd>{{ grant.roles.join(', ') }}</TableTd>
+							</TableRow>
+						</TableBody>
+					</Table>
+				</div>
+			</div>
+			<p v-else-if="lock.rawConfig" class="text-theme-faded">
+				Raw config is indexed, but decoded config is unavailable.
+			</p>
+			<p v-else class="text-theme-faded">No decoded configuration available.</p>
+		</section>
+	</DrawerContent>
+
+	<DrawerContent>
+		<section class="mb-12">
+			<h2 class="text-xl mb-4">Lifecycle history</h2>
+			<Table v-if="historyItems.length" :class="{ fetching }">
+				<TableHead>
+					<TableRow>
+						<TableTh>Transaction</TableTh>
+						<TableTh>Type</TableTh>
+						<TableTh>Time</TableTh>
+						<TableTh>Details</TableTh>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					<TableRow v-for="event in historyItems" :key="event.id">
+						<TableTd>
+							<TransactionLink :hash="event.transaction.transactionHash" />
+						</TableTd>
+						<TableTd>{{ formatEventType(event.eventType) }}</TableTd>
+						<TableTd>{{ formatTimestamp(event.slotTime) }}</TableTd>
+						<TableTd>
+							<template v-if="event.amount">
+								<PltAmount
+									:value="event.amount.value"
+									:decimals="Number(event.amount.decimals)"
+								/>
+								<span v-if="event.tokenId" class="numerical ml-1">
+									{{ event.tokenId }}
+								</span>
+							</template>
+							<template v-if="event.account?.address.asString">
+								<span class="mx-1 text-theme-faded">account</span>
+								<AccountLink :address="event.account.address.asString" />
+							</template>
+							<template v-if="event.source?.address.asString">
+								<span class="mx-1 text-theme-faded">from</span>
+								<AccountLink :address="event.source.address.asString" />
+							</template>
+							<template v-if="event.recipient?.address.asString">
+								<span class="mx-1 text-theme-faded">to</span>
+								<AccountLink :address="event.recipient.address.asString" />
+							</template>
+						</TableTd>
+					</TableRow>
+				</TableBody>
+			</Table>
+			<p v-else class="text-theme-faded">No lifecycle history indexed.</p>
+			<p v-if="lock.history.pageInfo.hasNextPage" class="text-theme-faded mt-4">
+				Showing the first 50 history events.
+			</p>
+		</section>
+	</DrawerContent>
+</template>
+
+<script lang="ts" setup>
+import LockDetailsHeader from './LockDetailsHeader.vue'
+import DrawerContent from '~/components/Drawer/DrawerContent.vue'
+import DetailsCard from '~/components/DetailsCard.vue'
+import PltAmount from '~/components/atoms/PltAmount.vue'
+import AccountLink from '~/components/molecules/AccountLink.vue'
+import TransactionLink from '~/components/molecules/TransactionLink.vue'
+import { formatTimestamp } from '~/utils/format'
+import type { Lock } from '~/types/generated'
+
+type Props = {
+	lock: Lock
+	fetching: boolean
+}
+
+const props = defineProps<Props>()
+
+const metadataName = computed(
+	() => props.lock.config?.metadata?.name ?? props.lock.metadataName
+)
+const metadataDescription = computed(
+	() => props.lock.config?.metadata?.description ?? props.lock.metadataDescription
+)
+const simpleController = computed(
+	() => props.lock.config?.controller.simpleV0 ?? null
+)
+const historyItems = computed(() => props.lock.history.nodes ?? [])
+
+const formatEventType = (eventType: string) =>
+	eventType
+		.toLowerCase()
+		.split('_')
+		.map(part => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ')
+</script>
+
+<style scoped>
+.fetching tbody tr {
+	opacity: 0.4;
+}
+</style>

--- a/frontend/src/components/Locks/LockDetailsHeader.vue
+++ b/frontend/src/components/Locks/LockDetailsHeader.vue
@@ -1,0 +1,45 @@
+<template>
+	<DrawerTitle class="flex flex-row flex-wrap">
+		<LockClosedIcon class="w-10 h-10 mr-6 hidden md:block" />
+
+		<div class="flex flex-wrap flex-grow w-1/2">
+			<h3 class="w-full text-sm text-theme-faded">Lock</h3>
+			<div class="w-full flex items-center justify-items-stretch">
+				<h1 class="inline-block text-2xl numerical">
+					{{ shortenHash(lock.lockId) }}
+				</h1>
+				<TextCopy
+					:text="lock.lockId"
+					label="Click to copy lock ID to clipboard"
+					class="mx-3"
+					icon-size="h-5 w-5"
+					tooltip-class="font-sans"
+				/>
+				<Badge :type="statusBadgeType">
+					{{ lock.status.toLowerCase() }}
+				</Badge>
+			</div>
+		</div>
+	</DrawerTitle>
+</template>
+
+<script lang="ts" setup>
+import { LockClosedIcon } from '@heroicons/vue/solid/index.js'
+import DrawerTitle from '~/components/Drawer/DrawerTitle.vue'
+import Badge from '~/components/Badge.vue'
+import TextCopy from '~/components/atoms/TextCopy.vue'
+import { shortenHash } from '~/utils/format'
+import { LockStatus, type Lock } from '~/types/generated'
+
+type Props = {
+	lock: Lock
+}
+
+const props = defineProps<Props>()
+
+const statusBadgeType = computed(() => {
+	if (props.lock.status === LockStatus.Active) return 'success'
+	if (props.lock.status === LockStatus.Expired) return 'info'
+	return 'failure'
+})
+</script>

--- a/frontend/src/components/Search/Search.vue
+++ b/frontend/src/components/Search/Search.vue
@@ -12,7 +12,7 @@
 				v-model="searchValue"
 				:class="$style.input"
 				class="rounded p-2 w-full focus:ring-2 focus:ring-pink-500 outline-none md:block pl-9"
-				placeholder="Search for account, validator, block, transaction, PLT token &hellip;"
+				placeholder="Search for account, validator, block, transaction, PLT token, lock &hellip;"
 				type="search"
 				@blur="lostFocusOnSearch"
 				@keyup.enter="gotoSearchResult"
@@ -214,6 +214,32 @@
 						</div>
 					</SearchResultCategory>
 					<SearchResultCategory
+						v-if="resultCount.locks"
+						title="Locks"
+						:has-more-results="data.search.locks.pageInfo.hasNextPage"
+					>
+						<div
+							v-for="lock in data.search.locks.nodes"
+							:key="lock.lockId"
+							:class="$style.searchColumns"
+						>
+							<LockLink
+								:lock-id="lock.lockId"
+								:hide-tooltip="true"
+								@blur="lostFocusOnSearch"
+							/>
+							<div :class="$style.twoColumns">
+								{{ lock.status }}
+							</div>
+							<div :class="$style.threeColumns">
+								Age
+								<Tooltip :text="formatTimestamp(lock.createdAt)">
+									{{ convertTimestampToRelative(lock.createdAt || '', NOW) }}
+								</Tooltip>
+							</div>
+						</div>
+					</SearchResultCategory>
+					<SearchResultCategory
 						v-if="resultCount.modules"
 						title="Modules"
 						:has-more-results="data.search.modules.pageInfo.hasNextPage"
@@ -310,6 +336,7 @@ import AccountLink from '~/components/molecules/AccountLink.vue'
 import ContractLink from '~/components/molecules/ContractLink.vue'
 import { useDateNow } from '~/composables/useDateNow'
 import NodeLink from '~/components/molecules/NodeLink.vue'
+import LockLink from '~/components/molecules/LockLink.vue'
 
 const { NOW } = useDateNow()
 const drawer = useDrawer()
@@ -396,7 +423,11 @@ const gotoSearchResult = async () => {
 			`/protocol-token/${data.value.search.pltTokens.nodes[0].tokenId}`
 		)
 		return
-	}
+	} else if (data.value.search.locks.nodes[0])
+		drawer.push({
+			entityTypeName: 'lock',
+			lockId: data.value.search.locks.nodes[0].lockId,
+		})
 	searchValue.value = ''
 	status.value = 'idle'
 	isMaskVisible.value = false
@@ -422,6 +453,7 @@ const resultCount = computed(() => ({
 	nodeStatuses: data.value?.search.nodeStatuses.nodes.length,
 	tokens: data.value?.search.tokens.nodes.length,
 	pltTokens: data.value?.search.pltTokens.nodes.length,
+	locks: data.value?.search.locks.nodes.length,
 	total:
 		(data.value?.search.contracts.nodes.length ?? 0) +
 		(data.value?.search.blocks.nodes.length ?? 0) +
@@ -431,7 +463,8 @@ const resultCount = computed(() => ({
 		(data.value?.search.nodeStatuses.nodes.length ?? 0) +
 		(data.value?.search.modules?.nodes.length ?? 0) +
 		(data.value?.search.tokens?.nodes.length ?? 0) +
-		(data.value?.search.pltTokens?.nodes.length ?? 0),
+		(data.value?.search.pltTokens?.nodes.length ?? 0) +
+		(data.value?.search.locks?.nodes.length ?? 0),
 }))
 </script>
 

--- a/frontend/src/components/Search/Search.vue
+++ b/frontend/src/components/Search/Search.vue
@@ -21,7 +21,8 @@
 
 		<div
 			v-if="searchValue !== ''"
-			class="left-0 lg:left-auto absolute border-theme-selected border solid rounded-lg p-4 bg-theme-background-primary-elevated-nontrans w-full z-20"
+			class="left-0 lg:left-auto absolute border-theme-selected border solid rounded-lg p-4 bg-theme-background-primary-elevated-nontrans z-20"
+			:class="$style.resultsPanel"
 			@click="searchValue = ''"
 		>
 			<div class="overflow-hidden whitespace-nowrap overflow-ellipsis">
@@ -509,6 +510,10 @@ const resultCount = computed(() => ({
 
 .container {
 	max-width: 600px;
+}
+
+.resultsPanel {
+	width: min(400px, calc(100vw - 2.5rem));
 }
 
 .mask {

--- a/frontend/src/components/TransactionEventList/Events/ChainUpdateEnqueued.vue
+++ b/frontend/src/components/TransactionEventList/Events/ChainUpdateEnqueued.vue
@@ -535,6 +535,23 @@
 			</DescriptionList>
 		</span>
 		<span
+			v-else-if="event.payload.__typename === 'MaxLockDurationUpdate'"
+			class="text-theme-faded"
+		>
+			Updated max lock duration to:
+
+			<DescriptionList class="mt-4 ml-8">
+				<DescriptionListItem>
+					Duration
+					<template #content>
+						<span class="numerical">
+							{{ formatNumber(event.payload.durationSeconds) }}s
+						</span>
+					</template>
+				</DescriptionListItem>
+			</DescriptionList>
+		</span>
+		<span
 			v-else-if="event.payload.__typename === 'CreatePltUpdate'"
 			class="text-theme-faded"
 		>

--- a/frontend/src/components/TransactionEventList/Events/LockEvents.vue
+++ b/frontend/src/components/TransactionEventList/Events/LockEvents.vue
@@ -1,0 +1,113 @@
+<template>
+	<span v-if="event.__typename === 'LockCreated'">
+		Created lock
+		<LockLink v-if="event.lockId" :lock-id="event.lockId" />
+		<template v-else>with pending lock ID</template>
+		<template v-if="event.config?.metadata?.name">
+			named <b>{{ event.config.metadata.name }}</b>
+		</template>
+		<template v-if="event.config">
+			expiring {{ formatTimestamp(event.config.expiry) }}
+			for
+			<template v-if="event.config.recipients.recipientType === 'Any'">
+				any eligible recipient
+			</template>
+			<template v-else>
+				<template
+					v-for="(account, i) in event.config.recipients.accounts"
+					:key="account.address.asString"
+				>
+					<AccountLink :address="account.address.asString" />
+					<template
+						v-if="i < event.config.recipients.accounts.length - 1"
+					>, </template>
+				</template>
+			</template>
+			<template v-if="event.config.controller.simpleV0">
+				<span>
+					(SimpleV0<template
+						v-if="event.config.controller.simpleV0.keepAlive"
+					>, keep alive</template
+					><template v-if="event.config.controller.simpleV0.tokenIds.length">
+						; tokens
+						<b>{{ event.config.controller.simpleV0.tokenIds.join(', ') }}</b></template
+					>)
+				</span>
+			</template>
+		</template>
+		<template v-else-if="event.configUnavailable">
+			with unavailable config
+		</template>
+	</span>
+
+	<span v-else-if="event.__typename === 'LockFunded'">
+		Funded lock <LockLink :lock-id="event.lockId" /> with
+		<PltAmount
+			:value="event.amount.value"
+			:decimals="Number(event.amount.decimals)"
+		/>
+		<b>{{ event.tokenId }}</b>
+		<PltTransferMemo v-if="event.memo" :memo="event.memo" />
+	</span>
+
+	<span v-else-if="event.__typename === 'LockSent'">
+		Sent
+		<PltAmount
+			:value="event.amount.value"
+			:decimals="Number(event.amount.decimals)"
+		/>
+		<b>{{ event.tokenId }}</b> from lock <LockLink :lock-id="event.lockId" />
+		held by <AccountLink :address="event.source.address.asString" /> to
+		<AccountLink :address="event.recipient.address.asString" />
+		<PltTransferMemo v-if="event.memo" :memo="event.memo" />
+	</span>
+
+	<span v-else-if="event.__typename === 'LockReturned'">
+		Returned
+		<PltAmount
+			:value="event.amount.value"
+			:decimals="Number(event.amount.decimals)"
+		/>
+		<b>{{ event.tokenId }}</b> from lock <LockLink :lock-id="event.lockId" />
+		to <AccountLink :address="event.source.address.asString" />
+		<PltTransferMemo v-if="event.memo" :memo="event.memo" />
+	</span>
+
+	<span v-else-if="event.__typename === 'LockCanceled'">
+		Canceled lock <LockLink :lock-id="event.lockId" />
+		<template v-if="event.destroyed"> and destroyed it</template>
+		<PltTransferMemo v-if="event.memo" :memo="event.memo" />
+	</span>
+
+	<span v-else-if="event.__typename === 'LockDestroyed'">
+		Destroyed lock <LockLink :lock-id="event.lockId" />
+	</span>
+</template>
+
+<script setup lang="ts">
+import type {
+	LockCanceled,
+	LockCreated,
+	LockDestroyed,
+	LockFunded,
+	LockReturned,
+	LockSent,
+} from '~/types/generated'
+import { formatTimestamp } from '~/utils/format'
+import LockLink from '~/components/molecules/LockLink.vue'
+import PltTransferMemo from './PltTransferMemo.vue'
+
+type LockEvent =
+	| LockCreated
+	| LockFunded
+	| LockSent
+	| LockReturned
+	| LockCanceled
+	| LockDestroyed
+
+type Props = {
+	event: LockEvent
+}
+
+defineProps<Props>()
+</script>

--- a/frontend/src/components/TransactionEventList/Events/TokenEvents.vue
+++ b/frontend/src/components/TransactionEventList/Events/TokenEvents.vue
@@ -8,14 +8,12 @@
 		<b>{{ event.tokenId }}</b> from
 		<AccountLink :address="event.event.from.address.asString" />
 		<template v-if="event.event.fromLock">
-			(source lock <b>{{ event.event.fromLock }}</b
-			>)
+			(source lock <LockLink :lock-id="event.event.fromLock" />)
 		</template>
 		to
 		<AccountLink :address="event.event.to.address.asString" />
 		<template v-if="event.event.toLock">
-			(destination lock <b>{{ event.event.toLock }}</b
-			>)
+			(destination lock <LockLink :lock-id="event.event.toLock" />)
 		</template>
 		<PltTransferMemo v-if="event.event.memo" :memo="event.event.memo" />
 	</span>
@@ -150,6 +148,7 @@
 import type { TokenUpdate } from '~/types/generated'
 import PltTransferMemo from './PltTransferMemo.vue'
 import ExternalLinkIcon from '~/components/icons/ExternalLinkIcon.vue'
+import LockLink from '~/components/molecules/LockLink.vue'
 
 type Props = {
 	event: TokenUpdate

--- a/frontend/src/components/TransactionEventList/Events/TokenEvents.vue
+++ b/frontend/src/components/TransactionEventList/Events/TokenEvents.vue
@@ -6,8 +6,17 @@
 			:decimals="Number(event.event.amount.decimals)"
 		/>
 		<b>{{ event.tokenId }}</b> from
-		<AccountLink :address="event.event.from.address.asString" /> to
+		<AccountLink :address="event.event.from.address.asString" />
+		<template v-if="event.event.fromLock">
+			(source lock <b>{{ event.event.fromLock }}</b
+			>)
+		</template>
+		to
 		<AccountLink :address="event.event.to.address.asString" />
+		<template v-if="event.event.toLock">
+			(destination lock <b>{{ event.event.toLock }}</b
+			>)
+		</template>
 		<PltTransferMemo v-if="event.event.memo" :memo="event.event.memo" />
 	</span>
 

--- a/frontend/src/components/TransactionEventList/TransactionEventList.vue
+++ b/frontend/src/components/TransactionEventList/TransactionEventList.vue
@@ -186,6 +186,18 @@
 					:event="event"
 				/>
 
+				<LockEvents
+					v-else-if="
+						event.__typename === 'LockCreated' ||
+						event.__typename === 'LockFunded' ||
+						event.__typename === 'LockSent' ||
+						event.__typename === 'LockReturned' ||
+						event.__typename === 'LockCanceled' ||
+						event.__typename === 'LockDestroyed'
+					"
+					:event="event"
+				/>
+
 				<span v-else>Transaction event: {{ event.__typename }}</span>
 			</li>
 		</ul>
@@ -235,6 +247,7 @@ import DelegationSetDelegationTarget from '~/components/TransactionEventList/Eve
 import DelegationAdded from '~/components/TransactionEventList/Events/DelegationAdded.vue'
 import TokenEvents from '~/components/TransactionEventList/Events/TokenEvents.vue'
 import TokenCreationDetails from '~/components/TransactionEventList/Events/TokenCreationDetails.vue'
+import LockEvents from '~/components/TransactionEventList/Events/LockEvents.vue'
 import DelegationRemoved from '~/components/TransactionEventList/Events/DelegationRemoved.vue'
 import { PAGE_SIZE } from '~/composables/usePagination'
 import type { PaginationTarget } from '~/composables/usePagination'

--- a/frontend/src/components/molecules/LockLink.vue
+++ b/frontend/src/components/molecules/LockLink.vue
@@ -1,0 +1,29 @@
+<template>
+	<div v-if="props.lockId" class="inline-block whitespace-nowrap">
+		<LockClosedIcon class="h-4 w-4 text-theme-white inline align-text-top" />
+		<span class="numerical px-2">
+			<Tooltip :text="props.lockId" text-class="text-theme-body">
+				{{ shortenHash(props.lockId) }}
+			</Tooltip>
+		</span>
+		<TextCopy
+			:text="props.lockId"
+			label="Click to copy lock ID to clipboard"
+			class="h-5 inline align-baseline"
+			tooltip-class="font-sans"
+		/>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import { LockClosedIcon } from '@heroicons/vue/solid/index.js'
+import { shortenHash } from '~/utils/format'
+import TextCopy from '~/components/atoms/TextCopy.vue'
+import Tooltip from '~/components/atoms/Tooltip.vue'
+
+type Props = {
+	lockId?: string | null
+}
+
+const props = defineProps<Props>()
+</script>

--- a/frontend/src/components/molecules/LockLink.vue
+++ b/frontend/src/components/molecules/LockLink.vue
@@ -1,11 +1,25 @@
 <template>
 	<div v-if="props.lockId" class="inline-block whitespace-nowrap">
-		<LockClosedIcon class="h-4 w-4 text-theme-white inline align-text-top" />
-		<span class="numerical px-2">
-			<Tooltip :text="props.lockId" text-class="text-theme-body">
+		<LockClosedIcon
+			v-if="props.iconSize == 'big'"
+			class="h-5 inline align-text-top mr-3"
+		/>
+		<LockClosedIcon
+			v-else
+			class="h-4 w-4 text-theme-white inline align-text-top"
+		/>
+		<LinkButton
+			class="numerical px-2"
+			@blur="emitBlur"
+			@click="() => handleOnClick(props.lockId)"
+		>
+			<div v-if="props.hideTooltip" text-class="text-theme-body">
+				{{ shortenHash(props.lockId) }}
+			</div>
+			<Tooltip v-else :text="props.lockId" text-class="text-theme-body">
 				{{ shortenHash(props.lockId) }}
 			</Tooltip>
-		</span>
+		</LinkButton>
 		<TextCopy
 			:text="props.lockId"
 			label="Click to copy lock ID to clipboard"
@@ -20,10 +34,23 @@ import { LockClosedIcon } from '@heroicons/vue/solid/index.js'
 import { shortenHash } from '~/utils/format'
 import TextCopy from '~/components/atoms/TextCopy.vue'
 import Tooltip from '~/components/atoms/Tooltip.vue'
+import LinkButton from '~/components/atoms/LinkButton.vue'
+import { useDrawer } from '~/composables/useDrawer'
 
 type Props = {
 	lockId?: string | null
+	iconSize?: string
+	hideTooltip?: boolean
 }
 
 const props = defineProps<Props>()
+const drawer = useDrawer()
+const emit = defineEmits(['blur'])
+const emitBlur = (newTarget: FocusEvent) => {
+	emit('blur', newTarget)
+}
+
+const handleOnClick = (lockId?: string | null) => {
+	if (lockId) drawer.push({ entityTypeName: 'lock', lockId })
+}
 </script>

--- a/frontend/src/composables/useDrawer.ts
+++ b/frontend/src/composables/useDrawer.ts
@@ -67,6 +67,11 @@ type TokenDrawerItem = {
 	contractAddressSubIndex: number
 }
 
+type LockDrawerItem = {
+	entityTypeName: 'lock'
+	lockId: string
+}
+
 export type DrawerItem = (
 	| BlockDrawerItem
 	| TxDrawerItem
@@ -79,6 +84,7 @@ export type DrawerItem = (
 	| SuspendedValidatorsItem
 	| NodeDrawerItem
 	| TokenDrawerItem
+	| LockDrawerItem
 ) & {
 	scrollY?: number
 }
@@ -169,6 +175,12 @@ export const isItemOnTop = (
 			item.contractAddressSubIndex ===
 				currentTopItem.value.contractAddressSubIndex
 		)
+	}
+	if (
+		item.entityTypeName === 'lock' &&
+		item.entityTypeName === currentTopItem.value.entityTypeName
+	) {
+		return !!(item.lockId && item.lockId === currentTopItem.value.lockId)
 	}
 
 	if (
@@ -269,6 +281,15 @@ export const pushToRouter =
 						dcontractAddressIndex: drawerItem.contractAddressIndex ?? undefined,
 						dcontractAddressSubIndex:
 							drawerItem.contractAddressSubIndex ?? undefined,
+					},
+				})
+				break
+			case 'lock':
+				router.push({
+					query: {
+						dcount,
+						dentity,
+						dlockId: drawerItem.lockId ?? undefined,
 					},
 				})
 				break
@@ -382,6 +403,14 @@ export const useDrawer = () => {
 					route.query.dcontractAddressSubIndex as string
 				),
 			})
+		} else if (route.query.dentity === 'lock' && route.query.dlockId) {
+			push(
+				{
+					entityTypeName: 'lock',
+					lockId: route.query.dlockId as string,
+				},
+				false
+			)
 		} else router.push({ query: {} })
 	}
 

--- a/frontend/src/pages/protocol-token/index.vue
+++ b/frontend/src/pages/protocol-token/index.vue
@@ -178,22 +178,26 @@
 							</a>
 						</TableTd>
 						<TableTd>
-							<AccountLink
-								:address="
-									event.tokenEvent.__typename == 'TokenTransferEvent'
-										? event.tokenEvent.from.address.asString
-										: ''
-								"
-							/>
+							<template v-if="event.tokenEvent.__typename == 'TokenTransferEvent'">
+								<AccountLink :address="event.tokenEvent.from.address.asString" />
+								<div
+									v-if="event.tokenEvent.fromLock"
+									class="text-xs text-theme-text-secondary break-all"
+								>
+									Lock: {{ event.tokenEvent.fromLock }}
+								</div>
+							</template>
 						</TableTd>
 						<TableTd>
-							<AccountLink
-								:address="
-									event.tokenEvent.__typename == 'TokenTransferEvent'
-										? event.tokenEvent.to.address.asString
-										: ''
-								"
-							/>
+							<template v-if="event.tokenEvent.__typename == 'TokenTransferEvent'">
+								<AccountLink :address="event.tokenEvent.to.address.asString" />
+								<div
+									v-if="event.tokenEvent.toLock"
+									class="text-xs text-theme-text-secondary break-all"
+								>
+									Lock: {{ event.tokenEvent.toLock }}
+								</div>
+							</template>
 						</TableTd>
 						<TableTd>
 							<AccountLink

--- a/frontend/src/queries/useAccountQuery.ts
+++ b/frontend/src/queries/useAccountQuery.ts
@@ -21,6 +21,10 @@ type AccountQueryVariables = {
 	beforePlt: QueryVariables['before']
 	firstPlt: QueryVariables['first']
 	lastPlt: QueryVariables['last']
+	afterRelatedLocks: QueryVariables['after']
+	beforeRelatedLocks: QueryVariables['before']
+	firstRelatedLocks: QueryVariables['first']
+	lastRelatedLocks: QueryVariables['last']
 }
 
 type AccountByIdResponse = {
@@ -69,6 +73,36 @@ plts(
             tokenId
             decimal
             amount
+		}
+	}
+
+	relatedLocks(
+		after: $afterRelatedLocks
+		before: $beforeRelatedLocks
+		first: $firstRelatedLocks
+		last: $lastRelatedLocks
+	) {
+		pageInfo {
+			hasNextPage
+			hasPreviousPage
+			startCursor
+			endCursor
+			__typename
+		}
+		nodes {
+			lock {
+				lockId
+				createdAt
+				expiry
+				status
+			}
+			accountBalances {
+				tokenId
+				amount {
+					value
+					decimals
+				}
+			}
 		}
 	}
 
@@ -277,6 +311,10 @@ const AccountQuery = gql<AccountByIdResponse>`
 		$beforePlt: String
 		$firstPlt: Int
 		$lastPlt: Int
+		$afterRelatedLocks: String
+		$beforeRelatedLocks: String
+		$firstRelatedLocks: Int
+		$lastRelatedLocks: Int
 	) {
 		account(id: $id) {
 			${AccountQueryFragment}
@@ -311,6 +349,10 @@ const AccountQueryByAddress = gql<AccountByAddressResponse>`
 		$beforePlt: String
 		$firstPlt: Int
 		$lastPlt: Int
+		$afterRelatedLocks: String
+		$beforeRelatedLocks: String
+		$firstRelatedLocks: Int
+		$lastRelatedLocks: Int
 	) {
 		accountByAddress(accountAddress: $address) {
 			${AccountQueryFragment}

--- a/frontend/src/queries/useAccountQuery.ts
+++ b/frontend/src/queries/useAccountQuery.ts
@@ -96,6 +96,7 @@ plts(
 				expiry
 				status
 			}
+			roles
 			accountBalances {
 				tokenId
 				amount {

--- a/frontend/src/queries/useLockQuery.ts
+++ b/frontend/src/queries/useLockQuery.ts
@@ -1,0 +1,131 @@
+import { gql, useQuery, type CombinedError } from '@urql/vue'
+import type { Ref } from 'vue'
+import { useComponentState, type ComponentState } from '~/composables/useComponentState'
+import type { Lock } from '~/types/generated'
+
+type QueryParams = {
+	lockId: Ref<string>
+}
+
+type LockQueryResponse = {
+	lock: Lock
+}
+
+const accountFields = `
+address {
+  asString
+}
+`
+
+const LockQuery = gql`
+query LockDetails($lockId: String!) {
+  lock(lockId: $lockId) {
+    id
+    lockId
+    status
+    createdAt
+    expiry
+    canceledAt
+    metadataName
+    metadataDescription
+    rawConfig
+    creator {
+      ${accountFields}
+    }
+    createdTransaction {
+      transactionHash
+    }
+    canceledTransaction {
+      transactionHash
+    }
+    balances {
+      accountAddress {
+        asString
+      }
+      tokenId
+      amount {
+        value
+        decimals
+      }
+    }
+    config {
+      expiry
+      recipients {
+        recipientType
+        accounts {
+          ${accountFields}
+        }
+      }
+      controller {
+        simpleV0 {
+          keepAlive
+          tokenIds
+          grants {
+            account {
+              ${accountFields}
+            }
+            roles
+          }
+        }
+      }
+      metadata {
+        name
+        description
+      }
+    }
+    history(first: 50) {
+      nodes {
+        id
+        eventType
+        slotTime
+        operationOrder
+        tokenId
+        amount {
+          value
+          decimals
+        }
+        account {
+          ${accountFields}
+        }
+        source {
+          ${accountFields}
+        }
+        recipient {
+          ${accountFields}
+        }
+        transaction {
+          transactionHash
+        }
+      }
+      pageInfo {
+        hasNextPage
+      }
+    }
+  }
+}
+`
+
+export const useLockQuery = ({
+	lockId,
+}: QueryParams): {
+	data: Ref<LockQueryResponse | undefined>
+	error: Ref<CombinedError | undefined>
+	componentState: Ref<ComponentState>
+	fetching: Ref<boolean>
+} => {
+	const { data, fetching, error } = useQuery<LockQueryResponse>({
+		query: LockQuery,
+		requestPolicy: 'cache-first',
+		variables: {
+			lockId: lockId.value,
+		},
+	})
+
+	const componentState = useComponentState<LockQueryResponse | undefined>({
+		fetching,
+		error,
+		data,
+	})
+
+	return { data, error, componentState, fetching }
+}

--- a/frontend/src/queries/usePltEventsQuery.ts
+++ b/frontend/src/queries/usePltEventsQuery.ts
@@ -44,6 +44,8 @@ const PLT_TOKEN_QUERY = gql<PltEventsQueryResponse>`
 						}
 					}
 					... on TokenTransferEvent {
+						fromLock
+						toLock
 						from {
 							address {
 								asString
@@ -154,6 +156,8 @@ const PLT_EVENT_BY_ID_QUERY = gql<PltEventsByTokenIdQueryResponse>`
 						}
 					}
 					... on TokenTransferEvent {
+						fromLock
+						toLock
 						from {
 							address {
 								asString

--- a/frontend/src/queries/useSearchQuery.ts
+++ b/frontend/src/queries/useSearchQuery.ts
@@ -11,6 +11,7 @@ import type {
 	ModuleReferenceEvent,
 	Token,
 	PltToken,
+	Lock,
 } from '~/types/generated'
 type SearchResponse = {
 	search: {
@@ -19,6 +20,7 @@ type SearchResponse = {
 		blocks: { nodes: Block[]; pageInfo: PageInfo }
 		transactions: { nodes: Transaction[]; pageInfo: PageInfo }
 		accounts: { nodes: Account[]; pageInfo: PageInfo }
+		locks: { nodes: Lock[]; pageInfo: PageInfo }
 		nodeStatuses: { nodes: NodeStatus[]; pageInfo: PageInfo }
 		tokens: { nodes: Token[]; pageInfo: PageInfo }
 		pltTokens: { nodes: PltToken[]; pageInfo: PageInfo }
@@ -118,6 +120,17 @@ const SearchQuery = gql<SearchResponse>`
 					address {
 						asString
 					}
+				}
+				pageInfo {
+					hasNextPage
+				}
+			}
+			locks(first: 3) {
+				nodes {
+					lockId
+					status
+					createdAt
+					expiry
 				}
 				pageInfo {
 					hasNextPage

--- a/frontend/src/queries/useTransactionQuery.ts
+++ b/frontend/src/queries/useTransactionQuery.ts
@@ -264,6 +264,9 @@ __typename
 		...on MinBlockTimeUpdate {
 			durationSeconds
 		}
+		...on MaxLockDurationUpdate {
+			durationSeconds
+		}
 		...on TimeoutParametersUpdate {
 			decrease {
 				denominator
@@ -391,6 +394,8 @@ __typename
             details
         }
         ... on TokenTransferEvent {
+            fromLock
+            toLock
             memo {
                 decoded {
                     text
@@ -469,6 +474,8 @@ __typename
                 details
             }
             ... on TokenTransferEvent {
+                fromLock
+                toLock
                 from {
                     address {
                         asString

--- a/frontend/src/queries/useTransactionQuery.ts
+++ b/frontend/src/queries/useTransactionQuery.ts
@@ -441,6 +441,117 @@ __typename
         }
     }
 }
+... on LockCreated {
+    lockId
+    rawConfigPresent
+    configUnavailable
+    config {
+        expiry
+        recipients {
+            recipientType
+            accounts {
+                address {
+                    asString
+                }
+            }
+        }
+        controller {
+            controllerType
+            simpleV0 {
+                keepAlive
+                tokenIds
+                memo {
+                    decoded {
+                        text
+                        decodeType
+                    }
+                }
+                grants {
+                    roles
+                    account {
+                        address {
+                            asString
+                        }
+                    }
+                }
+            }
+        }
+        metadata {
+            name
+            description
+        }
+    }
+}
+... on LockFunded {
+    lockId
+    tokenId
+    amount {
+        value
+        decimals
+    }
+    memo {
+        decoded {
+            text
+            decodeType
+        }
+    }
+}
+... on LockSent {
+    lockId
+    tokenId
+    source {
+        address {
+            asString
+        }
+    }
+    recipient {
+        address {
+            asString
+        }
+    }
+    amount {
+        value
+        decimals
+    }
+    memo {
+        decoded {
+            text
+            decodeType
+        }
+    }
+}
+... on LockReturned {
+    lockId
+    tokenId
+    source {
+        address {
+            asString
+        }
+    }
+    amount {
+        value
+        decimals
+    }
+    memo {
+        decoded {
+            text
+            decodeType
+        }
+    }
+}
+... on LockCanceled {
+    lockId
+    destroyed
+    memo {
+        decoded {
+            text
+            decodeType
+        }
+    }
+}
+... on LockDestroyed {
+    lockId
+}
 ... on TokenCreationDetails {
     createPlt {
         tokenId

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -47,6 +47,7 @@ export type Account = {
    */
   nonce: Scalars['Int'];
   plts: AccountProtocolTokenConnection;
+  relatedLocks: AccountRelatedLockConnection;
   releaseSchedule: AccountReleaseSchedule;
   rewards: AccountRewardConnection;
   tokens: AccountTokenConnection;
@@ -68,6 +69,14 @@ export type AccountAccountStatementArgs = {
 
 
 export type AccountPltsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+export type AccountRelatedLocksArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
@@ -199,6 +208,31 @@ export type AccountProtocolTokenEdge = {
   cursor: Scalars['String'];
   /** The item at the end of the edge */
   node: AccountProtocolToken;
+};
+
+export type AccountRelatedLock = {
+  __typename?: 'AccountRelatedLock';
+  accountBalances: Array<LockBalance>;
+  lock: Lock;
+};
+
+export type AccountRelatedLockConnection = {
+  __typename?: 'AccountRelatedLockConnection';
+  /** A list of edges. */
+  edges: Array<AccountRelatedLockEdge>;
+  /** A list of nodes. */
+  nodes: Array<AccountRelatedLock>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/** An edge in a connection. */
+export type AccountRelatedLockEdge = {
+  __typename?: 'AccountRelatedLockEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge */
+  node: AccountRelatedLock;
 };
 
 export type AccountReleaseSchedule = {
@@ -1731,6 +1765,43 @@ export type LinkedContractsCollectionSegment = {
   totalCount: Scalars['Int'];
 };
 
+export type Lock = {
+  __typename?: 'Lock';
+  balances: Array<LockBalance>;
+  canceledAt?: Maybe<Scalars['DateTime']>;
+  canceledTransaction?: Maybe<Transaction>;
+  config?: Maybe<LockCreateConfig>;
+  createdAt?: Maybe<Scalars['DateTime']>;
+  createdTransaction?: Maybe<Transaction>;
+  creator?: Maybe<Account>;
+  expiry?: Maybe<Scalars['DateTime']>;
+  history: LockHistoryEventConnection;
+  id: Scalars['ID'];
+  lockId: Scalars['String'];
+  metadataDescription?: Maybe<Scalars['String']>;
+  metadataName?: Maybe<Scalars['String']>;
+  rawConfig?: Maybe<Scalars['String']>;
+  status: LockStatus;
+};
+
+
+export type LockHistoryArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+export type LockBalance = {
+  __typename?: 'LockBalance';
+  account: Account;
+  accountAddress: AccountAddress;
+  amount: TokenAmount;
+  lockId: Scalars['String'];
+  tokenId: Scalars['String'];
+  tokenIndex: Scalars['Int'];
+};
+
 export type LockCancelNotAuthorized = {
   __typename?: 'LockCancelNotAuthorized';
   details: Scalars['JSON'];
@@ -1803,6 +1874,45 @@ export type LockFunded = {
   tokenId: Scalars['String'];
 };
 
+export type LockHistoryEvent = {
+  __typename?: 'LockHistoryEvent';
+  account?: Maybe<Account>;
+  amount?: Maybe<TokenAmount>;
+  blockHeight: Scalars['Int'];
+  event: Scalars['JSON'];
+  eventType: Scalars['String'];
+  id: Scalars['ID'];
+  lockId: Scalars['String'];
+  memo?: Maybe<Scalars['JSON']>;
+  operationOrder: Scalars['Int'];
+  recipient?: Maybe<Account>;
+  slotTime: Scalars['DateTime'];
+  source?: Maybe<Account>;
+  tokenId?: Maybe<Scalars['String']>;
+  tokenIndex?: Maybe<Scalars['Int']>;
+  transaction: Transaction;
+  transactionIndex: Scalars['Int'];
+};
+
+export type LockHistoryEventConnection = {
+  __typename?: 'LockHistoryEventConnection';
+  /** A list of edges. */
+  edges: Array<LockHistoryEventEdge>;
+  /** A list of nodes. */
+  nodes: Array<LockHistoryEvent>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/** An edge in a connection. */
+export type LockHistoryEventEdge = {
+  __typename?: 'LockHistoryEventEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge */
+  node: LockHistoryEvent;
+};
+
 export type LockMetadataConfig = {
   __typename?: 'LockMetadataConfig';
   description?: Maybe<Scalars['String']>;
@@ -1848,6 +1958,12 @@ export type LockSent = {
   source: CborHolderAccount;
   tokenId: Scalars['String'];
 };
+
+export enum LockStatus {
+  Active = 'ACTIVE',
+  Canceled = 'CANCELED',
+  Expired = 'EXPIRED'
+}
 
 export type LockTokenNotPermitted = {
   __typename?: 'LockTokenNotPermitted';
@@ -2625,6 +2741,7 @@ export type Query = {
   globalPltMetrics: GlobalPltMetrics;
   importState: ImportState;
   latestChainParameters: LatestChainParameters;
+  lock: Lock;
   moduleReferenceEvent: ModuleReferenceEvent;
   nodeStatus?: Maybe<NodeStatus>;
   nodeStatuses: NodeStatusConnection;
@@ -2745,6 +2862,11 @@ export type QueryContractsArgs = {
 
 export type QueryGlobalPltMetricsArgs = {
   period: MetricsPeriod;
+};
+
+
+export type QueryLockArgs = {
+  lockId: Scalars['String'];
 };
 
 

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -390,6 +390,7 @@ export enum AccountTransactionType {
   EncryptedTransfer = 'ENCRYPTED_TRANSFER',
   EncryptedTransferWithMemo = 'ENCRYPTED_TRANSFER_WITH_MEMO',
   InitializeSmartContractInstance = 'INITIALIZE_SMART_CONTRACT_INSTANCE',
+  MetaUpdate = 'META_UPDATE',
   RegisterData = 'REGISTER_DATA',
   RemoveBaker = 'REMOVE_BAKER',
   SimpleTransfer = 'SIMPLE_TRANSFER',
@@ -991,7 +992,7 @@ export type ChainUpdateEnqueued = {
   payload: ChainUpdatePayload;
 };
 
-export type ChainUpdatePayload = AddAnonymityRevokerChainUpdatePayload | AddIdentityProviderChainUpdatePayload | BakerStakeThresholdChainUpdatePayload | BlockEnergyLimitUpdate | CooldownParametersChainUpdatePayload | CreatePltUpdate | ElectionDifficultyChainUpdatePayload | EuroPerEnergyChainUpdatePayload | FinalizationCommitteeParametersUpdate | FoundationAccountChainUpdatePayload | GasRewardsChainUpdatePayload | GasRewardsCpv2Update | Level1KeysChainUpdatePayload | MicroCcdPerEuroChainUpdatePayload | MinBlockTimeUpdate | MintDistributionChainUpdatePayload | MintDistributionV1ChainUpdatePayload | PoolParametersChainUpdatePayload | ProtocolChainUpdatePayload | RootKeysChainUpdatePayload | TimeParametersChainUpdatePayload | TimeoutParametersUpdate | TransactionFeeDistributionChainUpdatePayload | ValidatorScoreParametersUpdate;
+export type ChainUpdatePayload = AddAnonymityRevokerChainUpdatePayload | AddIdentityProviderChainUpdatePayload | BakerStakeThresholdChainUpdatePayload | BlockEnergyLimitUpdate | CooldownParametersChainUpdatePayload | CreatePltUpdate | ElectionDifficultyChainUpdatePayload | EuroPerEnergyChainUpdatePayload | FinalizationCommitteeParametersUpdate | FoundationAccountChainUpdatePayload | GasRewardsChainUpdatePayload | GasRewardsCpv2Update | Level1KeysChainUpdatePayload | MaxLockDurationUpdate | MicroCcdPerEuroChainUpdatePayload | MinBlockTimeUpdate | MintDistributionChainUpdatePayload | MintDistributionV1ChainUpdatePayload | PoolParametersChainUpdatePayload | ProtocolChainUpdatePayload | RootKeysChainUpdatePayload | TimeParametersChainUpdatePayload | TimeoutParametersUpdate | TransactionFeeDistributionChainUpdatePayload | ValidatorScoreParametersUpdate;
 
 export type Cis2Event = {
   __typename?: 'Cis2Event';
@@ -1730,6 +1731,46 @@ export type LinkedContractsCollectionSegment = {
   totalCount: Scalars['Int'];
 };
 
+export type LockCancelNotAuthorized = {
+  __typename?: 'LockCancelNotAuthorized';
+  details: Scalars['JSON'];
+};
+
+export type LockExpired = {
+  __typename?: 'LockExpired';
+  lockId: Scalars['String'];
+};
+
+export type LockFundNotAuthorized = {
+  __typename?: 'LockFundNotAuthorized';
+  details: Scalars['JSON'];
+};
+
+export type LockRecipientNotPermitted = {
+  __typename?: 'LockRecipientNotPermitted';
+  details: Scalars['JSON'];
+};
+
+export type LockReturnNotAuthorized = {
+  __typename?: 'LockReturnNotAuthorized';
+  details: Scalars['JSON'];
+};
+
+export type LockSendNotAuthorized = {
+  __typename?: 'LockSendNotAuthorized';
+  details: Scalars['JSON'];
+};
+
+export type LockTokenNotPermitted = {
+  __typename?: 'LockTokenNotPermitted';
+  details: Scalars['JSON'];
+};
+
+export type MaxLockDurationUpdate = {
+  __typename?: 'MaxLockDurationUpdate';
+  durationSeconds: Scalars['UnsignedLong'];
+};
+
 export type Memo = {
   __typename?: 'Memo';
   bytes: Scalars['String'];
@@ -2003,6 +2044,11 @@ export type NonExistentCredentialId = {
   __typename?: 'NonExistentCredentialId';
   /** @deprecated Don't use! This field is only in the schema to make this a valid GraphQL type (which does not allow types without any fields) */
   _: Scalars['Boolean'];
+};
+
+export type NonExistentLockId = {
+  __typename?: 'NonExistentLockId';
+  lockId: Scalars['String'];
 };
 
 export type NonExistentRewardAccount = {
@@ -3208,8 +3254,10 @@ export type TokenTransferEvent = {
   __typename?: 'TokenTransferEvent';
   amount: TokenAmount;
   from: TokenHolder;
+  fromLock?: Maybe<Scalars['String']>;
   memo?: Maybe<Memo>;
   to: TokenHolder;
+  toLock?: Maybe<Scalars['String']>;
 };
 
 /** Common event struct for both Holder and Governance events. */
@@ -3319,7 +3367,7 @@ export type TransactionMetricsBuckets = {
   y_TransactionCount: Array<Scalars['Int']>;
 };
 
-export type TransactionRejectReason = AlreadyABaker | AlreadyADelegator | AmountTooLarge | BakerInCooldown | BakingRewardCommissionNotInRange | CredentialHolderDidNotSign | DelegationTargetNotABaker | DelegatorInCooldown | DuplicateAggregationKey | DuplicateCredIds | EncryptedAmountSelfTransfer | FinalizationRewardCommissionNotInRange | FirstScheduledReleaseExpired | InsufficientBalanceForBakerStake | InsufficientBalanceForDelegationStake | InsufficientDelegationStake | InvalidAccountReference | InvalidAccountThreshold | InvalidContractAddress | InvalidCredentialKeySignThreshold | InvalidCredentials | InvalidEncryptedAmountTransferProof | InvalidIndexOnEncryptedTransfer | InvalidInitMethod | InvalidModuleReference | InvalidProof | InvalidReceiveMethod | InvalidTransferToPublicProof | KeyIndexAlreadyInUse | MissingBakerAddParameters | MissingDelegationAddParameters | ModuleHashAlreadyExists | ModuleNotWf | NonExistentCredIds | NonExistentCredentialId | NonExistentRewardAccount | NonExistentTokenId | NonIncreasingSchedule | NotABaker | NotADelegator | NotAllowedMultipleCredentials | NotAllowedToHandleEncrypted | NotAllowedToReceiveEncrypted | OutOfEnergy | PoolClosed | PoolWouldBecomeOverDelegated | RejectedInit | RejectedReceive | RemoveFirstCredential | RuntimeFailure | ScheduledSelfTransfer | SerializationFailure | StakeOverMaximumThresholdForPool | StakeUnderMinimumThresholdForBaking | TokenModuleReject | TransactionFeeCommissionNotInRange | UnauthorizedTokenGovernance | ZeroScheduledAmount;
+export type TransactionRejectReason = AlreadyABaker | AlreadyADelegator | AmountTooLarge | BakerInCooldown | BakingRewardCommissionNotInRange | CredentialHolderDidNotSign | DelegationTargetNotABaker | DelegatorInCooldown | DuplicateAggregationKey | DuplicateCredIds | EncryptedAmountSelfTransfer | FinalizationRewardCommissionNotInRange | FirstScheduledReleaseExpired | InsufficientBalanceForBakerStake | InsufficientBalanceForDelegationStake | InsufficientDelegationStake | InvalidAccountReference | InvalidAccountThreshold | InvalidContractAddress | InvalidCredentialKeySignThreshold | InvalidCredentials | InvalidEncryptedAmountTransferProof | InvalidIndexOnEncryptedTransfer | InvalidInitMethod | InvalidModuleReference | InvalidProof | InvalidReceiveMethod | InvalidTransferToPublicProof | KeyIndexAlreadyInUse | LockCancelNotAuthorized | LockExpired | LockFundNotAuthorized | LockRecipientNotPermitted | LockReturnNotAuthorized | LockSendNotAuthorized | LockTokenNotPermitted | MissingBakerAddParameters | MissingDelegationAddParameters | ModuleHashAlreadyExists | ModuleNotWf | NonExistentCredIds | NonExistentCredentialId | NonExistentLockId | NonExistentRewardAccount | NonExistentTokenId | NonIncreasingSchedule | NotABaker | NotADelegator | NotAllowedMultipleCredentials | NotAllowedToHandleEncrypted | NotAllowedToReceiveEncrypted | OutOfEnergy | PoolClosed | PoolWouldBecomeOverDelegated | RejectedInit | RejectedReceive | RemoveFirstCredential | RuntimeFailure | ScheduledSelfTransfer | SerializationFailure | StakeOverMaximumThresholdForPool | StakeUnderMinimumThresholdForBaking | TokenModuleReject | TransactionFeeCommissionNotInRange | UnauthorizedTokenGovernance | ZeroScheduledAmount;
 
 export type TransactionResult = Rejected | Success;
 
@@ -3370,6 +3418,7 @@ export enum UpdateTransactionType {
   CreatePltUpdate = 'CREATE_PLT_UPDATE',
   FinalizationCommitteeParametersUpdate = 'FINALIZATION_COMMITTEE_PARAMETERS_UPDATE',
   GasRewardsCpv_2Update = 'GAS_REWARDS_CPV_2_UPDATE',
+  MaxLockDurationUpdate = 'MAX_LOCK_DURATION_UPDATE',
   MintDistributionCpv_1Update = 'MINT_DISTRIBUTION_CPV_1_UPDATE',
   MinBlockTimeUpdate = 'MIN_BLOCK_TIME_UPDATE',
   TimeoutParametersUpdate = 'TIMEOUT_PARAMETERS_UPDATE',

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -1815,6 +1815,16 @@ export type LockCanceled = {
   memo?: Maybe<Memo>;
 };
 
+export type LockConnection = {
+  __typename?: 'LockConnection';
+  /** A list of edges. */
+  edges: Array<LockEdge>;
+  /** A list of nodes. */
+  nodes: Array<Lock>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
 export type LockControllerConfig = {
   __typename?: 'LockControllerConfig';
   controllerType: Scalars['String'];
@@ -1855,6 +1865,15 @@ export type LockCreated = {
 export type LockDestroyed = {
   __typename?: 'LockDestroyed';
   lockId: Scalars['String'];
+};
+
+/** An edge in a connection. */
+export type LockEdge = {
+  __typename?: 'LockEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String'];
+  /** The item at the end of the edge */
+  node: Lock;
 };
 
 export type LockExpired = {
@@ -3132,6 +3151,7 @@ export type SearchResult = {
   bakers: BakerConnection;
   blocks: BlockConnection;
   contracts: ContractConnection;
+  locks: LockConnection;
   modules: ModuleReferenceEventConnection;
   nodeStatuses: NodeStatusConnection;
   pltTokens: PltTokenConnection;
@@ -3165,6 +3185,14 @@ export type SearchResultBlocksArgs = {
 
 
 export type SearchResultContractsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+export type SearchResultLocksArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -1457,7 +1457,7 @@ export type EuroPerEnergyChainUpdatePayload = {
   exchangeRate: Ratio;
 };
 
-export type Event = AccountCreated | AmountAddedByDecryption | BakerAdded | BakerDelegationRemoved | BakerKeysUpdated | BakerRemoved | BakerResumed | BakerSetBakingRewardCommission | BakerSetFinalizationRewardCommission | BakerSetMetadataUrl | BakerSetOpenStatus | BakerSetRestakeEarnings | BakerSetTransactionFeeCommission | BakerStakeDecreased | BakerStakeIncreased | BakerSuspended | ChainUpdateEnqueued | ContractCall | ContractInitialized | ContractInterrupted | ContractModuleDeployed | ContractResumed | ContractUpdated | ContractUpgraded | CredentialDeployed | CredentialKeysUpdated | CredentialsUpdated | DataRegistered | DelegationAdded | DelegationRemoved | DelegationSetDelegationTarget | DelegationSetRestakeEarnings | DelegationStakeDecreased | DelegationStakeIncreased | EncryptedAmountsRemoved | EncryptedSelfAmountAdded | NewEncryptedAmount | TokenCreationDetails | TokenUpdate | TransferMemo | Transferred | TransferredWithSchedule;
+export type Event = AccountCreated | AmountAddedByDecryption | BakerAdded | BakerDelegationRemoved | BakerKeysUpdated | BakerRemoved | BakerResumed | BakerSetBakingRewardCommission | BakerSetFinalizationRewardCommission | BakerSetMetadataUrl | BakerSetOpenStatus | BakerSetRestakeEarnings | BakerSetTransactionFeeCommission | BakerStakeDecreased | BakerStakeIncreased | BakerSuspended | ChainUpdateEnqueued | ContractCall | ContractInitialized | ContractInterrupted | ContractModuleDeployed | ContractResumed | ContractUpdated | ContractUpgraded | CredentialDeployed | CredentialKeysUpdated | CredentialsUpdated | DataRegistered | DelegationAdded | DelegationRemoved | DelegationSetDelegationTarget | DelegationSetRestakeEarnings | DelegationStakeDecreased | DelegationStakeIncreased | EncryptedAmountsRemoved | EncryptedSelfAmountAdded | LockCanceled | LockCreated | LockDestroyed | LockFunded | LockReturned | LockSent | NewEncryptedAmount | TokenCreationDetails | TokenUpdate | TransferMemo | Transferred | TransferredWithSchedule;
 
 export type EventConnection = {
   __typename?: 'EventConnection';
@@ -1736,6 +1736,55 @@ export type LockCancelNotAuthorized = {
   details: Scalars['JSON'];
 };
 
+export type LockCanceled = {
+  __typename?: 'LockCanceled';
+  destroyed: Scalars['Boolean'];
+  lockId: Scalars['String'];
+  memo?: Maybe<Memo>;
+};
+
+export type LockControllerConfig = {
+  __typename?: 'LockControllerConfig';
+  controllerType: Scalars['String'];
+  simpleV0?: Maybe<LockControllerSimpleV0Config>;
+};
+
+export type LockControllerGrant = {
+  __typename?: 'LockControllerGrant';
+  account: CborHolderAccount;
+  roles: Array<Scalars['String']>;
+};
+
+export type LockControllerSimpleV0Config = {
+  __typename?: 'LockControllerSimpleV0Config';
+  grants: Array<LockControllerGrant>;
+  keepAlive: Scalars['Boolean'];
+  memo?: Maybe<Memo>;
+  tokenIds: Array<Scalars['String']>;
+};
+
+export type LockCreateConfig = {
+  __typename?: 'LockCreateConfig';
+  controller: LockControllerConfig;
+  expiry: Scalars['DateTime'];
+  metadata?: Maybe<LockMetadataConfig>;
+  recipients: LockRecipientsConfig;
+};
+
+export type LockCreated = {
+  __typename?: 'LockCreated';
+  config?: Maybe<LockCreateConfig>;
+  configUnavailable: Scalars['Boolean'];
+  lockId?: Maybe<Scalars['String']>;
+  rawConfig?: Maybe<Scalars['String']>;
+  rawConfigPresent: Scalars['Boolean'];
+};
+
+export type LockDestroyed = {
+  __typename?: 'LockDestroyed';
+  lockId: Scalars['String'];
+};
+
 export type LockExpired = {
   __typename?: 'LockExpired';
   lockId: Scalars['String'];
@@ -1746,9 +1795,29 @@ export type LockFundNotAuthorized = {
   details: Scalars['JSON'];
 };
 
+export type LockFunded = {
+  __typename?: 'LockFunded';
+  amount: TokenAmount;
+  lockId: Scalars['String'];
+  memo?: Maybe<Memo>;
+  tokenId: Scalars['String'];
+};
+
+export type LockMetadataConfig = {
+  __typename?: 'LockMetadataConfig';
+  description?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+};
+
 export type LockRecipientNotPermitted = {
   __typename?: 'LockRecipientNotPermitted';
   details: Scalars['JSON'];
+};
+
+export type LockRecipientsConfig = {
+  __typename?: 'LockRecipientsConfig';
+  accounts: Array<CborHolderAccount>;
+  recipientType: Scalars['String'];
 };
 
 export type LockReturnNotAuthorized = {
@@ -1756,9 +1825,28 @@ export type LockReturnNotAuthorized = {
   details: Scalars['JSON'];
 };
 
+export type LockReturned = {
+  __typename?: 'LockReturned';
+  amount: TokenAmount;
+  lockId: Scalars['String'];
+  memo?: Maybe<Memo>;
+  source: CborHolderAccount;
+  tokenId: Scalars['String'];
+};
+
 export type LockSendNotAuthorized = {
   __typename?: 'LockSendNotAuthorized';
   details: Scalars['JSON'];
+};
+
+export type LockSent = {
+  __typename?: 'LockSent';
+  amount: TokenAmount;
+  lockId: Scalars['String'];
+  memo?: Maybe<Memo>;
+  recipient: CborHolderAccount;
+  source: CborHolderAccount;
+  tokenId: Scalars['String'];
 };
 
 export type LockTokenNotPermitted = {

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -214,6 +214,7 @@ export type AccountRelatedLock = {
   __typename?: 'AccountRelatedLock';
   accountBalances: Array<LockBalance>;
   lock: Lock;
+  roles: Array<Scalars['String']>;
 };
 
 export type AccountRelatedLockConnection = {

--- a/frontend/src/utils/translateRejectionReasons.ts
+++ b/frontend/src/utils/translateRejectionReasons.ts
@@ -49,6 +49,14 @@ const translations: TranslationMap = {
 	NonExistentTokenId: 'Token ID does not exist',
 	TokenModuleReject: 'Token module transaction reject reason',
 	UnauthorizedTokenGovernance: 'Unauthorized token governance action',
+	NonExistentLockId: 'Lock ID does not exist',
+	LockExpired: 'The lock has expired',
+	LockFundNotAuthorized: 'Not authorized to fund the lock',
+	LockSendNotAuthorized: 'Not authorized to send from the lock',
+	LockReturnNotAuthorized: 'Not authorized to return funds from the lock',
+	LockCancelNotAuthorized: 'Not authorized to cancel the lock',
+	LockTokenNotPermitted: 'Token is not permitted for the lock',
+	LockRecipientNotPermitted: 'Recipient is not permitted for the lock',
 }
 
 export const translateRejectionReasons = (

--- a/frontend/src/utils/translateTransactionTypes.ts
+++ b/frontend/src/utils/translateTransactionTypes.ts
@@ -29,6 +29,7 @@ const translations = {
 		ENCRYPTED_TRANSFER_WITH_MEMO: 'Encrypted transfer with memo',
 		TRANSFER_WITH_SCHEDULE_WITH_MEMO: 'Transfer with schedule and memo',
 		TOKEN_UPDATE: 'Token update',
+		META_UPDATE: 'Meta update',
 		UNKNOWN: 'Unknown account transaction',
 	} as Record<AccountTransactionType | 'UNKNOWN', string>,
 	credentialDeploymentTypes: {
@@ -69,6 +70,7 @@ const translations = {
 		UPDATE_LEVEL_1_KEYS: 'Update level 1 keys',
 		UPDATE_LEVEL_2_KEYS: 'Update level 2 keys',
 		CREATE_PLT_UPDATE: 'Update create PLT',
+		MAX_LOCK_DURATION_UPDATE: 'Update max lock duration',
 		UNKNOWN: 'Unknown update transaction',
 	} as Record<UpdateTransactionType | 'UNKNOWN', string>,
 }


### PR DESCRIPTION
## Purpose

Add support for Protocol Level Token Locks so Concordium Scan can correctly process, index, and display lock-related activity introduced with P11.

This gives users a clear view of locked token activity directly from indexed chain data: lock creation, funding, sending, returning, cancellation, current lock status, balances, and history. It also prevents new lock-related transaction types and rejection reasons from being dropped or shown as unknown.

## Changes

<table>
    <tr>
        <td>
<img width="1728" height="904" alt="image" src="https://github.com/user-attachments/assets/6cb5af84-ce71-43d7-ac08-a6540cabc3d3" />
</td>
        <td>
<img width="1728" height="907" alt="image" src="https://github.com/user-attachments/assets/06b9f218-1ca0-4e63-bdf0-5b1118f42c25" />
</td>
    </tr>
    <tr>
        <td>
<img width="1728" height="905" alt="image" src="https://github.com/user-attachments/assets/7608a365-c73b-41ad-861c-436e2b1ff0ed" />
</td>
        <td>
<img width="1728" height="908" alt="image" src="https://github.com/user-attachments/assets/8f3cf719-0a33-4d67-b7e6-bef5535a6d88" />
</td>
    </tr>
</table>

- Added backend support for new lock-related transaction types, reject reasons, chain updates, and token transfer lock fields.
- Added transaction detail support for lock lifecycle events, so users can see when locks are created, funded, sent from, returned from, or canceled.
- Added indexed database state for locks, including current status, balances, related accounts, and historical lifecycle events.
- Added GraphQL APIs for querying individual locks and account-related locks from indexed data only.
- Added frontend lock display support, including lock links, lock-aware token transfer text, and readable labels for new lock events and rejection reasons.
- Added a lock details drawer showing lock status, creation and expiry information, balances, configuration, and lifecycle history.
- Added account drawer support for related locks, including account-specific locked balances and expired or canceled locks.
- Regenerated backend and frontend GraphQL schemas/types and updated checks around the new lock data paths.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
